### PR TITLE
libmbp: Drop support for SIN! image and header in Sony ELF images

### DIFF
--- a/Android_GUI/src/com/github/chenxiaolong/dualbootpatcher/nativelib/LibMbp.java
+++ b/Android_GUI/src/com/github/chenxiaolong/dualbootpatcher/nativelib/LibMbp.java
@@ -121,10 +121,6 @@ public class LibMbp {
         static native void mbp_bootimage_set_rpm_image(CBootImage bi, Pointer data, int size);
         static native void mbp_bootimage_appsbl_image(CBootImage bi, PointerByReference dataReturn, /* size_t */ IntByReference sizeReturn);
         static native void mbp_bootimage_set_appsbl_image(CBootImage bi, Pointer data, int size);
-        static native void mbp_bootimage_sin_image(CBootImage bi, PointerByReference dataReturn, /* size_t */ IntByReference sizeReturn);
-        static native void mbp_bootimage_set_sin_image(CBootImage bi, Pointer data, int size);
-        static native void mbp_bootimage_sin_header(CBootImage bi, PointerByReference dataReturn, /* size_t */ IntByReference sizeReturn);
-        static native void mbp_bootimage_set_sin_header(CBootImage bi, Pointer data, int size);
         static native boolean mbp_bootimage_equals(CBootImage lhs, CBootImage rhs);
         // END: cbootimage.h
 
@@ -773,25 +769,6 @@ public class LibMbp {
             Memory mem = new Memory(data.length);
             mem.write(0, data, 0, data.length);
             CWrapper.mbp_bootimage_set_appsbl_image(mCBootImage, mem, data.length);
-        }
-
-        public byte[] getSinImage() {
-            validate(mCBootImage, BootImage.class, "getSinImage");
-            PointerByReference pData = new PointerByReference();
-            IntByReference pSize = new IntByReference();
-            CWrapper.mbp_bootimage_sin_image(mCBootImage, pData, pSize);
-            Pointer data = pData.getValue();
-            int size = pSize.getValue();
-            return data.getByteArray(0, size);
-        }
-
-        public void setSinImage(byte[] data) {
-            validate(mCBootImage, BootImage.class, "setSinImage", data.length);
-            ensureNotNull(data);
-
-            Memory mem = new Memory(data.length);
-            mem.write(0, data, 0, data.length);
-            CWrapper.mbp_bootimage_set_sin_image(mCBootImage, mem, data.length);
         }
     }
 

--- a/bootimgtool/bootimgtool.cpp
+++ b/bootimgtool/bootimgtool.cpp
@@ -88,8 +88,6 @@ static const char UnpackUsage[] =
     "  ipl             Ipl image                                     [    S]\n"
     "  rpm             Rpm image                                     [    S]\n"
     "  appsbl          Appsbl image                                  [    S]\n"
-    "  sin             Sin image                                     [    S]\n"
-    "  sinhdr          Sin header                                    [    S]\n"
     "\n"
     "Legend:\n"
     "  [A B L M S]\n"
@@ -167,8 +165,6 @@ static const char PackUsage[] =
     "  ipl              Ipl image                                     [    S]\n"
     "  rpm              Rpm image                                     [    S]\n"
     "  appsbl           Appsbl image                                  [    S]\n"
-    "  sin              Sin image                                     [    S]\n"
-    "  sinhdr           Sin header                                    [    S]\n"
     "\n"
     "Legend:\n"
     "  [A B L M S]\n"
@@ -384,8 +380,6 @@ bool unpack_main(int argc, char *argv[])
     std::string path_ipl;
     std::string path_rpm;
     std::string path_appsbl;
-    std::string path_sin;
-    std::string path_sinhdr;
 
     // Arguments with no short options
     enum unpack_options : int
@@ -411,8 +405,6 @@ bool unpack_main(int argc, char *argv[])
         OPT_OUTPUT_IPL            = 10000 + 19,
         OPT_OUTPUT_RPM            = 10000 + 20,
         OPT_OUTPUT_APPSBL         = 10000 + 21,
