### PR TITLE
Android GUI: Add option for explicitly patching Odin images

### DIFF
--- a/Android_GUI/res/layout/fragment_patcher.xml
+++ b/Android_GUI/res/layout/fragment_patcher.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <!--
-   * Copyright (C) 2014-2015  Andrew Gunnerson <andrewgunnerson@gmail.com>
+   * Copyright (C) 2014-2016  Andrew Gunnerson <andrewgunnerson@gmail.com>
    *
    * This program is free software: you can redistribute it and/or modify
    * it under the terms of the GNU General Public License as published by
@@ -37,7 +37,7 @@
         android:layout_height="wrap_content"
         android:layout_centerInParent="true"
         android:gravity="center"
-        android:text="Tap the FAB to add files to patch." />
+        android:text="@string/patcher_background_message" />
 
     <!-- List of files to patch -->
     <android.support.v7.widget.RecyclerView
@@ -51,17 +51,37 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 
-        <!-- FAB to add more files to patch -->
-        <com.github.clans.fab.FloatingActionButton
+        <!-- FAB to add files to patch -->
+        <com.github.clans.fab.FloatingActionMenu
             android:id="@+id/fab"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="end|bottom"
             android:layout_marginBottom="@dimen/fab_margin_bottom"
             android:layout_marginEnd="@dimen/fab_margin_end"
-            android:src="@drawable/ic_plus_white_24dp"
             app:layout_behavior="com.github.chenxiaolong.dualbootpatcher.views.FloatingActionButtonBehavior"
-            fab:fab_colorNormal="@color/fab_pink"
-            fab:fab_colorPressed="@color/fab_pink_pressed" />
+            fab:menu_colorNormal="@color/fab_pink"
+            fab:menu_colorPressed="@color/fab_pink_pressed">
+
+            <com.github.clans.fab.FloatingActionButton
+                android:id="@+id/fab_add_odin_image"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:src="@drawable/ic_plus_white_24dp"
+                fab:fab_colorNormal="@color/fab_pink"
+                fab:fab_colorPressed="@color/fab_pink_pressed"
+                fab:fab_size="mini"
+                fab:fab_label="@string/patcher_add_odin_image" />
+
+            <com.github.clans.fab.FloatingActionButton
+                android:id="@+id/fab_add_flashable_zip"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:src="@drawable/ic_plus_white_24dp"
+                fab:fab_colorNormal="@color/fab_pink"
+                fab:fab_colorPressed="@color/fab_pink_pressed"
+                fab:fab_size="mini"
+                fab:fab_label="@string/patcher_add_flashable_zip" />
+        </com.github.clans.fab.FloatingActionMenu>
     </android.support.design.widget.CoordinatorLayout>
 </RelativeLayout>

--- a/Android_GUI/res/values/strings.xml
+++ b/Android_GUI/res/values/strings.xml
@@ -332,6 +332,14 @@
     <!-- Backup name input field hint for backup name dialog -->
     <string name="br_name_dialog_hint">Enter backup name…</string>
 
+    <!-- Text shown on blank background when no files have been added for patching yet -->
+    <string name="patcher_background_message">Tap the FAB to add files to patch.</string>
+
+    <!-- Label for FAB to add a flashable zip -->
+    <string name="patcher_add_flashable_zip">Add flashable zip</string>
+    <!-- Label for FAB to add an Odin image -->
+    <string name="patcher_add_odin_image">Add Odin image</string>
+
     <!-- Dialog error message shown if the user denies storage permissions to the app in Android >= 6.0. The patcher cannot patch files if it cannot read and write to the internal storage. -->
     <string name="patcher_storage_permission_required">The patcher cannot patch files without read
         and write access to the internal storage. Please grant storage permissions to be able to

--- a/Android_GUI/src/com/github/chenxiaolong/dualbootpatcher/patcher/PatchFileFragment.java
+++ b/Android_GUI/src/com/github/chenxiaolong/dualbootpatcher/patcher/PatchFileFragment.java
@@ -74,6 +74,7 @@ import com.github.chenxiaolong.dualbootpatcher.views.DragSwipeItemTouchCallback;
 import com.github.chenxiaolong.dualbootpatcher.views.DragSwipeItemTouchCallback
         .OnItemMovedOrDismissedListener;
 import com.github.clans.fab.FloatingActionButton;
+import com.github.clans.fab.FloatingActionMenu;
 
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.io.IOUtils;
@@ -99,11 +100,11 @@ public class PatchFileFragment extends Fragment implements
     private static final String PROGRESS_DIALOG_QUERYING_METADATA =
             PatchFileFragment.class.getCanonicalName() + ".progress.querying_metadata";
 
+    private static final String EXTRA_SELECTED_PATCHER_ID = "selected_patcher_id";
     private static final String EXTRA_SELECTED_INPUT_URI = "selected_input_file";
     private static final String EXTRA_SELECTED_OUTPUT_URI = "selected_output_file";
     private static final String EXTRA_SELECTED_INPUT_FILE_NAME = "selected_input_file_name";
     private static final String EXTRA_SELECTED_INPUT_FILE_SIZE = "selected_input_file_size";
