### PR TITLE
Workaround installation issues of systemless SuperSU due to its hardcoded /dev/block/loop0 path

### DIFF
--- a/libmbutil/src/loopdev.cpp
+++ b/libmbutil/src/loopdev.cpp
@@ -95,7 +95,9 @@ static int find_loopdev_by_scanning(void)
     int fd;
     char loopdev[64];
 
-    for (int n = 0; n < MAX_LOOPDEVS; ++n) {
+    // Avoid /dev/block/loop0 since some installers (ahem, SuperSU) are
+    // hardcoded to use it
+    for (int n = 1; n < MAX_LOOPDEVS; ++n) {
         struct loop_info64 loopinfo;
         struct stat sb;
 
@@ -146,7 +148,9 @@ static int find_loopdev_by_scanning(void)
 std::string loopdev_find_unused(void)
 {
     int n = find_loopdev_by_loop_control();
-    if (n < 0) {
+    // Also search by scanning if n == 0, since some installers hardcode
+    // /dev/block/loop0
+    if (n <= 0) {
         n = find_loopdev_by_scanning();
     }
     if (n < 0) {

--- a/mbtool/installer.cpp
+++ b/mbtool/installer.cpp
@@ -327,6 +327,20 @@ bool Installer::create_chroot()
         return false;
     }
 
+    // Create a few loopback devices since some installers expect them to exist,
+    // but don't create them. They are not necessary for mbtool to work.
+    if (log_mkdir(in_chroot("/dev/block").c_str(), 0755) < 0
+            || log_mknod(in_chroot("/dev/block/loop0").c_str(), S_IFBLK | 0644, makedev(7, 0)) < 0
+            || log_mknod(in_chroot("/dev/block/loop1").c_str(), S_IFBLK | 0644, makedev(7, 1)) < 0
+            || log_mknod(in_chroot("/dev/block/loop2").c_str(), S_IFBLK | 0644, makedev(7, 2)) < 0
+            || log_mknod(in_chroot("/dev/block/loop3").c_str(), S_IFBLK | 0644, makedev(7, 3)) < 0
+            || log_mknod(in_chroot("/dev/block/loop4").c_str(), S_IFBLK | 0644, makedev(7, 4)) < 0
+            || log_mknod(in_chroot("/dev/block/loop5").c_str(), S_IFBLK | 0644, makedev(7, 5)) < 0
+            || log_mknod(in_chroot("/dev/block/loop6").c_str(), S_IFBLK | 0644, makedev(7, 6)) < 0
+            || log_mknod(in_chroot("/dev/block/loop7").c_str(), S_IFBLK | 0644, makedev(7, 7)) < 0) {
+        return false;
+    }
+
     // We need /dev/input/* and /dev/graphics/* for AROMA
 #if 1
     if (!log_copy_dir("/dev/input", in_chroot("/dev/input"),

--- a/mbtool/installer.cpp
+++ b/mbtool/installer.cpp
@@ -1309,6 +1309,13 @@ Installer::ProceedState Installer::install_stage_set_up_chroot()
     util::copy_file("/file_contexts", in_chroot("/file_contexts"),
                     util::COPY_ATTRIBUTES | util::COPY_XATTRS);
 
+    // Copy /etc/fstab
+    util::copy_file("/etc/fstab", in_chroot("/etc/fstab"),
+                    util::COPY_ATTRIBUTES | util::COPY_XATTRS);
+
+    // Copy /etc/recovery.fstab
+    util::copy_file("/etc/recovery.fstab", in_chroot("/etc/recovery.fstab"),
+                    util::COPY_ATTRIBUTES | util::COPY_XATTRS);
 
     return on_set_up_chroot();
 }


### PR DESCRIPTION
It's ridiculous that these hacks are necessary, but what can I do about it?