### PR TITLE
Add support for YU Yunique

### DIFF
--- a/data/devices/yu.yml
+++ b/data/devices/yu.yml
@@ -48,7 +48,8 @@
   id: jalebi
   codenames:
     - YUNIQUE
-      - jalebi
+    - jalebi
+    - YU4711
   architecture: armeabi-v7a
 
   block_devs:

--- a/data/devices/yu.yml
+++ b/data/devices/yu.yml
@@ -45,7 +45,7 @@
     theme: portrait_hdpi
 
 - name: YU Yunique
-  id: lettuce
+  id: jalebi
   codenames:
     - YUNIQUE
       - jalebi

--- a/data/devices/yu.yml
+++ b/data/devices/yu.yml
@@ -57,20 +57,25 @@
       - /dev/block/bootdevice/by-name      
       - /dev/block/platform/soc.0/7824900.sdhci/by-name
     system:
+      - /dev/block/platform/soc.0/7824900.sdhci/by-name/system
       - /dev/block/bootdevice/by-name/system
-      - /dev/block/platform/soc.0/7864900.sdhci/by-name/system
+      - /dev/block/mmcblk0p24
     cache:
+      - /dev/block/platform/soc.0/7824900.sdhci/by-name/cache
       - /dev/block/bootdevice/by-name/cache
-      - /dev/block/platform/soc.0/7864900.sdhci/by-name/cache
+      - /dev/block/mmcblk0p25
     data:
+      - /dev/block/platform/soc.0/7824900.sdhci/by-name/userdata
       - /dev/block/bootdevice/by-name/userdata
-      - /dev/block/platform/soc.0/7864900.sdhci/by-name/userdata
+      - /dev/block/mmcblk0p32
     boot:
+      - /dev/block/platform/soc.0/7824900.sdhci/by-name/boot
       - /dev/block/bootdevice/by-name/boot
-      - /dev/block/platform/soc.0/7864900.sdhci/by-name/boot
+      - /dev/block/mmcblk0p21
     recovery:
+      - /dev/block/platform/soc.0/7824900.sdhci/by-name/recovery
       - /dev/block/bootdevice/by-name/recovery
-      - /dev/block/platform/soc.0/7864900.sdhci/by-name/recovery
+      - /dev/block/mmcblk0p22
 
   boot_ui:
     supported: true

--- a/data/devices/yu.yml
+++ b/data/devices/yu.yml
@@ -43,3 +43,43 @@
     graphics_backends:
       - fbdev
     theme: portrait_hdpi
+
+- name: YU Yunique
+  id: lettuce
+  codenames:
+    - YUNIQUE
+      - jalebi
+  architecture: armeabi-v7a
+
+  block_devs:
+    base_dirs:
+      - /dev/block/bootdevice/by-name      
+      - /dev/block/platform/soc.0/7824900.sdhci/by-name
+    system:
+      - /dev/block/bootdevice/by-name/system
+      - /dev/block/platform/soc.0/7864900.sdhci/by-name/system
+    cache:
+      - /dev/block/bootdevice/by-name/cache
+      - /dev/block/platform/soc.0/7864900.sdhci/by-name/cache
+    data:
+      - /dev/block/bootdevice/by-name/userdata
+      - /dev/block/platform/soc.0/7864900.sdhci/by-name/userdata
+    boot:
+      - /dev/block/bootdevice/by-name/boot
+      - /dev/block/platform/soc.0/7864900.sdhci/by-name/boot
+    recovery:
+      - /dev/block/bootdevice/by-name/recovery
+      - /dev/block/platform/soc.0/7864900.sdhci/by-name/recovery
+
+  boot_ui:
+    supported: true
+    flags:
+      - TW_QCOM_RTC_FIX
+      - TW_GRAPHICS_FORCE_USE_LINELENGTH
+    pixel_format: RGBA_8888
+    brightness_path: /sys/class/leds/lcd-backlight/brightness
+    max_brightness: 255
+    default_brightness: 128
+    graphics_backends:
+      - fbdev
+    theme: portrait_hdpi


### PR DESCRIPTION
Having issues with NDK just like @out386 

```

  x86_64-linux-android-g++: error: x86_64-none-linux-android: No such file or
  directory

  x86_64-linux-android-g++: error: x86_64-none-linux-android: No such file or
  directory

  x86_64-linux-android-g++: error: unrecognized command line option '-target'

  x86_64-linux-android-g++: error: unrecognized command line option '-target'

  x86_64-linux-android-g++: error: unrecognized command line option
  '-fno-limit-debug-info'

  make[4]: *** [CMakeFiles/cmTC_4c8ab.dir/testCXXCompiler.cxx.o] Error 1

  make[4]: Leaving directory
  `/root/harsh/DualBootPatcher/build/android/android-system_x86_64-prefix/src/android-system_x86_64-build/CMakeFiles/CMakeTmp'


  make[3]: *** [cmTC_4c8ab/fast] Error 2

  make[3]: Leaving directory
  `/root/harsh/DualBootPatcher/build/android/android-system_x86_64-prefix/src/android-system_x86_64-build/CMakeFiles/CMakeTmp'
```