### PR TITLE
mbtool: Check if /system is mounted before attempting to unmount it

### DIFF
--- a/odinupdater/odinupdater.cpp
+++ b/odinupdater/odinupdater.cpp
@@ -835,7 +835,7 @@ static bool flash_zip()
     }
 
     // Unmount system
-    if (!umount_system()) {
+    if (mb::util::is_mounted("/system") && !umount_system()) {
         ui_print("Failed to unmount /system");
         return false;
     }


### PR DESCRIPTION
This prevents `odinupdater` from failing now that `update-binary-tool` handles all the mounting instead of just returning 0.