### PR TITLE
mbtool: Don't mount wrapped binaries image with MS_NOSUID

### DIFF
--- a/mbtool/mount_fstab.cpp
+++ b/mbtool/mount_fstab.cpp
@@ -637,12 +637,12 @@ static bool create_ext4_temp_fs(const char *mount_point)
         }
     }
 
-    return util::mount(EXT4_TEMP_IMAGE, mount_point, "ext4", MS_NOSUID, "");
+    return util::mount(EXT4_TEMP_IMAGE, mount_point, "ext4", 0, "");
 }
 
 static bool create_tmpfs_temp_fs(const char *mount_point)
 {
-    return util::mount("tmpfs", mount_point, "tmpfs", MS_NOSUID, "mode=0755");
+    return util::mount("tmpfs", mount_point, "tmpfs", 0, "mode=0755");
 }
 
 static bool create_temporary_fs(const char *mount_point)


### PR DESCRIPTION
check_nnp_nosuid() in security/selinux/hooks.c of the kernel source code
calls security_bounded_transition() for mount points with the nosuid
flag set. This will cause the process of setexeccon'ing to
fsck_untrusted and exec'ing a 'fsck_exec' labeled binary to fail unless
an appropriate typebounds statement exists in the policy.

Sample audit message for failure:

```
  type=1401 audit(1478575822.166:457): op=security_bounded_transition seresult=denied oldcontext=u:r:vold:s0 newcontext=u:r:fsck_untrusted:s0
```

We fix this by simply not mounting the /wrapped mount point with nosuid,
which matches the mount options for /system anyway.