### PR TITLE
libmbp: patcherconfig.cpp: Add support for mt2l03

### DIFF
--- a/libmbp/patcherconfig.cpp
+++ b/libmbp/patcherconfig.cpp
@@ -839,7 +839,7 @@ void PatcherConfig::Impl::addOnePlusDevices()
     devices.push_back(device);
 }
 
-void PatcherConfig::Impl::addSonyDevices()
+void PatcherConfig::Impl::addHuaweiDevices()
 {
     Device *device;
     

--- a/libmbp/patcherconfig.cpp
+++ b/libmbp/patcherconfig.cpp
@@ -72,6 +72,7 @@ public:
     void addMotorolaDevices();
     void addNexusDevices();
     void addOnePlusDevices();
+    void addHuaweiDevices();
     void addSonyDevices();
     void loadDefaultDevices();
 };
@@ -841,6 +842,26 @@ void PatcherConfig::Impl::addOnePlusDevices()
 void PatcherConfig::Impl::addSonyDevices()
 {
     Device *device;
+    
+    // Huawei Mate 2
+    device = new Device();
+    device->setArchitecture("armeabi-v7a");
+    device->setId("mt2l03");
+    device->setCodenames({ "hwMT2L03", "hwMT2LO3", "mt2", "MT2", "mt2l03", "MT2L03", "mt2-l03", "MT2-L03" });
+    device->setName("Huawei Ascend Mate 2");
+    device->setBlockDevBaseDirs({ QCOM_BASE_DIR });
+    device->setSystemBlockDevs({ QCOM_SYSTEM, "/dev/block/mmcblk0p23" });
+    device->setCacheBlockDevs({ QCOM_CACHE, "/dev/block/mmcblk0p21" });
+    device->setDataBlockDevs({ QCOM_USERDATA, "/dev/block/mmcblk0p24" });
+    device->setBootBlockDevs({ QCOM_BOOT, "/dev/block/mmcblk0p18" });
+    device->setRecoveryBlockDevs({ QCOM_RECOVERY, "/dev/block/mmcblk0p19" });
+    devices.push_back(device);
+    
+}
+
+void PatcherConfig::Impl::addSonyDevices()
+{
+    Device *device;
 
     // Sony Xperia Sola
     device = new Device();
@@ -862,6 +883,7 @@ void PatcherConfig::Impl::loadDefaultDevices()
     addMotorolaDevices();
     addNexusDevices();
     addOnePlusDevices();
+    addHuaweiDevices();
     addSonyDevices();
 }
 


### PR DESCRIPTION
MultiBoot support for the Huawei Ascend Mate 2 device.

* Heavily tested and confirmed working.
* Roms tested and verified:
  ** Stock 5.1 EMUI Lollipop
  ** Cyanogenmod 12.1
  ** Cyanogenmod 13.0
  ** Carbon Rom 5.1.1
  ** Pac Rom 5.1.1