### PR TITLE
libmbp: Support Moto X 2014

### DIFF
--- a/libmbp/devices/motorola.cpp
+++ b/libmbp/devices/motorola.cpp
@@ -76,7 +76,7 @@ void addMotorolaDevices(std::vector<Device *> *devices)
     device->setCodenames({ "ghost", "ghost_att", "ghost_rcica", "ghost_retail",
                            "ghost_sprint", "ghost_usc", "ghost_verizon",
                            "xt1052", "xt1053", "xt1055", "xt1056", "xt1058",
-                           "xt1060", });
+                           "xt1060" });
     device->setName("Motorola Moto X (2013)");
     device->setBlockDevBaseDirs({ QCOM_BASE_DIR });
     device->setSystemBlockDevs({ QCOM_SYSTEM, "/dev/block/mmcblk0p38" });
@@ -84,6 +84,19 @@ void addMotorolaDevices(std::vector<Device *> *devices)
     device->setDataBlockDevs({ QCOM_USERDATA, "/dev/block/mmcblk0p40" });
     device->setBootBlockDevs({ QCOM_BOOT, "/dev/block/mmcblk0p33" });
     device->setRecoveryBlockDevs({ QCOM_RECOVERY });
+    devices->push_back(device);
+
+    // Motorola Moto X (2014)
+    device = new Device();
+    device->setId("victara");
+    device->setCodenames({ "victara" });
+    device->setName("Motorola Moto X (2014)");
+    device->setBlockDevBaseDirs({ QCOM_BASE_DIR });
+    device->setSystemBlockDevs({ QCOM_SYSTEM, "/dev/block/mmcblk0p38" });
+    device->setCacheBlockDevs({ QCOM_CACHE, "/dev/block/mmcblk0p37" });
+    device->setDataBlockDevs({ QCOM_USERDATA, "/dev/block/mmcblk0p39" });
+    device->setBootBlockDevs({ QCOM_BOOT, "/dev/block/mmcblk0p33" });
+    device->setRecoveryBlockDevs({ QCOM_RECOVERY, "/dev/block/mmcblk0p34" });
     devices->push_back(device);
 
     // Motorola Moto X Pure Edition


### PR DESCRIPTION
"ls -l /dev/block/platform/msm_sdcc.1/by-name/
system -> /dev/block/mmcblk0p38
cache -> /dev/block/mmcblk0p37
userdata -> /dev/block/mmcblk0p39
boot -> /dev/block/mmcblk0p33
recovery -> /dev/block/mmcblk0p34"

ps: The unique differences of the 2013 version is /cache and /userdata partition (maybe /recovery too)
ps2: Fixed mistype on Moto X 2013
ps3: Not tested, due to fault on my PC
ps4: Made with help @lucasdessy

Signed-off-by: Caio Oliveira <caiooliveirafarias0@gmail.com>