-        OPT_OUTPUT_SIN            = 10000 + 22,
-        OPT_OUTPUT_SINHDR         = 10000 + 23
     };
 
     static struct option long_options[] = {
@@ -442,8 +434,6 @@ bool unpack_main(int argc, char *argv[])
         {"output-ipl",            required_argument, 0, OPT_OUTPUT_IPL},
         {"output-rpm",            required_argument, 0, OPT_OUTPUT_RPM},
         {"output-appsbl",         required_argument, 0, OPT_OUTPUT_APPSBL},
-        {"output-sin",            required_argument, 0, OPT_OUTPUT_SIN},
-        {"output-sinhdr",         required_argument, 0, OPT_OUTPUT_SINHDR},
         {0, 0, 0, 0}
     };
 
@@ -475,8 +465,6 @@ bool unpack_main(int argc, char *argv[])
         case OPT_OUTPUT_IPL:            path_ipl = optarg;            break;
         case OPT_OUTPUT_RPM:            path_rpm = optarg;            break;
         case OPT_OUTPUT_APPSBL:         path_appsbl = optarg;         break;
-        case OPT_OUTPUT_SIN:            path_sin = optarg;            break;
-        case OPT_OUTPUT_SINHDR:         path_sinhdr = optarg;         break;
 
         case 'h':
             fprintf(stdout, UnpackUsage);
@@ -551,10 +539,6 @@ bool unpack_main(int argc, char *argv[])
         path_rpm = io::pathJoin({output_dir, prefix + "rpm"});
     if (path_appsbl.empty())
         path_appsbl = io::pathJoin({output_dir, prefix + "appsbl"});