-    private static final String EXTRA_SELECTED_IS_ODIN = "selected_is_odin";
     private static final String EXTRA_SELECTED_TASK_ID = "selected_task_id";
     private static final String EXTRA_SELECTED_DEVICE = "selected_device";
     private static final String EXTRA_SELECTED_ROM_ID = "selected_rom_id";
@@ -125,7 +126,9 @@ public class PatchFileFragment extends Fragment implements
     /** Main files list */
     private RecyclerView mRecycler;
     /** FAB */
-    private FloatingActionButton mFAB;
+    private FloatingActionMenu mFAB;
+    private FloatingActionButton mFABAddZip;
+    private FloatingActionButton mFABAddOdin;
     /** Loading progress spinner */
     private ProgressBar mProgressBar;
     /** Add zip message */
@@ -161,6 +164,8 @@ public class PatchFileFragment extends Fragment implements
     /** Item touch callback for dragging and swiping */
     DragSwipeItemTouchCallback mItemTouchCallback;
 
+    /** Selected patcher ID */
+    private String mSelectedPatcherId;
     /** Selected input file */
     private Uri mSelectedInputUri;
     /** Selected output file */
@@ -169,8 +174,6 @@ public class PatchFileFragment extends Fragment implements
     private String mSelectedInputFileName;
     /** Selected input file's size */
     private long mSelectedInputFileSize;
-    /** Selected file is Odin image */
-    private boolean mSelectedIsOdin;
     /** Task ID of selected patcher item */
     private int mSelectedTaskId;
     /** Target device */
@@ -204,11 +207,11 @@ public class PatchFileFragment extends Fragment implements
         super.onActivityCreated(savedInstanceState);
 
         if (savedInstanceState != null) {
+            mSelectedPatcherId = savedInstanceState.getString(EXTRA_SELECTED_PATCHER_ID);
             mSelectedInputUri = savedInstanceState.getParcelable(EXTRA_SELECTED_INPUT_URI);
             mSelectedOutputUri = savedInstanceState.getParcelable(EXTRA_SELECTED_OUTPUT_URI);
             mSelectedInputFileName = savedInstanceState.getString(EXTRA_SELECTED_INPUT_FILE_NAME);
             mSelectedInputFileSize = savedInstanceState.getLong(EXTRA_SELECTED_INPUT_FILE_SIZE);
-            mSelectedIsOdin = savedInstanceState.getBoolean(EXTRA_SELECTED_IS_ODIN);
             mSelectedTaskId = savedInstanceState.getInt(EXTRA_SELECTED_TASK_ID);
             mSelectedDevice = savedInstanceState.getParcelable(EXTRA_SELECTED_DEVICE);
             mSelectedRomId = savedInstanceState.getString(EXTRA_SELECTED_ROM_ID);
@@ -217,7 +220,9 @@ public class PatchFileFragment extends Fragment implements
 
         // Initialize UI elements
         mRecycler = (RecyclerView) getActivity().findViewById(R.id.files_list);
-        mFAB = (FloatingActionButton) getActivity().findViewById(R.id.fab);
+        mFAB = (FloatingActionMenu) getActivity().findViewById(R.id.fab);
+        mFABAddZip = (FloatingActionButton) getActivity().findViewById(R.id.fab_add_flashable_zip);
+        mFABAddOdin = (FloatingActionButton) getActivity().findViewById(R.id.fab_add_odin_image);
         mProgressBar = (ProgressBar) getActivity().findViewById(R.id.loading);
         mAddZipMessage = (TextView) getActivity().findViewById(R.id.add_zip_message);
 
@@ -233,14 +238,18 @@ public class PatchFileFragment extends Fragment implements
         }
 
         // Set up listener for the FAB
-        mFAB.setOnClickListener(new OnClickListener() {
+        mFABAddZip.setOnClickListener(new OnClickListener() {
             @Override
             public void onClick(View view) {
-                if (PermissionUtils.supportsRuntimePermissions()) {
-                    requestPermissions();
-                } else {
-                    selectInputUri();
-                }
+                startFileSelection(PatcherUtils.PATCHER_ID_MULTIBOOTPATCHER);
+                mFAB.close(true);
+            }
+        });
+        mFABAddOdin.setOnClickListener(new OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                startFileSelection(PatcherUtils.PATCHER_ID_ODINPATCHER);
+                mFAB.close(true);
             }
         });
 
@@ -254,7 +263,7 @@ public class PatchFileFragment extends Fragment implements
         mRecycler.setLayoutManager(llm);
 
         // Hide FAB initially
-        mFAB.hide(false);
+        mFAB.hideMenuButton(false);
 
         // Show loading progress bar
         updateLoadingStatus();
