### PR TITLE
Add Asus Zenfone 2 [Z008] aka ZE550ML

### DIFF
--- a/libmbp/devices/asus.cpp
+++ b/libmbp/devices/asus.cpp
@@ -28,10 +28,10 @@ void addAsusDevices(std::vector<Device *> *devices)
 {
     Device *device;
 
-    // ASUS ZenFone 2
+    // ASUS ZenFone 2 [ZE551ML/ZE550ML]
     device = new Device();
     device->setId("Z00A");
-    device->setCodenames({ "Z00A" });
+    device->setCodenames({ "Z00A", "Z008" });
     device->setName("ASUS ZenFone 2");
     device->setArchitecture(ARCH_X86);
     device->setBlockDevBaseDirs({ INTEL_PCI_BASE_DIR, BLOCK_BASE_DIR });
@@ -46,6 +46,7 @@ void addAsusDevices(std::vector<Device *> *devices)
     device->setRecoveryBlockDevs({ INTEL_PCI_RECOVERY_2, BLOCK_RECOVERY,
                                    "/dev/block/mmcblk0p2" });
     devices->push_back(device);
+
 }
 
 }


### PR DESCRIPTION
we can still use the same setId i.e. Z00A since we only need the correct code name.

Signed-off-by: sayeed99 <sayeed.afridi2009@gmail.com>