-    if (path_sin.empty())
-        path_sin = io::pathJoin({output_dir, prefix + "sin"});
-    if (path_sinhdr.empty())
-        path_sinhdr = io::pathJoin({output_dir, prefix + "sinhdr"});
 
     if (!io::createDirectories(output_dir)) {
         fprintf(stderr, "%s: Failed to create directory: %s\n",
@@ -596,8 +580,6 @@ bool unpack_main(int argc, char *argv[])
     PRINT_IF(SUPPORTS_IPL_IMAGE,       "- ipl:            %s\n", path_ipl.c_str());
     PRINT_IF(SUPPORTS_RPM_IMAGE,       "- rpm:            %s\n", path_rpm.c_str());
     PRINT_IF(SUPPORTS_APPSBL_IMAGE,    "- appsbl:         %s\n", path_appsbl.c_str());
-    PRINT_IF(SUPPORTS_SONY_SIN_IMAGE,  "- sin:            %s\n", path_sin.c_str());
-    PRINT_IF(SUPPORTS_SONY_SIN_HEADER, "- sinhdr:         %s\n", path_sinhdr.c_str());
 #undef PRINT_IF
 
     /* Extract all the stuff! */
@@ -728,16 +710,6 @@ bool unpack_main(int argc, char *argv[])
         WRITE_FILE_DATA(path_appsbl, bi.appsblImage());
     }
 
-    // Write sin image
-    if (supportMask & SUPPORTS_SONY_SIN_IMAGE) {
-        WRITE_FILE_DATA(path_sin, bi.sinImage());
-    }
-
-    // Write sinhdr image
-    if (supportMask & SUPPORTS_SONY_SIN_HEADER) {
-        WRITE_FILE_DATA(path_sinhdr, bi.sinHeader());
-    }
-
 #undef WRITE_FILE_DATA
 
     printf("\nDone\n");
@@ -774,8 +746,6 @@ bool pack_main(int argc, char *argv[])
     std::string path_ipl;
     std::string path_rpm;
     std::string path_appsbl;
-    std::string path_sin;
-    std::string path_sinhdr;
     // Values
     std::unordered_map<int, bool> values;
     std::string cmdline;
@@ -800,8 +770,6 @@ bool pack_main(int argc, char *argv[])
     std::vector<unsigned char> ipl_image;
     std::vector<unsigned char> rpm_image;
     std::vector<unsigned char> appsbl_image;
-    std::vector<unsigned char> sin_image;
-    std::vector<unsigned char> sin_header;
     mbp::BootImage::Type type = mbp::BootImage::Type::Android;
 
     // Arguments with no short options
@@ -830,8 +798,6 @@ bool pack_main(int argc, char *argv[])
         OPT_INPUT_IPL            = 10000 + 20,
         OPT_INPUT_RPM            = 10000 + 21,
         OPT_INPUT_APPSBL         = 10000 + 22,
-        OPT_INPUT_SIN            = 10000 + 23,
-        OPT_INPUT_SINHDR         = 10000 + 24,
         // Values
         OPT_VALUE_CMDLINE        = 20000 + 1,
         OPT_VALUE_BOARD          = 20000 + 2,
@@ -876,8 +842,6 @@ bool pack_main(int argc, char *argv[])
         {"input-ipl",            required_argument, 0, OPT_INPUT_IPL},
         {"input-rpm",            required_argument, 0, OPT_INPUT_RPM},
         {"input-appsbl",         required_argument, 0, OPT_INPUT_APPSBL},
-        {"input-sin",            required_argument, 0, OPT_INPUT_SIN},
-        {"input-sinhdr",         required_argument, 0, OPT_INPUT_SINHDR},
         // Value arguments
         {"value-cmdline",        required_argument, 0, OPT_VALUE_CMDLINE},
         {"value-board",          required_argument, 0, OPT_VALUE_BOARD},
@@ -923,8 +887,6 @@ bool pack_main(int argc, char *argv[])
         case OPT_INPUT_IPL:            path_ipl = optarg;            break;
         case OPT_INPUT_RPM:            path_rpm = optarg;            break;
         case OPT_INPUT_APPSBL:         path_appsbl = optarg;         break;
-        case OPT_INPUT_SIN:            path_sin = optarg;            break;
-        case OPT_INPUT_SINHDR:         path_sinhdr = optarg;         break;
 
         case OPT_VALUE_CMDLINE:
             path_cmdline.clear();
@@ -1822,48 +1784,6 @@ bool pack_main(int argc, char *argv[])
     } else {
         if (!path_appsbl.empty())
             printf(not_supported, "--input-appsbl");
-    }
-
-    ////////////////////////////////////////////////////////////////////////////
-    // Sony SIN! image
-    ////////////////////////////////////////////////////////////////////////////
-
-    if (support_mask & SUPPORTS_SONY_SIN_IMAGE) {
-        if (path_sin.empty())
-            path_sin = io::pathJoin({input_dir, prefix + "sin"});
-
-        printf(fmt_path, "sin", path_sin.c_str());
-
-        if (!read_file_data(path_sin, &sin_image) && errno != ENOENT) {
-            fprintf(stderr, "%s: %s\n", path_sin.c_str(), strerror(errno));
-            return false;
-        }
-
-        bi.setSinImage(std::move(sin_image));
-    } else {
-        if (!path_sin.empty())
-            printf(not_supported, "--input-sin");
-    }
-
-    ////////////////////////////////////////////////////////////////////////////
-    // Sony SIN! header
-    ////////////////////////////////////////////////////////////////////////////
-
-    if (support_mask & SUPPORTS_SONY_SIN_HEADER) {
-        if (path_sinhdr.empty())
-            path_sinhdr = io::pathJoin({input_dir, prefix + "sinhdr"});
-
-        printf(fmt_path, "sinhdr", path_sinhdr.c_str());
-
-        if (!read_file_data(path_sinhdr, &sin_header) && errno != ENOENT) {
-            fprintf(stderr, "%s: %s\n", path_sinhdr.c_str(), strerror(errno));
-            return false;
-        }
-
-        bi.setSinHeader(std::move(sin_header));
-    } else {
-        if (!path_sinhdr.empty())
-            printf(not_supported, "--input-sinhdr");
     }
 
     // Create boot image

--- a/libmbp/include/mbp/bootimage-common.h
+++ b/libmbp/include/mbp/bootimage-common.h
@@ -44,6 +44,4 @@
 #define SUPPORTS_IPL_IMAGE               0x20000llu
 #define SUPPORTS_RPM_IMAGE               0x40000llu
 #define SUPPORTS_APPSBL_IMAGE            0x80000llu
