### PR TITLE
Android GUI: Launch mbtool from a tmpfs if possible

### DIFF
--- a/Android_GUI/src/com/github/chenxiaolong/dualbootpatcher/CommandUtils.java
+++ b/Android_GUI/src/com/github/chenxiaolong/dualbootpatcher/CommandUtils.java
@@ -148,4 +148,19 @@ public final class CommandUtils {
 
         return -1;
     }
+
+    public static int runRootCommand(String... args) {
+        StringBuilder command = new StringBuilder();
+        for (int i = 0; i < args.length; i++) {
+            if (i > 0) {
+                command.append(' ');
+            }
+            command.append(shellQuote(args[i]));
+        }
+        return runRootCommand(command.toString());
+    }
+
+    public static String shellQuote(String text) {
+        return "'" + text.replace("'", "'\"'\"'") + "'";
+    }
 }


### PR DESCRIPTION
Android N's toybox has bad argument parsing code and cannot handle:

    mount -o remount,rw /

which prevents us from putting mbtool in rootfs.