### PR TITLE
libmbp: Strip 'erase' command in system.transfer.list due to BLKDISCARD bugs on some devices

### DIFF
--- a/libmbp/include/mbp/autopatchers/standardpatcher.h
+++ b/libmbp/include/mbp/autopatchers/standardpatcher.h
@@ -39,6 +39,8 @@ public:
 
     static const std::string UpdaterScript;
 
+    static const std::string SystemTransferList;
+
     virtual ErrorCode error() const override;
 
     virtual std::string id() const override;
@@ -47,6 +49,9 @@ public:
     virtual std::vector<std::string> existingFiles() const override;
 
     virtual bool patchFiles(const std::string &directory) override;
+
+    bool patchUpdater(const std::string &directory);
+    bool patchTransferList(const std::string &directory);
 
 private:
     class Impl;


### PR DESCRIPTION
CM 13 and earlier contained an updater-script file that did not verify
the result of block_image_update(). If a BLKDISCARD ioctl call failed
before, it would simply be ignored. This changed with CM 14, which
properly checks the return value of block_image_update(). We'll work
around the issue by removing the 'erase' command in
system.transfer.list.