-#define SUPPORTS_SONY_SIN_IMAGE         0x100000llu
-#define SUPPORTS_SONY_SIN_HEADER        0x200000llu
-#define SUPPORTS_ENTRYPOINT             0x400000llu
+#define SUPPORTS_ENTRYPOINT             0x100000llu

--- a/libmbp/include/mbp/bootimage.h
+++ b/libmbp/include/mbp/bootimage.h
@@ -195,18 +195,6 @@ public:
     void appsblImageC(const unsigned char **data, std::size_t *size) const;
     void setAppsblImageC(const unsigned char *data, std::size_t size);
 
-    // Sony SIN! image
-    const std::vector<unsigned char> & sinImage() const;
-    void setSinImage(std::vector<unsigned char> data);
-    void sinImageC(const unsigned char **data, std::size_t *size) const;
-    void setSinImageC(const unsigned char *data, std::size_t size);
-
-    // Sony SIN! header
-    const std::vector<unsigned char> & sinHeader() const;
-    void setSinHeader(std::vector<unsigned char> data);
-    void sinHeaderC(const unsigned char **data, std::size_t *size) const;
-    void setSinHeaderC(const unsigned char *data, std::size_t size);
-
     bool operator==(const BootImage &other) const;
     bool operator!=(const BootImage &other) const;
 

--- a/libmbp/include/mbp/bootimage/intermediate.h
+++ b/libmbp/include/mbp/bootimage/intermediate.h
@@ -46,8 +46,6 @@ struct BootImageIntermediate
     std::vector<unsigned char> iplImage;      // |         |      |      |     | X    |
     std::vector<unsigned char> rpmImage;      // |         |      |      |     | X    |
     std::vector<unsigned char> appsblImage;   // |         |      |      |     | X    |
-    std::vector<unsigned char> sonySinImage;  // |         |      |      |     | X    |
-    std::vector<unsigned char> sonySinHdr;    // |         |      |      |     | X    |
     // Raw header values                         |---------|------|------|-----|------|
     uint32_t hdrKernelSize = 0;               // | X       | X    | X    | X   |      |
     uint32_t hdrRamdiskSize = 0;              // | X       | X    | X    | X   |      |

