### PR TITLE
Add support of ZUK Z2 Plus and disable rendering of mouse cursor 

### DIFF
--- a/data/devices/lenovo.yml
+++ b/data/devices/lenovo.yml
@@ -125,6 +125,62 @@
       - /dev/block/bootdevice/by-name/recovery
       - /dev/block/mmcblk0p10
 
+ 
+- name: Lenovo ZUK Z2 Plus
+  id: z2_plus
+  codenames:
+    - z2_plus
+    - z2plus
+    - Z2_PLUS
+    - z2
+    - Z2
+    - Z2131
+    - Z2PLUS
+    - z2131
+  architecture: arm64-v8a
+
+  block_devs:
+    base_dirs:
+      - /dev/block/bootdevice/by-name
+      - /dev/block/platform/soc/7464900.sdhci/by-name
+    system:
+      - /dev/block/bootdevice/by-name/system
+      - /dev/block/platform/soc/7464900.sdhci/by-name/system
+      - /dev/block/mmcblk0p16
+    cache:
+      - /dev/block/bootdevice/by-name/cache
+      - /dev/block/platform/soc/7464900.sdhci/by-name/cache
+      - /dev/block/mmcblk0p39
+    data:
+      - /dev/block/bootdevice/by-name/userdata
+      - /dev/block/platform/soc/7464900.sdhci/by-name/userdata
+      - /dev/block/mmcblk0p48
+    boot:
+      - /dev/block/bootdevice/by-name/boot
+      - /dev/block/platform/soc/7464900.sdhci/by-name/boot
+      - /dev/block/mmcblk0p14
+    recovery:
+      - /dev/block/bootdevice/by-name/recovery
+      - /dev/block/platform/soc/7464900.sdhci/by-name/recovery
+      - /dev/block/mmcblk0p15
+
+  boot_ui:
+    supported: true
+    graphics_backends:
+      - fbdev
+    flags:
+      - TW_BOARD_HAS_FLIPPED_SCREEN
+      - TW_QCOM_RTC_FIX
+    pixel_format: RGBA_8888
+    max_brightness: 255
+    default_brightness: 100
+    theme: portrait_hdpi
+
+  crypto:
+    supported: true
+    header_path: footer
+
+
 - name: Lenovo Vibe P1 Turbo
   id: P1a42
   codenames:

--- a/mbbootui/gui/mousecursor.cpp
+++ b/mbbootui/gui/mousecursor.cpp
@@ -59,10 +59,10 @@ int MouseCursor::Render()
     }
 
     if (m_image) {
-        gr_blit(m_image->GetResource(), 0, 0, mRenderW, mRenderH, mRenderX, mRenderY);
+        //gr_blit(m_image->GetResource(), 0, 0, mRenderW, mRenderH, mRenderX, mRenderY);
     } else {
-        gr_color(m_color.red, m_color.green, m_color.blue, m_color.alpha);
-        gr_fill(mRenderX, mRenderY, mRenderW, mRenderH);
+        //gr_color(m_color.red, m_color.green, m_color.blue, m_color.alpha);
+        //gr_fill(mRenderX, mRenderY, mRenderW, mRenderH);
     }
     return 0;
 }


### PR DESCRIPTION
But it dont patch boot.img in zip file. But it don't patching boot.img in *.zip file. Need update ramdisk manually after intall rom, chose primary rom, and chose newly installed rom.
