### PR TITLE
mbtool: Fix mounting ROM directories if target exists and is a symlink

### DIFF
--- a/libmbutil/include/mbutil/mount.h
+++ b/libmbutil/include/mbutil/mount.h
@@ -28,8 +28,6 @@ namespace util
 
 bool is_mounted(const std::string &mountpoint);
 bool unmount_all(const std::string &dir);
-bool bind_mount(const std::string &source, mode_t source_perms,
-                const std::string &target, mode_t target_perms);
 bool mount(const char *source, const char *target, const char *fstype,
            unsigned long mount_flags, const void *data);
 bool umount(const char *target);

--- a/libmbutil/src/mount.cpp
+++ b/libmbutil/src/mount.cpp
@@ -132,58 +132,6 @@ bool unmount_all(const std::string &dir)
 }
 
 /*!
- * \brief Bind mount a directory
- *
- * This function will create or chmod the source and target directories before
- * performing the bind mount. If the source or target directories don't exist,
- * they will be created (recursively) with the specified permissions. If the
- * directories already exist, they will be chmod'ed with the specified mode
- * (parent directories will not be touched).
- *
- * \param source Source path
- * \param source_perms Permissions for source path
- * \param target Target path
- * \param target_perms Permissions for target path
- *
- * \return True if bind mount is successful. False, otherwise.
- */
-bool bind_mount(const std::string &source, mode_t source_perms,
-                const std::string &target, mode_t target_perms)
-{
-    struct stat sb;
-
-    if (stat(source.c_str(), &sb) < 0
-            && !mkdir_recursive(source, source_perms)) {
-        LOGE("Failed to create %s: %s", source.c_str(), strerror(errno));
-        return false;
-    }
-
-    if (stat(target.c_str(), &sb) < 0
-            && !mkdir_recursive(target, target_perms)) {
-        LOGE("Failed to create %s: %s", target.c_str(), strerror(errno));
-        return false;
-    }
-
-    if (chmod(source.c_str(), source_perms) < 0) {
-        LOGE("Failed to chmod %s: %s", source.c_str(), strerror(errno));
-        return false;
-    }
-
-    if (chmod(target.c_str(), target_perms) < 0) {
-        LOGE("Failed to chmod %s: %s", target.c_str(), strerror(errno));
-        return false;
-    }
-
-    if (::mount(source.c_str(), target.c_str(), "", MS_BIND, "") < 0) {
-        LOGE("Failed to bind mount %s to %s: %s",
-             source.c_str(), target.c_str(), strerror(errno));
-        return false;
-    }
-
-    return true;
-}
-
-/*!
  * \brief Mount filesystem
  *
  * This function takes the same arguments as mount(2), but returns true on

--- a/mbtool/installer.cpp
+++ b/mbtool/installer.cpp
@@ -730,7 +730,9 @@ bool Installer::mount_dir_or_image(const std::string &source,
 
         _associated_loop_devs.push_back(loopdev);
     } else {
-        if (!util::bind_mount(source, 0771, bind_target, 0771)) {
+        if (!util::mkdir_recursive(source, 0771)
+                || !util::mkdir_recursive(bind_target, 0771)
+                || mount(source.c_str(), bind_target.c_str(), "", MS_BIND, "") < 0) {
             display_msg("Failed to bind mount %s to %s",
                         source.c_str(), bind_target.c_str());
             return false;


### PR DESCRIPTION
This makes mbtool behave more like fs_mgr in Android. If /system,
/cache, or /data already exists and is a symlink, then the symlink is
unlinked and a directory is created in its place.