--- a/libmbp/include/mbp/cwrapper/cbootimage.h
+++ b/libmbp/include/mbp/cwrapper/cbootimage.h
@@ -152,16 +152,6 @@ MB_EXPORT void mbp_bootimage_appsbl_image(const CBootImage *bootImage,
 MB_EXPORT void mbp_bootimage_set_appsbl_image(CBootImage *bootImage,
                                               const unsigned char *data, size_t size);
 
-MB_EXPORT void mbp_bootimage_sin_image(const CBootImage *bootImage,
-                                       const unsigned char **data, size_t *size);
-MB_EXPORT void mbp_bootimage_set_sin_image(CBootImage *bootImage,
-                                           const unsigned char *data, size_t size);
-
-MB_EXPORT void mbp_bootimage_sin_header(const CBootImage *bootImage,
-                                        const unsigned char **data, size_t *size);
-MB_EXPORT void mbp_bootimage_set_sin_header(CBootImage *bootImage,
-                                            const unsigned char *data, size_t size);
-
 MB_EXPORT bool mbp_bootimage_equals(CBootImage *lhs, CBootImage *rhs);
 
 #ifdef __cplusplus

--- a/libmbp/src/bootimage.cpp
+++ b/libmbp/src/bootimage.cpp
@@ -897,62 +897,6 @@ void BootImage::setAppsblImageC(const unsigned char *data, std::size_t size)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-// Sony SIN! image
-////////////////////////////////////////////////////////////////////////////////
-
-const std::vector<unsigned char> & BootImage::sinImage() const
-{
-    return m_impl->i10e.sonySinImage;
-}
-
-void BootImage::setSinImage(std::vector<unsigned char> data)
-{
-    m_impl->i10e.sonySinImage = std::move(data);
-}
-
-void BootImage::sinImageC(const unsigned char **data, std::size_t *size) const
-{
-    *data = m_impl->i10e.sonySinImage.data();
-    *size = m_impl->i10e.sonySinImage.size();
-}
-
-void BootImage::setSinImageC(const unsigned char *data, std::size_t size)
-{
-    m_impl->i10e.sonySinImage.clear();
-    m_impl->i10e.sonySinImage.shrink_to_fit();
-    m_impl->i10e.sonySinImage.resize(size);
-    std::memcpy(m_impl->i10e.sonySinImage.data(), data, size);
-}
-
-////////////////////////////////////////////////////////////////////////////////
-// Sony SIN! header
-////////////////////////////////////////////////////////////////////////////////
-
-const std::vector<unsigned char> & BootImage::sinHeader() const
-{
-    return m_impl->i10e.sonySinHdr;
-}
-
-void BootImage::setSinHeader(std::vector<unsigned char> data)
-{
-    m_impl->i10e.sonySinHdr = std::move(data);
-}
-
-void BootImage::sinHeaderC(const unsigned char **data, std::size_t *size) const
-{
-    *data = m_impl->i10e.sonySinHdr.data();
-    *size = m_impl->i10e.sonySinHdr.size();
-}
-
-void BootImage::setSinHeaderC(const unsigned char *data, std::size_t size)
-{
-    m_impl->i10e.sonySinHdr.clear();
-    m_impl->i10e.sonySinHdr.shrink_to_fit();
-    m_impl->i10e.sonySinHdr.resize(size);
-    std::memcpy(m_impl->i10e.sonySinHdr.data(), data, size);
-}
-
-////////////////////////////////////////////////////////////////////////////////
 
 bool BootImage::operator==(const BootImage &other) const
 {
@@ -973,8 +917,6 @@ bool BootImage::operator==(const BootImage &other) const
             && m_impl->i10e.iplImage == other.m_impl->i10e.iplImage
             && m_impl->i10e.rpmImage == other.m_impl->i10e.rpmImage
             && m_impl->i10e.appsblImage == other.m_impl->i10e.appsblImage
-            && m_impl->i10e.sonySinImage == other.m_impl->i10e.sonySinImage
-            && m_impl->i10e.sonySinHdr == other.m_impl->i10e.sonySinHdr
             // Header's integral values
             && m_impl->i10e.hdrKernelSize == other.m_impl->i10e.hdrKernelSize
             && m_impl->i10e.kernelAddr == other.m_impl->i10e.kernelAddr

--- a/libmbp/src/cwrapper/cbootimage.cpp
+++ b/libmbp/src/cwrapper/cbootimage.cpp
@@ -656,34 +656,6 @@ void mbp_bootimage_set_appsbl_image(CBootImage *bootImage,
     bi->setAppsblImageC(data, size);
 }
 
-void mbp_bootimage_sin_image(const CBootImage *bootImage,
-                             const unsigned char **data, size_t *size)
-{
-    CCAST(bootImage);
-    bi->sinImageC(data, size);
-}
-
-void mbp_bootimage_set_sin_image(CBootImage *bootImage,
-                                 const unsigned char *data, size_t size)
-{
-    CAST(bootImage);
-    bi->setSinImageC(data, size);
-}
-
-void mbp_bootimage_sin_header(const CBootImage *bootImage,
-                              const unsigned char **data, size_t *size)
-{
-    CCAST(bootImage);
-    bi->sinHeaderC(data, size);
-}
-
-void mbp_bootimage_set_sin_header(CBootImage *bootImage,
-                                  const unsigned char *data, size_t size)
-{
-    CAST(bootImage);
-    bi->setSinHeaderC(data, size);
-}
-
 bool mbp_bootimage_equals(CBootImage *lhs, CBootImage *rhs)
 {
     const mbp::BootImage *biLhs = reinterpret_cast<const mbp::BootImage *>(lhs);


### PR DESCRIPTION
The SIN ELF section contains the RSA signature of the boot image, which
is impossible for us to recreate. Thus, readding an existing SIN section
to a modified boot image may result in a broken image. We'll avoid that
by simply ignoring this section.