### PR TITLE
Add support - Lenovo K4 Note

### DIFF
--- a/data/devices/lenovo.yml
+++ b/data/devices/lenovo.yml
@@ -66,6 +66,71 @@
     theme: portrait_hdpi
 
 
+- name: Lenovo K4 Note
+  id: A7010a48
+  codenames:
+    - A7010a48
+    - K4
+    - K4 Note
+    - Lenovo K4 Note
+    - Vibe X3 Lite
+    - Lenovo A7010a48
+
+  architecture: arm64-v8a
+  flags:
+    - FSTAB_SKIP_SDCARD0
+
+  block_devs:
+    base_dirs:
+      - /dev/block/platform/mtk-msdc.0/by-name
+      - /dev/block/platform/mtk-msdc.0/11230000.MSDC0/by-name
+    system:
+      - /dev/block/platform/mtk-msdc.0/by-name/system
+      - /dev/block/platform/mtk-msdc.0/11230000.MSDC0/by-name/system
+      - /dev/block/mmcblk0p23
+    cache:
+      - /dev/block/platform/mtk-msdc.0/by-name/cache
+      - /dev/block/platform/mtk-msdc.0/11230000.MSDC0/by-name/cache
+      - /dev/block/mmcblk0p24
+    data:
+      - /dev/block/platform/mtk-msdc.0/by-name/userdata
+      - /dev/block/platform/mtk-msdc.0/11230000.MSDC0/by-name/userdata
+      - /dev/block/mmcblk0p25
+    boot:
+      - /dev/block/platform/mtk-msdc.0/by-name/boot
+      - /dev/block/platform/mtk-msdc.0/11230000.MSDC0/by-name/boot
+      - /dev/block/mmcblk0p7
+    recovery:
+      - /dev/block/platform/mtk-msdc.0/by-name/recovery
+      - /dev/block/platform/mtk-msdc.0/11230000.MSDC0/by-name/recovery
+      - /dev/block/mmcblk0p8
+    extra:
+      - /dev/block/mmcblk0boot0
+      - /dev/block/platform/mtk-msdc.0/by-name/lk
+      - /dev/block/platform/mtk-msdc.0/11230000.MSDC0/by-name/lk
+      - /dev/block/platform/mtk-msdc.0/by-name/logo
+      - /dev/block/platform/mtk-msdc.0/11230000.MSDC0/by-name/logo
+      - /dev/block/platform/mtk-msdc.0/by-name/para
+      - /dev/block/platform/mtk-msdc.0/11230000.MSDC0/by-name/para
+      - /dev/block/platform/mtk-msdc.0/by-name/tee1
+      - /dev/block/platform/mtk-msdc.0/11230000.MSDC0/by-name/tee1
+      - /dev/block/platform/mtk-msdc.0/by-name/tee2
+      - /dev/block/platform/mtk-msdc.0/11230000.MSDC0/by-name/tee2
+      - /dev/block/platform/mtk-msdc.0/by-name/uboot
+      - /dev/block/platform/mtk-msdc.0/11230000.MSDC0/by-name/uboot
+
+  boot_ui:
+    supported: true
+    graphics_backends:
+      - fbdev
+    flags:
+      - TW_GRAPHICS_FORCE_USE_LINELENGTH
+    pixel_format: RGBX_8888
+    max_brightness: 255
+    default_brightness: 162
+    cpu_temp_path: /sys/class/thermal/thermal_zone1/temp
+    theme: portrait_hdpi
+
 - name: Lenovo Vibe Z2 Pro
   id: K920
   codenames:


### PR DESCRIPTION
- name: Lenovo K4 Note
  id: A7010a48
  codenames:
    - A7010a48
    - K4
    - K4 Note
    - Lenovo K4 Note
    - Vibe X3 Lite
    - Lenovo A7010a48

lenovo.yml provided by dg28gadhavi@xda

Build was successful.