### PR TITLE
mbbootui: Fix null pointer dereferencing if daemon returns incomplete ROM data

### DIFF
--- a/mbbootui/daemon_connection.cpp
+++ b/mbbootui/daemon_connection.cpp
@@ -150,12 +150,24 @@ public:
         if (response->roms()) {
             for (auto const &mb_rom : *response->roms()) {
                 roms.emplace_back();
-                roms.back().id = mb_rom->id()->str();
-                roms.back().system_path = mb_rom->system_path()->str();
-                roms.back().cache_path = mb_rom->cache_path()->str();
-                roms.back().data_path = mb_rom->data_path()->str();
-                roms.back().version = mb_rom->version()->str();
-                roms.back().build = mb_rom->build()->str();
+                if (mb_rom->id()) {
+                    roms.back().id = mb_rom->id()->str();
+                }
+                if (mb_rom->system_path()) {
+                    roms.back().system_path = mb_rom->system_path()->str();
+                }
+                if (mb_rom->cache_path()) {
+                    roms.back().cache_path = mb_rom->cache_path()->str();
+                }
+                if (mb_rom->data_path()) {
+                    roms.back().data_path = mb_rom->data_path()->str();
+                }
+                if (mb_rom->version()) {
+                    roms.back().version = mb_rom->version()->str();
+                }
+                if (mb_rom->build()) {
+                    roms.back().build = mb_rom->build()->str();
+                }
             }
         }
 


### PR DESCRIPTION
When getting the list of installed ROMs from the daemon, the client did
not check if the fields (system path, build, version, etc.) were NULL
before accessing them. This would cause the Boot UI to crash upon
selection of the Switch ROM page. Under normal operation, this could
happen if, for any ROM:

* The build.prop file is not found or not readable
* The build.prop file is missing properties for the build and version
* The ROM uses a system image and thus, the build.prop file cannot be
  read