### PR TITLE
mbtool: Force kmsg error levels to all be errors

### DIFF
--- a/mbtool/init.cpp
+++ b/mbtool/init.cpp
@@ -1317,7 +1317,7 @@ int init_main(int argc, char *argv[])
     open_devnull_stdio();
 
     // Log to kmsg
-    log::log_set_logger(std::make_shared<log::KmsgLogger>(false));
+    log::log_set_logger(std::make_shared<log::KmsgLogger>(true));
     if (klogctl(KLOG_CONSOLE_LEVEL, nullptr, 7) < 0) {
         LOGE("Failed to set loglevel: %s", strerror(errno));
     }


### PR DESCRIPTION
Some kernels don't respect

    klogctl(KLOG_CONSOLE_LEVEL, nullptr, 7)

so valuable log messages are lost when looking at /proc/last_kmsg or
/sys/fs/pstore/console-ramoops. We'll work around this by logging
everything as errors.