### PR TITLE
Add codename for LG G2 Korean variant

### DIFF
--- a/libmbp/devices/lg.cpp
+++ b/libmbp/devices/lg.cpp
@@ -31,7 +31,7 @@ static void addLgGSeriesPhones(std::vector<Device *> *devices)
     // LG G2
     device = new Device();
     device->setId("lgg2");
-    device->setCodenames({ "g2", "d800", "d801", "ls980", "vs980" });
+    device->setCodenames({ "g2", "d800", "d801", "ls980", "vs980", "f320" });
     device->setName("LG G2");
     device->setBlockDevBaseDirs({ QCOM_BASE_DIR });
     device->setSystemBlockDevs({ QCOM_SYSTEM, "/dev/block/mmcblk0p34" });


### PR DESCRIPTION
I made a tiny addition to support for LG G2 Korean model.
and I confirm that it works correctly.

This is the partition information of 'f320' which is the device name of LG G2 Korean variant.
http://pastebin.com/N4J1Dsfk

Thank you