@@ -279,11 +288,11 @@ public class PatchFileFragment extends Fragment implements
     public void onSaveInstanceState(Bundle outState) {
         super.onSaveInstanceState(outState);
 
+        outState.putString(EXTRA_SELECTED_PATCHER_ID, mSelectedPatcherId);
         outState.putParcelable(EXTRA_SELECTED_INPUT_URI, mSelectedInputUri);
         outState.putParcelable(EXTRA_SELECTED_OUTPUT_URI, mSelectedOutputUri);
         outState.putString(EXTRA_SELECTED_INPUT_FILE_NAME, mSelectedInputFileName);
         outState.putLong(EXTRA_SELECTED_INPUT_FILE_SIZE, mSelectedInputFileSize);
-        outState.putBoolean(EXTRA_SELECTED_IS_ODIN, mSelectedIsOdin);
         outState.putInt(EXTRA_SELECTED_TASK_ID, mSelectedTaskId);
         outState.putParcelable(EXTRA_SELECTED_DEVICE, mSelectedDevice);
         outState.putString(EXTRA_SELECTED_ROM_ID, mSelectedRomId);
@@ -528,12 +537,12 @@ public class PatchFileFragment extends Fragment implements
     private void updateLoadingStatus() {
         if (mShowingProgress) {
             mRecycler.setVisibility(View.GONE);
-            mFAB.hide(true);
+            mFAB.hideMenuButton(true);
             mAddZipMessage.setVisibility(View.GONE);
             mProgressBar.setVisibility(View.VISIBLE);
         } else {
             mRecycler.setVisibility(View.VISIBLE);
-            mFAB.show(true);
+            mFAB.showMenuButton(true);
             mAddZipMessage.setVisibility(View.VISIBLE);
             mProgressBar.setVisibility(View.GONE);
         }
@@ -660,6 +669,16 @@ public class PatchFileFragment extends Fragment implements
         dialog.show(getFragmentManager(), DIALOG_PATCHER_OPTIONS);
     }
 
+    private void startFileSelection(String patcherId) {
+        mSelectedPatcherId = patcherId;
+
+        if (PermissionUtils.supportsRuntimePermissions()) {
+            requestPermissions();
+        } else {
+            selectInputUri();
+        }
+    }
+
     private void requestPermissions() {
         FragmentCompat.requestPermissions(PatchFileFragment.this,
                 PermissionUtils.STORAGE_PERMISSIONS, PERMISSIONS_REQUEST_STORAGE);
@@ -717,8 +736,9 @@ public class PatchFileFragment extends Fragment implements
     private void selectOutputFile() {
         String baseName;
         String extension;
-        if (mSelectedIsOdin) {
-            baseName = mSelectedInputFileName.replaceAll("\\.tar\\.md5(\\.gz|\\.xz)?$", "");
+        if (mSelectedPatcherId.equals(PatcherUtils.PATCHER_ID_ODINPATCHER)) {
+            baseName = mSelectedInputFileName.replaceAll(
+                    "(\\.tar\\.md5(\\.gz|\\.xz)?|\\.zip)$", "");
             extension = "zip";
         } else {
             baseName = FilenameUtils.getBaseName(mSelectedInputFileName);
@@ -831,10 +851,6 @@ public class PatchFileFragment extends Fragment implements
         mSelectedInputFileName = metadata.displayName;
         mSelectedInputFileSize = metadata.size;
 
-        mSelectedIsOdin = mSelectedInputFileName.endsWith(".tar.md5")
-                || mSelectedInputFileName.endsWith(".tar.md5.gz")
-                || mSelectedInputFileName.endsWith(".tar.md5.xz");
-
         // Open patcher options
         showPatcherOptionsDialog(-1);
     }
@@ -902,11 +918,7 @@ public class PatchFileFragment extends Fragment implements
             @Override
             public void run() {
                 final PatchFileItem pf = new PatchFileItem();
-                if (mSelectedIsOdin) {
-                    pf.patcherId = "OdinPatcher";
-                } else {
-                    pf.patcherId = "MultiBootPatcher";
-                }
+                pf.patcherId = mSelectedPatcherId;
                 pf.device = mSelectedDevice;
                 pf.inputUri = mSelectedInputUri;
                 pf.outputUri = mSelectedOutputUri;

--- a/Android_GUI/src/com/github/chenxiaolong/dualbootpatcher/patcher/PatcherUtils.java
+++ b/Android_GUI/src/com/github/chenxiaolong/dualbootpatcher/patcher/PatcherUtils.java
@@ -44,6 +44,9 @@ public class PatcherUtils {
     private static final String PREFIX_DATA_SLOT = "data-slot-";
     private static final String PREFIX_EXTSD_SLOT = "extsd-slot-";
 
+    public static final String PATCHER_ID_MULTIBOOTPATCHER = "MultiBootPatcher";
+    public static final String PATCHER_ID_ODINPATCHER = "OdinPatcher";
+
     private static boolean sInitialized;
 
     private static Device[] sDevices;


### PR DESCRIPTION
This allows zipped Odin tarballs to be patched since it won't be
ambiguous as to whether MultiBootPatcher or OdinPatcher should be used.