### PR TITLE
mbutil: external: Don't set property file SELinux label

### DIFF
--- a/libmbutil/src/external/system_properties.cpp
+++ b/libmbutil/src/external/system_properties.cpp
@@ -240,6 +240,9 @@ static prop_area* map_prop_area_rw(const char* filename, const char* context,
     }
 
     if (context) {
+#if 0
+        // NOTE: Not wanted for DualBootPatcher since the properties service
+        // initializes before SELinux
         if (fsetxattr(fd, XATTR_NAME_SELINUX, context, strlen(context) + 1, 0) != 0) {
             LOGE("fsetxattr failed to set context (%s) for \"%s\"", context, filename);
             /*
@@ -255,6 +258,7 @@ static prop_area* map_prop_area_rw(const char* filename, const char* context,
                 *fsetxattr_failed = true;
             }
         }
+#endif
     }
 
     if (ftruncate(fd, PA_SIZE) < 0) {


### PR DESCRIPTION
This can't be done before SELinux is initialized, which is the case in
the mbtool boot environment.