### PR TITLE
Add Moto G4 & G4 plus support

### DIFF
--- a/data/devices/motorola.yml
+++ b/data/devices/motorola.yml
@@ -372,3 +372,45 @@
     recovery:
       - /dev/block/platform/msm_sdcc.1/by-name/recovery
       - /dev/block/mmcblk0p37
+
+- name: Motorola Moto G4 & G4 Plus Edition
+  id: athene
+  codenames:
+    - athene
+    - athene_f
+    - xt1621
+    - xt1622
+    - xt1625
+    - xt1626
+    - xt1640
+    - xt1641
+    - xt1642
+    - xt1643
+    - xt1644
+
+  architecture: armeabi-v7a
+
+  block_devs:
+    base_dirs:
+      - /dev/block/bootdevice/by-name
+      - /dev/block/platform/soc.0/7824900.sdhci/by-name
+    system:
+      - /dev/block/bootdevice/by-name/system
+      - /dev/block/platform/soc.0/7824900.sdhci/by-name/system
+      - /dev/block/mmcblk0p47
+    cache:
+      - /dev/block/bootdevice/by-name/cache
+      - /dev/block/platform/soc.0/7824900.sdhci/by-name/cache
+      - /dev/block/mmcblk0p46
+    data:
+      - /dev/block/bootdevice/by-name/userdata
+      - /dev/block/platform/soc.0/7824900.sdhci/by-name/userdata
+      - /dev/block/mmcblk0p48
+    boot:
+      - /dev/block/bootdevice/by-name/boot
+      - /dev/block/platform/soc.0/7824900.sdhci/by-name/boot
+      - /dev/block/mmcblk0p28
+    recovery:
+      - /dev/block/bootdevice/by-name/recovery
+      - /dev/block/platform/soc.0/7824900.sdhci/by-name/recovery
+      - /dev/block/mmcblk0p29


### PR DESCRIPTION
Chen, can you merge this and create an apk so that I can test this. I am not able to build the apk locally. Lots of errors starting with minimum cmake version needed being 3.6.0, I am running peppermint OS which comes with cmake 3.5.1. Even after manually fixing it by upgrading cmake, i get errors 

`CMake Error at cmake/android.toolchain.cmake:47 (file):
  file failed to open for reading (No such file or directory):

    /home/sileshn/DualBootPatcher/source.properties
Call Stack (most recent call first):
  /usr/share/cmake-3.7/Modules/CMakeDetermineSystem.cmake:88 (include)
  CMakeLists.txt:3 (project)


CMake Error at cmake/android.toolchain.cmake:51 (message):
  Failed to parse Android NDK revision:
  /home/sileshn/DualBootPatcher/source.properties.

Call Stack (most recent call first):
  /usr/share/cmake-3.7/Modules/CMakeDetermineSystem.cmake:88 (include)
  CMakeLists.txt:3 (project)


CMake Error at cmake/android.toolchain.cmake:319 (message):
  Invalid Android platform: android-24.
Call Stack (most recent call first):
  /usr/share/cmake-3.7/Modules/CMakeDetermineSystem.cmake:88 (include)
  CMakeLists.txt:3 (project)


CMake Error: CMAKE_CXX_COMPILER not set, after EnableLanguage
CMake Error: CMAKE_C_COMPILER not set, after EnableLanguage
CMake Error: CMAKE_ASM_COMPILER not set, after EnableLanguage
-- Configuring incomplete, errors occurred!
android/CMakeFiles/android-system_x86_64.dir/build.make:105: recipe for target 'android/android-system_x86_64-prefix/src/android-system_x86_64-stamp/android-system_x86_64-configure' failed
make[2]: *** [android/android-system_x86_64-prefix/src/android-system_x86_64-stamp/android-system_x86_64-configure] Error 1
CMakeFiles/Makefile2:1772: recipe for target 'android/CMakeFiles/android-system_x86_64.dir/all' failed
make[1]: *** [android/CMakeFiles/android-system_x86_64.dir/all] Error 2
Makefile:160: recipe for target 'all' failed
make: *** [all] Error 2`