### PR TITLE
mbtool: Switch to libmbbootimg and patch boot image at flash time

### DIFF
--- a/libmbp/src/patchers/multibootpatcher.cpp
+++ b/libmbp/src/patchers/multibootpatcher.cpp
@@ -31,8 +31,6 @@
 #include "mblog/logging.h"
 #include "mbpio/delete.h"
 
-#include "mbp/bootimage.h"
-#include "mbp/cpiofile.h"
 #include "mbp/patcherconfig.h"
 #include "mbp/private/fileutils.h"
 #include "mbp/private/miniziputils.h"
@@ -224,16 +222,16 @@ bool MultiBootPatcher::Impl::patchZip()
 
     if (cancelled) return false;
 
+    std::string archDir(pc->dataDirectory());
+    archDir += "/binaries/android/";
+    archDir += mb_device_architecture(info->device());
+
     std::vector<CopySpec> toCopy{
         {
-            pc->dataDirectory() + "/binaries/android/"
-                    + mb_device_architecture(info->device())
-                    + "/mbtool_recovery",
+            archDir + "/mbtool_recovery",
             "META-INF/com/google/android/update-binary"
         }, {
-            pc->dataDirectory() + "/binaries/android/"
-                    + mb_device_architecture(info->device())
-                    + "/mbtool_recovery.sig",
+            archDir + "/mbtool_recovery.sig",
             "META-INF/com/google/android/update-binary.sig"
         }, {
             pc->dataDirectory() + "/scripts/bb-wrapper.sh",
@@ -243,6 +241,22 @@ bool MultiBootPatcher::Impl::patchZip()
             "multiboot/bb-wrapper.sh.sig"
         }
     };
+
+    std::vector<std::string> binaries{
+        "file-contexts-tool",
+        "file-contexts-tool.sig",
+        "fsck-wrapper",
+        "fsck-wrapper.sig",
+        "mbtool",
+        "mbtool.sig",
+        "mount.exfat",
+        "mount.exfat.sig",
+    };
+
+    for (auto const &binary : binaries) {
+        toCopy.push_back({archDir + "/" + binary,
+                          "multiboot/binaries/" + binary});
+    }
 
     // +1 for info.prop
     // +1 for device.json
@@ -330,7 +344,6 @@ bool MultiBootPatcher::Impl::patchZip()
  *
  * This performs the following operations:
  *
- * - Patch boot images and copy them to the output zip.
  * - Files needed by an AutoPatcher are extracted to the temporary directory.
  * - Otherwise, the file is copied directly to the output zip.
  */
@@ -369,68 +382,18 @@ bool MultiBootPatcher::Impl::pass1(const std::string &temporaryDir,
             continue;
         }
 
-        // Try to patch files that end in a common boot image extension
-
-        bool isExtImg = mb_ends_with(curFile.c_str(), ".img");
-        bool isExtLok = mb_ends_with(curFile.c_str(), ".lok");
-        bool isExtGz = mb_ends_with(curFile.c_str(), ".gz");
-        // Boot images should never be over about 30 MiB. This check is here so
-        // the patcher won't try to read a multi-gigabyte system image into RAM
-        bool isSizeOK = fi.uncompressed_size <= 50 * 1024 * 1024;
-
-        if ((isExtImg || isExtLok || isExtGz) && isSizeOK) {
-            // Load the file into memory
-            std::vector<unsigned char> data;
-
-            if (!MinizipUtils::readToMemory(uf, &data,
-                                            &laProgressCb, this)) {
-                error = ErrorCode::ArchiveReadDataError;
-                return false;
-            }
-
-            if (isExtGz) {
-                // Some zips build the boot image at install time and the zip
-                // just includes the split out parts of the boot image
-                if (!patchRamdisk(pc, info, &data, &error)) {
-                    // Just ignore for now
-                }
-            } else {
-                // If the file contains the boot image magic string, then
-                // assume it really is a boot image and patch it
-                if (BootImage::isValid(data.data(), data.size())) {
-                    if (!patchBootImage(pc, info, &data, &error)) {
-                        return false;
-                    }
-                }
-            }
-
-            // Update total size
-            maxBytes += (data.size() - fi.uncompressed_size);
-
-            auto ret2 = MinizipUtils::addFile(zf, curFile, data);
-            if (ret2 != ErrorCode::NoError) {
-                error = ret2;
-                return false;
-            }
-
-            bytes += data.size();
-        } else {
-            // Directly copy other files to the output zip
-
-            // Rename the installer for mbtool
-            if (curFile == "META-INF/com/google/android/update-binary") {
-                curFile = "META-INF/com/google/android/update-binary.orig";
-            }
-
-            if (!MinizipUtils::copyFileRaw(uf, zf, curFile,
-                                           &laProgressCb, this)) {
-                LOGW("minizip: Failed to copy raw data: %s", curFile.c_str());
-                error = ErrorCode::ArchiveWriteDataError;
-                return false;
-            }
-
-            bytes += fi.uncompressed_size;
+        // Rename the installer for mbtool
+        if (curFile == "META-INF/com/google/android/update-binary") {
+            curFile = "META-INF/com/google/android/update-binary.orig";
         }
+
+        if (!MinizipUtils::copyFileRaw(uf, zf, curFile, &laProgressCb, this)) {
+            LOGW("minizip: Failed to copy raw data: %s", curFile.c_str());
+            error = ErrorCode::ArchiveWriteDataError;
+            return false;
+        }
+
+        bytes += fi.uncompressed_size;
     } while ((ret = unzGoToNextFile(uf)) == UNZ_OK);
 
     if (ret != UNZ_END_OF_LIST_OF_FILE) {
@@ -577,91 +540,6 @@ void MultiBootPatcher::Impl::laProgressCb(uint64_t bytes, void *userData)
 {
     Impl *impl = static_cast<Impl *>(userData);
     impl->updateProgress(impl->bytes + bytes, impl->maxBytes);
-}
-
-bool MultiBootPatcher::patchRamdisk(PatcherConfig * const pc,
-                                    const FileInfo * const info,
-                                    std::vector<unsigned char> *data,
-                                    ErrorCode *errorOut)
-{
-    // Load the ramdisk cpio
-    CpioFile cpio;
-    if (!cpio.load(*data)) {
-        if (errorOut) {
-            *errorOut = cpio.error();
-        }
-        return false;
-    }
-
-    std::string rpId(mb_device_id(info->device()));
-    rpId += "/default";
-    auto *rp = pc->createRamdiskPatcher(rpId, info, &cpio);
-    if (!rp) {
-        rpId = "default";
-        rp = pc->createRamdiskPatcher(rpId, info, &cpio);
-    }
-    if (!rp) {
-        if (errorOut) {
-            *errorOut = ErrorCode::RamdiskPatcherCreateError;
-        }
-        return false;
-    }
-
-    if (!rp->patchRamdisk()) {
-        if (errorOut) {
-            *errorOut = rp->error();
-        }
-        pc->destroyRamdiskPatcher(rp);
-        return false;
-    }
-
-    pc->destroyRamdiskPatcher(rp);
-
-    std::vector<unsigned char> newRamdisk;
-    if (!cpio.createData(&newRamdisk)) {
-        if (errorOut) {
-            *errorOut = cpio.error();
-        }
-        return false;
-    }
-
-    data->swap(newRamdisk);
-
-    return true;
-}
-
-bool MultiBootPatcher::patchBootImage(PatcherConfig * const pc,
-                                      const FileInfo * const info,
-                                      std::vector<unsigned char> *data,
-                                      ErrorCode *errorOut)
-{
-    BootImage bi;
-    if (!bi.load(*data)) {
-        if (errorOut) {
-            *errorOut = bi.error();
-        }
-        return false;
-    }
-
-    // Release memory since BootImage keeps a copy of the separate components
-    data->clear();
-    data->shrink_to_fit();
-
-    std::vector<unsigned char> ramdiskImage = bi.ramdiskImage();
-    if (!patchRamdisk(pc, info, &ramdiskImage, errorOut)) {
-        return false;
-    }
-
-    bi.setRamdiskImage(std::move(ramdiskImage));
-
-    if (!bi.create(data)) {
-        if (errorOut) {
-            *errorOut = bi.error();
-        }
-        return false;
-    }
-
-    return true;
 }
 
 template<typename SomeType, typename Predicate>

--- a/libmbp/src/patchers/odinpatcher.cpp
+++ b/libmbp/src/patchers/odinpatcher.cpp
@@ -44,8 +44,6 @@
 
 #include "mblog/logging.h"
 
-#include "mbp/bootimage.h"
-#include "mbp/cpiofile.h"
 #include "mbp/patcherconfig.h"
 #include "mbp/patchers/multibootpatcher.h"
 #include "mbp/private/fileutils.h"
@@ -96,8 +94,7 @@ public:
 
     bool patchTar();
 
-    bool processBootImage(archive *a, archive_entry *entry);
-    bool processSparseFile(archive *a, archive_entry *entry);
+    bool processFile(archive *a, archive_entry *entry, bool sparse);
     bool processContents(archive *a, int depth);
     bool openInputArchive();
     bool closeInputArchive();
@@ -256,36 +253,28 @@ bool OdinPatcher::Impl::patchTar()
         return false;
     }
 
+    std::string archDir(pc->dataDirectory());
+    archDir += "/binaries/android/";
+    archDir += mb_device_architecture(info->device());
+
     std::vector<CopySpec> toCopy{
         {
-            pc->dataDirectory() + "/binaries/android/"
-                    + mb_device_architecture(info->device())
-                    + "/odinupdater",
+            archDir + "/odinupdater",
             "META-INF/com/google/android/update-binary.orig"
         }, {
-            pc->dataDirectory() + "/binaries/android/"
-                    + mb_device_architecture(info->device())
-                    + "/odinupdater.sig",
+            archDir + "/odinupdater.sig",
             "META-INF/com/google/android/update-binary.orig.sig"
         }, {
-            pc->dataDirectory() + "/binaries/android/"
-                    + mb_device_architecture(info->device())
-                    + "/fuse-sparse",
+            archDir + "/fuse-sparse",
             "fuse-sparse"
         }, {
-            pc->dataDirectory() + "/binaries/android/"
-                    + mb_device_architecture(info->device())
-                    + "/fuse-sparse.sig",
+            archDir + "/fuse-sparse.sig",
             "fuse-sparse.sig"
         }, {
-            pc->dataDirectory() + "/binaries/android/"
-                    + mb_device_architecture(info->device())
-                    + "/mbtool_recovery",
+            archDir + "/mbtool_recovery",
             "META-INF/com/google/android/update-binary"
         }, {
-            pc->dataDirectory() + "/binaries/android/"
-                    + mb_device_architecture(info->device())
-                    + "/mbtool_recovery.sig",
+            archDir + "/mbtool_recovery.sig",
             "META-INF/com/google/android/update-binary.sig"
         }, {
             pc->dataDirectory() + "/scripts/bb-wrapper.sh",
@@ -295,6 +284,22 @@ bool OdinPatcher::Impl::patchTar()
             "multiboot/bb-wrapper.sh.sig"
         }
     };
+
+    std::vector<std::string> binaries{
+        "file-contexts-tool",
+        "file-contexts-tool.sig",
+        "fsck-wrapper",
+        "fsck-wrapper.sig",
+        "mbtool",
+        "mbtool.sig",
+        "mount.exfat",
+        "mount.exfat.sig",
+    };
+
+    for (auto const &binary : binaries) {
+        toCopy.push_back({archDir + "/" + binary,
+                          "multiboot/binaries/" + binary});
+    }
 
     zipFile zf = MinizipUtils::ctxGetZipFile(zOutput);
 
@@ -351,52 +356,18 @@ bool OdinPatcher::Impl::patchTar()
     return true;
 }
 
-bool OdinPatcher::Impl::processBootImage(archive *a, archive_entry *entry)
-{
-    // Boot images should never be over about 50 MiB. This check is here
-    // so the patcher won't try to read a multi-gigabyte system image
-    // into RAM
-    la_int64_t size = archive_entry_size(entry);
-    if (size > 50 * 1024 * 1024) {
-        LOGE("Boot image exceeds 50 MiB: %" PRId64, size);
-        error = ErrorCode::BootImageTooLargeError;
-        return false;
-    }
-
-    std::vector<unsigned char> data(size);
-
-    la_ssize_t ret = archive_read_data(a, data.data(), data.size());
-    if (ret < 0 || static_cast<size_t>(ret) != data.size()) {
-        LOGE("libarchive: Failed to read data: %s",
-             archive_error_string(a));
-        error = ErrorCode::ArchiveReadDataError;
-        return false;
-    }
-
-    if (!MultiBootPatcher::patchBootImage(pc, info, &data, &error)) {
-        return false;
-    }
-
-    zipFile zf = MinizipUtils::ctxGetZipFile(zOutput);
-    const char *name = archive_entry_pathname(entry);
-
-    auto errorRet = MinizipUtils::addFile(zf, name, data);
-    if (errorRet != ErrorCode::NoError) {
-        error = errorRet;
-        return false;
-    }
-
-    return true;
-}
-
-bool OdinPatcher::Impl::processSparseFile(archive *a, archive_entry *entry)
+bool OdinPatcher::Impl::processFile(archive *a, archive_entry *entry,
+                                    bool sparse)
 {
     const char *name = archive_entry_pathname(entry);
     std::string zipName(name);
-    if (mb_ends_with(name, ".ext4")) {
-        zipName.erase(zipName.size() - 5);
+
+    if (sparse) {
+        if (mb_ends_with(name, ".ext4")) {
+            zipName.erase(zipName.size() - 5);
+        }
+        zipName += ".sparse";
     }
-    zipName += ".sparse";
 
     // Ha! I'll be impressed if a Samsung firmware image does NOT need zip64
     int zip64 = archive_entry_size(entry) > ((1ll << 32) - 1);
@@ -527,7 +498,7 @@ bool OdinPatcher::Impl::processContents(archive *a, int depth)
             LOGV("%sHandling boot image: %s", indent(depth), name);
             added_files.insert(name);
 
-            if (!processBootImage(a, entry)) {
+            if (!processFile(a, entry, false)) {
                 return false;
             }
         } else if (mb_starts_with(name, "cache.img")
@@ -535,7 +506,7 @@ bool OdinPatcher::Impl::processContents(archive *a, int depth)
             LOGV("%sHandling sparse image: %s", indent(depth), name);
             added_files.insert(name);
 
-            if (!processSparseFile(a, entry)) {
+            if (!processFile(a, entry, true)) {
                 return false;
             }
         } else if (mb_ends_with(name, ".tar.md5")) {

--- a/mbtool/CMakeLists.txt
+++ b/mbtool/CMakeLists.txt
@@ -87,9 +87,13 @@ set(MBTOOL_BASE_SOURCES
 )
 
 set(MBTOOL_RECOVERY_SOURCES
+    archive_util.cpp
     backup.cpp
+    bootimg_util.cpp
     image.cpp
     installer.cpp
+    installer_util.cpp
+    ramdisk_patcher.cpp
     rom_installer.cpp
     update_binary.cpp
     update_binary_tool.cpp
@@ -186,6 +190,7 @@ if(${MBP_BUILD_TARGET} STREQUAL android-system)
         mbsign-static
         mbdevice-static
         mblog-static
+        mbbootimg-static
         mbcommon-static
         minizip-static
         ${MBP_JANSSON_LIBRARIES}
@@ -198,9 +203,8 @@ if(${MBP_BUILD_TARGET} STREQUAL android-system)
         mbutil-static
         mbsign-static
         mblog-static
-        mbp-static
-        mbpio-static
         mbdevice-static
+        mbbootimg-static
         mbcommon-static
         minizip-static
         ${MBP_JANSSON_LIBRARIES}

--- a/mbtool/archive_util.cpp
+++ b/mbtool/archive_util.cpp
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2017  Andrew Gunnerson <andrewgunnerson@gmail.com>
+ *
+ * This file is part of MultiBootPatcher
+ *
+ * MultiBootPatcher is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MultiBootPatcher is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MultiBootPatcher.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "archive_util.h"
+
+#include <cerrno>
+#include <cstring>
+
+#include "mblog/logging.h"
+
+#define BUF_SIZE    10240
+
+namespace mb
+{
+
+bool la_copy_data_to_fd(archive *a, int fd)
+{
+    char buf[BUF_SIZE];
+    la_ssize_t n_read;
+    ssize_t n_written;
+    la_ssize_t remain;
+
+    while ((n_read = archive_read_data(a, buf, sizeof(buf))) > 0) {
+        remain = n_read;
+
+        while (remain > 0) {
+            n_written = write(fd, buf + (n_read - remain), remain);
+            if (n_written <= 0) {
+                LOGE("Failed to write data: %s", strerror(errno));
+                return false;
+            }
+
+            remain -= n_written;
+        }
+    }
+
+    if (n_read < 0) {
+        LOGE("Failed to read archive entry data: %s",
+             archive_error_string(a));
+        return false;
+    }
+
+    return true;
+}
+
+}

--- a/mbtool/archive_util.h
+++ b/mbtool/archive_util.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2017  Andrew Gunnerson <andrewgunnerson@gmail.com>
+ *
+ * This file is part of MultiBootPatcher
+ *
+ * MultiBootPatcher is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MultiBootPatcher is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MultiBootPatcher.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <archive.h>
+
+namespace mb
+{
+
+bool la_copy_data_to_fd(archive *a, int fd);
+
+}

--- a/mbtool/bootimg_util.cpp
+++ b/mbtool/bootimg_util.cpp
@@ -1,0 +1,169 @@
+/*
+ * Copyright (C) 2017  Andrew Gunnerson <andrewgunnerson@gmail.com>
+ *
+ * This file is part of MultiBootPatcher
+ *
+ * MultiBootPatcher is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MultiBootPatcher is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MultiBootPatcher.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "bootimg_util.h"
+
+#include <cerrno>
+#include <cstdio>
+#include <cstring>
+
+#include <unistd.h>
+
+#include "mblog/logging.h"
+
+#define BUF_SIZE    10240
+
+typedef std::unique_ptr<FILE, decltype(fclose) *> ScopedFILE;
+
+namespace mb
+{
+
+bool bi_copy_data_to_fd(MbBiReader *bir, int fd)
+{
+    int ret;
+    char buf[BUF_SIZE];
+    size_t n_read;
+    ssize_t n_written;
+    size_t remain;
+
+    while ((ret = mb_bi_reader_read_data(bir, buf, sizeof(buf), &n_read))
+            == MB_BI_OK) {
+        remain = n_read;
+
+        while (remain > 0) {
+            n_written = write(fd, buf + (n_read - remain), remain);
+            if (n_written <= 0) {
+                LOGE("Failed to write data: %s", strerror(errno));
+                return false;
+            }
+
+            remain -= n_written;
+        }
+    }
+
+    if (ret != MB_BI_EOF) {
+        LOGE("Failed to read boot image entry data: %s",
+             mb_bi_reader_error_string(bir));
+        return false;
+    }
+
+    return true;
+}
+
+bool bi_copy_file_to_data(const std::string &path, MbBiWriter *biw)
+{
+    ScopedFILE fp(fopen(path.c_str(), "rb"), fclose);
+    if (!fp) {
+        LOGE("%s: Failed to open for reading: %s",
+             path.c_str(), strerror(errno));
+        return false;
+    }
+
+    char buf[10240];
+    size_t n;
+
+    while (true) {
+        n = fread(buf, 1, sizeof(buf), fp.get());
+
+        size_t bytes_written;
+
+        if (mb_bi_writer_write_data(biw, buf, n, &bytes_written) != MB_BI_OK
+                || bytes_written != n) {
+            LOGE("Failed to write entry data: %s",
+                 mb_bi_writer_error_string(biw));
+            return false;
+        }
+
+        if (n < sizeof(buf)) {
+            if (ferror(fp.get())) {
+                LOGE("%s: Failed to read file: %s",
+                     path.c_str(), strerror(errno));
+            } else {
+                break;
+            }
+        }
+    }
+
+    return true;
+}
+
+bool bi_copy_data_to_file(MbBiReader *bir, const std::string &path)
+{
+    ScopedFILE fp(fopen(path.c_str(), "wb"), fclose);
+    if (!fp) {
+        LOGE("%s: Failed to open for writing: %s",
+             path.c_str(), strerror(errno));
+        return false;
+    }
+
+    int ret;
+    char buf[10240];
+    size_t n;
+
+    while ((ret = mb_bi_reader_read_data(bir, buf, sizeof(buf), &n))
+            == MB_BI_OK) {
+        if (fwrite(buf, 1, n, fp.get()) != n) {
+            LOGE("%s: Failed to write data: %s",
+                 path.c_str(), strerror(errno));
+            return false;
+        }
+    }
+
+    if (ret != MB_BI_EOF) {
+        LOGE("Failed to read entry data: %s",
+             mb_bi_reader_error_string(bir));
+        return false;
+    }
+
+    if (fclose(fp.release()) < 0) {
+        LOGE("%s: Failed to close file: %s",
+             path.c_str(), strerror(errno));
+        return false;
+    }
+
+    return true;
+}
+
+bool bi_copy_data_to_data(MbBiReader *bir, MbBiWriter *biw)
+{
+    int ret;
+    char buf[10240];
+    size_t n_read;
+    size_t n_written;
+
+    while ((ret = mb_bi_reader_read_data(bir, buf, sizeof(buf), &n_read))
+            == MB_BI_OK) {
+        ret = mb_bi_writer_write_data(biw, buf, n_read, &n_written);
+        if (ret != MB_BI_OK || n_read != n_written) {
+            LOGE("Failed to write entry data: %s",
+                 mb_bi_writer_error_string(biw));
+            return false;
+        }
+    }
+
+    if (ret != MB_BI_EOF) {
+        LOGE("Failed to read boot image entry data: %s",
+             mb_bi_reader_error_string(bir));
+        return false;
+    }
+
+    return true;
+}
+
+}

--- a/mbtool/bootimg_util.h
+++ b/mbtool/bootimg_util.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2017  Andrew Gunnerson <andrewgunnerson@gmail.com>
+ *
+ * This file is part of MultiBootPatcher
+ *
+ * MultiBootPatcher is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MultiBootPatcher is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MultiBootPatcher.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <string>
+
+#include "mbbootimg/reader.h"
+#include "mbbootimg/writer.h"
+
+namespace mb
+{
+
+bool bi_copy_data_to_fd(MbBiReader *bir, int fd);
+bool bi_copy_file_to_data(const std::string &path, MbBiWriter *biw);
+bool bi_copy_data_to_file(MbBiReader *bir, const std::string &path);
+bool bi_copy_data_to_data(MbBiReader *bir, MbBiWriter *biw);
+
+}

--- a/mbtool/installer.h
+++ b/mbtool/installer.h
@@ -25,7 +25,6 @@
 
 #include "mbcommon/common.h"
 #include "mbdevice/device.h"
-#include "mbp/patcherconfig.h"
 #include "mbutil/hash.h"
 
 #include "roms.h"
@@ -76,7 +75,6 @@ protected:
     int _output_fd;
     bool _passthrough;
 
-    mbp::PatcherConfig _pc;
     Device *_device = nullptr;
     std::string _detected_device;
     std::string _boot_block_dev;

--- a/mbtool/installer_util.cpp
+++ b/mbtool/installer_util.cpp
@@ -1,0 +1,743 @@
+/*
+ * Copyright (C) 2017  Andrew Gunnerson <andrewgunnerson@gmail.com>
+ *
+ * This file is part of MultiBootPatcher
+ *
+ * MultiBootPatcher is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MultiBootPatcher is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MultiBootPatcher.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "installer_util.h"
+
+#include <memory>
+
+#include <cerrno>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+
+#include <sys/stat.h>
+
+#include <archive.h>
+#include <archive_entry.h>
+
+#include "mbbootimg/entry.h"
+#include "mbbootimg/header.h"
+#include "mbbootimg/reader.h"
+#include "mbbootimg/writer.h"
+
+#include "mbcommon/file.h"
+#include "mbcommon/file_util.h"
+#include "mbcommon/file/filename.h"
+#include "mbcommon/string.h"
+
+#include "mblog/logging.h"
+
+#include "mbutil/delete.h"
+#include "mbutil/finally.h"
+#include "mbutil/path.h"
+
+#include "bootimg_util.h"
+#include "multiboot.h"
+
+typedef std::unique_ptr<archive, decltype(archive_free) *> ScopedArchive;
+typedef std::unique_ptr<archive_entry, decltype(archive_entry_free) *> ScopedArchiveEntry;
+typedef std::unique_ptr<FILE, decltype(fclose) *> ScopedFILE;
+typedef std::unique_ptr<MbFile, decltype(mb_file_free) *> ScopedMbFile;
+typedef std::unique_ptr<MbBiReader, decltype(mb_bi_reader_free) *> ScopedReader;
+typedef std::unique_ptr<MbBiWriter, decltype(mb_bi_writer_free) *> ScopedWriter;
+
+namespace mb
+{
+
+bool InstallerUtil::unpack_ramdisk(const std::string &input_file,
+                                   const std::string &output_dir,
+                                   int &format_out,
+                                   std::vector<int> &filters_out)
+{
+    ScopedArchive ain(archive_read_new(), archive_read_free);
+    ScopedArchive aout(archive_write_disk_new(), archive_write_free);
+    archive_entry *entry;
+    std::string target_path;
+    int ret;
+
+    if (!ain || !aout) {
+        LOGE("Failed to allocate archive reader or writer instance");
+        return false;
+    }
+
+    archive_read_support_filter_gzip(ain.get());
+    archive_read_support_filter_lzop(ain.get());
+    archive_read_support_filter_lz4(ain.get());
+    archive_read_support_filter_lzma(ain.get());
+    archive_read_support_filter_xz(ain.get());
+    archive_read_support_format_cpio(ain.get());
+
+    // Set up disk writer parameters
+    archive_write_disk_set_standard_lookup(aout.get());
+    archive_write_disk_set_options(aout.get(),
+                                   ARCHIVE_EXTRACT_TIME
+                                 | ARCHIVE_EXTRACT_SECURE_SYMLINKS
+                                 | ARCHIVE_EXTRACT_SECURE_NODOTDOT
+                                 | ARCHIVE_EXTRACT_OWNER
+                                 | ARCHIVE_EXTRACT_PERM);
+
+    if (archive_read_open_filename(ain.get(), input_file.c_str(), 10240)
+            != ARCHIVE_OK) {
+        LOGE("%s: Failed to open for reading: %s",
+             input_file.c_str(), archive_error_string(ain.get()));
+        return false;
+    }
+
+    while (true) {
+        ret = archive_read_next_header(ain.get(), &entry);
+        if (ret == ARCHIVE_EOF) {
+            break;
+        } else if (ret == ARCHIVE_RETRY) {
+            continue;
+        } else if (ret != ARCHIVE_OK) {
+            LOGE("%s: Failed to read header: %s",
+                 input_file.c_str(), archive_error_string(ain.get()));
+            return false;
+        }
+
+        const char *path = archive_entry_pathname(entry);
+        if (!path || !*path) {
+            LOGE("%s: Header has null or empty filename", input_file.c_str());
+            return false;
+        }
+
+        // Build path
+        target_path = output_dir;
+        if (!target_path.empty() && target_path.back() != '/' && *path != '/') {
+            target_path += '/';
+        }
+        target_path += path;
+
+        archive_entry_set_pathname(entry, target_path.c_str());
+
+        // Extract file
+        ret = archive_read_extract2(ain.get(), entry, aout.get());
+        if (ret != ARCHIVE_OK) {
+            LOGE("%s: %s", archive_entry_pathname(entry),
+                 archive_error_string(ain.get()));
+            return false;
+        }
+    }
+
+    // Save format
+    format_out = archive_format(ain.get());
+    filters_out.clear();
+    for (int i = 0; i < archive_filter_count(ain.get()); ++i) {
+        int code = archive_filter_code(ain.get(), i);
+        if (code != ARCHIVE_FILTER_NONE) {
+            filters_out.push_back(code);
+        }
+    }
+
+    if (archive_read_close(ain.get()) != ARCHIVE_OK) {
+        LOGE("%s: %s", input_file.c_str(), archive_error_string(ain.get()));
+        return false;
+    }
+
+    return true;
+}
+
+static int metadata_filter(archive *a, void *data, archive_entry *entry)
+{
+    (void) data;
+    (void) entry;
+
+    if (archive_read_disk_can_descend(a)) {
+        archive_read_disk_descend(a);
+    }
+    return 1;
+}
+
+bool InstallerUtil::pack_ramdisk(const std::string &input_dir,
+                                 const std::string &output_file,
+                                 int format,
+                                 const std::vector<int> &filters)
+{
+    ScopedArchive ain(archive_read_disk_new(), archive_read_free);
+    ScopedArchive aout(archive_write_new(), archive_write_free);
+    ScopedArchiveEntry entry(archive_entry_new(), archive_entry_free);
+    std::string full_path;
+    int ret;
+
+    if (!ain || !aout || !entry) {
+        LOGE("Failed to allocate archive reader, writer, or entry instance");
+        return false;
+    }
+
+    // Set up disk reader parameters
+    archive_read_disk_set_symlink_physical(ain.get());
+    archive_read_disk_set_metadata_filter_callback(
+            ain.get(), metadata_filter, nullptr);
+    // We don't want to look up usernames and group names on Android
+    //archive_read_disk_set_standard_lookup(in.get());
+
+    if (archive_write_set_format(aout.get(), format) != ARCHIVE_OK) {
+        LOGE("Failed to set output archive format: %s",
+             archive_error_string(aout.get()));
+        return false;
+    }
+    for (const int &filter : filters) {
+        if (archive_write_add_filter(aout.get(), filter) != ARCHIVE_OK) {
+            LOGE("Failed to add output archive filter: %s",
+                 archive_error_string(aout.get()));
+            return false;
+        }
+    }
+
+    archive_write_set_bytes_per_block(aout.get(), 512);
+
+    // Open output file
+    if (archive_write_open_filename(aout.get(), output_file.c_str())
+            != ARCHIVE_OK) {
+        LOGE("%s: Failed to open for writing: %s",
+             output_file.c_str(), archive_error_string(aout.get()));
+        return false;
+    }
+
+    ret = archive_read_disk_open(ain.get(), input_dir.c_str());
+    if (ret != ARCHIVE_OK) {
+        LOGE("%s: %s", input_dir.c_str(), archive_error_string(ain.get()));
+        return false;
+    }
+
+    while (true) {
+        // libarchive doesn't clear the entry automatically
+        archive_entry_clear(entry.get());
+
+        ret = archive_read_next_header2(ain.get(), entry.get());
+        if (ret == ARCHIVE_EOF) {
+            break;
+        } else if (ret != ARCHIVE_OK) {
+            LOGE("%s: Failed to read next header: %s", input_dir.c_str(),
+                 archive_error_string(ain.get()));
+            return false;
+        }
+
+        if (archive_entry_filetype(entry.get()) != AE_IFREG) {
+            archive_entry_set_size(entry.get(), 0);
+        }
+
+        const char *curpath = archive_entry_pathname(entry.get());
+        if (curpath && !input_dir.empty()) {
+            std::string relpath;
+            if (!util::relative_path(curpath, input_dir, &relpath)) {
+                LOGE("Failed to compute relative path of %s starting at %s: %s",
+                     curpath, input_dir.c_str(), strerror(errno));
+                return false;
+            }
+            if (relpath.empty()) {
+                // If the relative path is empty, then the current path is
+                // the root of the directory tree. We don't need that, so
+                // skip it.
+                continue;
+            }
+            archive_entry_set_pathname(entry.get(), relpath.c_str());
+        }
+
+        ret = archive_write_header(aout.get(), entry.get());
+        if (ret != ARCHIVE_OK) {
+            LOGE("%s: %s", output_file.c_str(),
+                 archive_error_string(aout.get()));
+            return false;
+        }
+
+        char buf[10240];
+        la_ssize_t n;
+
+        if (archive_entry_size(entry.get()) > 0) {
+            while ((n = archive_read_data(ain.get(), buf, sizeof(buf))) > 0) {
+                if (archive_write_data(aout.get(), buf, n) != n) {
+                    LOGE("Failed to write archive entry data: %s",
+                         archive_error_string(aout.get()));
+                    return false;
+                }
+            }
+
+            if (n < 0) {
+                LOGE("Failed to read archive entry data: %s",
+                     archive_error_string(ain.get()));
+                return false;
+            }
+        }
+    }
+
+    archive_read_close(ain.get());
+
+    if (archive_write_close(aout.get()) != ARCHIVE_OK) {
+        LOGE("%s: %s", output_file.c_str(), archive_error_string(aout.get()));
+        return false;
+    }
+
+    return true;
+}
+
+bool InstallerUtil::patch_boot_image(const std::string &input_file,
+                                     const std::string &output_file,
+                                     std::vector<std::function<RamdiskPatcherFn>> &rps)
+{
+    char *tmpdir = mb_format("%s.XXXXXX", output_file.c_str());
+    if (!tmpdir) {
+        LOGE("Out of memory");
+        return false;
+    }
+
+    auto free_temp_dir = util::finally([&]{
+        free(tmpdir);
+    });
+
+    if (!mkdtemp(tmpdir)) {
+        LOGE("Failed to create temporary directory: %s", strerror(errno));
+        return false;
+    }
+
+    auto delete_temp_dir = util::finally([&]{
+        util::delete_recursive(tmpdir);
+    });
+
+    ScopedReader bir(mb_bi_reader_new(), &mb_bi_reader_free);
+    ScopedWriter biw(mb_bi_writer_new(), &mb_bi_writer_free);
+    MbBiHeader *header;
+    MbBiEntry *in_entry;
+    MbBiEntry *out_entry;
+    int ret;
+
+    if (!bir || !biw) {
+        LOGE("Failed to allocate reader or writer instance");
+        return false;
+    }
+
+    // Open input boot image
+    ret = mb_bi_reader_enable_format_all(bir.get());
+    if (ret != MB_BI_OK) {
+        LOGE("Failed to enable input boot image formats: %s",
+             mb_bi_reader_error_string(bir.get()));
+        return false;
+    }
+    ret = mb_bi_reader_open_filename(bir.get(), input_file.c_str());
+    if (ret != MB_BI_OK) {
+        LOGE("%s: Failed to open boot image for reading: %s",
+             input_file.c_str(), mb_bi_reader_error_string(bir.get()));
+        return false;
+    }
+
+    // Open output boot image
+    ret = mb_bi_writer_set_format_by_code(
+            biw.get(), mb_bi_reader_format_code(bir.get()));
+    if (ret != MB_BI_OK) {
+        LOGE("Failed to set output boot image format: %s",
+             mb_bi_writer_error_string(biw.get()));
+        return false;
+    }
+    ret = mb_bi_writer_open_filename(biw.get(), output_file.c_str());
+    if (ret != MB_BI_OK) {
+        LOGE("%s: Failed to open boot image for writing: %s",
+             output_file.c_str(), mb_bi_writer_error_string(biw.get()));
+        return false;
+    }
+
+    // Debug
+    LOGD("Patching boot image");
+    LOGD("- Input: %s", input_file.c_str());
+    LOGD("- Output: %s", output_file.c_str());
+    LOGD("- Format: %s", mb_bi_reader_format_name(bir.get()));
+
+    // Copy header
+    ret = mb_bi_reader_read_header(bir.get(), &header);
+    if (ret != MB_BI_OK) {
+        LOGE("%s: Failed to read header: %s",
+             input_file.c_str(), mb_bi_reader_error_string(bir.get()));
+        return false;
+    }
+    ret = mb_bi_writer_write_header(biw.get(), header);
+    if (ret != MB_BI_OK) {
+        LOGE("%s: Failed to write header: %s",
+             output_file.c_str(), mb_bi_writer_error_string(biw.get()));
+        return false;
+    }
+
+    // Write entries
+    while ((ret = mb_bi_writer_get_entry(biw.get(), &out_entry)) == MB_BI_OK) {
+        int type = mb_bi_entry_type(out_entry);
+
+        // Write entry metadata
+        ret = mb_bi_writer_write_entry(biw.get(), out_entry);
+        if (ret != MB_BI_OK) {
+            LOGE("%s: Failed to write entry: %s",
+                 output_file.c_str(), mb_bi_writer_error_string(biw.get()));
+            return false;
+        }
+
+        // Special case for loki aboot
+        if (type == MB_BI_ENTRY_ABOOT) {
+            if (bi_copy_file_to_data(ABOOT_PARTITION, biw.get())) {
+                return false;
+            }
+        } else {
+            ret = mb_bi_reader_go_to_entry(bir.get(), &in_entry, type);
+            if (ret == MB_BI_EOF) {
+                LOGV("Skipping non existent boot image entry: %d", type);
+                continue;
+            } else if (ret != MB_BI_OK) {
+                LOGE("%s: Failed to go to entry: %d: %s",
+                     input_file.c_str(), type,
+                     mb_bi_reader_error_string(bir.get()));
+                return false;
+            }
+
+            if (type == MB_BI_ENTRY_RAMDISK) {
+                std::string ramdisk_in(tmpdir);
+                ramdisk_in += "/ramdisk.in";
+                std::string ramdisk_out(tmpdir);
+                ramdisk_out += "/ramdisk.out";
+
+                auto delete_temp_files = util::finally([&]{
+                    unlink(ramdisk_in.c_str());
+                    unlink(ramdisk_out.c_str());
+                });
+
+                if (!bi_copy_data_to_file(bir.get(), ramdisk_in)) {
+                    return false;
+                }
+
+                if (!patch_ramdisk(ramdisk_in, ramdisk_out, 0, rps)) {
+                    return false;
+                }
+
+                if (!bi_copy_file_to_data(ramdisk_out, biw.get())) {
+                    return false;
+                }
+            } else if (type == MB_BI_ENTRY_KERNEL) {
+                std::string kernel_in(tmpdir);
+                kernel_in += "/kernel.in";
+                std::string kernel_out(tmpdir);
+                kernel_out += "/kernel.out";
+
+                auto delete_temp_files = util::finally([&]{
+                    unlink(kernel_in.c_str());
+                    unlink(kernel_out.c_str());
+                });
+
+                if (!bi_copy_data_to_file(bir.get(), kernel_in)) {
+                    return false;
+                }
+
+                if (!patch_kernel_rkp(kernel_in, kernel_out)) {
+                    return false;
+                }
+
+                if (!bi_copy_file_to_data(kernel_out, biw.get())) {
+                    return false;
+                }
+            } else {
+                // Copy entry directly
+                if (!bi_copy_data_to_data(bir.get(), biw.get())) {
+                    return false;
+                }
+            }
+        }
+    }
+
+    if (mb_bi_writer_close(biw.get()) != MB_BI_OK) {
+        LOGE("%s: Failed to close boot image: %s",
+             output_file.c_str(), mb_bi_writer_error_string(biw.get()));
+        return false;
+    }
+
+    return true;
+}
+
+bool InstallerUtil::patch_ramdisk(const std::string &input_file,
+                                  const std::string &output_file,
+                                  unsigned int depth,
+                                  std::vector<std::function<RamdiskPatcherFn>> &rps)
+{
+    if (depth > 1) {
+        LOGV("Ignoring doubly-nested ramdisk");
+        return true;
+    }
+
+    char *tmpdir = mb_format("%s.XXXXXX", output_file.c_str());
+    if (!tmpdir) {
+        LOGE("Out of memory");
+        return false;
+    }
+
+    auto free_temp_dir = util::finally([&]{
+        free(tmpdir);
+    });
+
+    if (!mkdtemp(tmpdir)) {
+        LOGE("Failed to create temporary directory: %s", strerror(errno));
+        return false;
+    }
+
+    auto delete_temp_dir = util::finally([&]{
+        util::delete_recursive(tmpdir);
+    });
+
+    int format;
+    std::vector<int> filters;
+
+    // Extract ramdisk
+    if (!unpack_ramdisk(input_file, tmpdir, format, filters)) {
+        return false;
+    }
+
+    // Patch ramdisk
+    std::string nested(tmpdir);
+    nested += "/sbin/ramdisk.cpio";
+    struct stat sb;
+    bool ret;
+
+    if (stat(nested.c_str(), &sb) == 0) {
+        ret = patch_ramdisk(nested, nested, depth + 1, rps);
+    } else {
+        ret = patch_ramdisk_dir(tmpdir, rps);
+    }
+
+    // Pack ramdisk
+    if (!pack_ramdisk(tmpdir, output_file, format, filters)) {
+        return false;
+    }
+
+    return ret;
+}
+
+bool InstallerUtil::patch_ramdisk_dir(const std::string &ramdisk_dir,
+                                      std::vector<std::function<RamdiskPatcherFn>> &rps)
+{
+    for (auto const &rp : rps) {
+        if (!rp(ramdisk_dir)) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+bool InstallerUtil::patch_kernel_rkp(const std::string &input_file,
+                                     const std::string &output_file)
+{
+    // We'll use SuperSU's patch for negating the effects of
+    // CONFIG_RKP_NS_PROT=y in newer Samsung kernels. This kernel feature
+    // prevents exec()'ing anything as a privileged user unless the binary
+    // resides in rootfs or whichever filesystem was first mounted at /system.
+    //
+    // It is trivial to update mbtool to only use rootfs, but we need to
+    // override fsck tools by bind-mounting dummy binaries from an ext4 image
+    // when booting from an external SD. Unless we patch the SELinux policy to
+    // allow vold to execute u:r:rootfs:s0-labeled fsck binaries, this patch
+    // must remain.
+
+    static const unsigned char source_pattern[] = {
+        0x49, 0x01, 0x00, 0x54, 0x01, 0x14, 0x40, 0xB9, 0x3F, 0xA0,
+        0x0F, 0x71, 0xE9, 0x00, 0x00, 0x54, 0x01, 0x08, 0x40, 0xB9,
+        0x3F, 0xA0, 0x0F, 0x71, 0x89, 0x00, 0x00, 0x54, 0x00, 0x18,
+        0x40, 0xB9, 0x1F, 0xA0, 0x0F, 0x71, 0x88, 0x01, 0x00, 0x54,
+    };
+    static const unsigned char target_pattern[] = {
+        0xA1, 0x02, 0x00, 0x54, 0x01, 0x14, 0x40, 0xB9, 0x3F, 0xA0,
+        0x0F, 0x71, 0x40, 0x02, 0x00, 0x54, 0x01, 0x08, 0x40, 0xB9,
+        0x3F, 0xA0, 0x0F, 0x71, 0xE0, 0x01, 0x00, 0x54, 0x00, 0x18,
+        0x40, 0xB9, 0x1F, 0xA0, 0x0F, 0x71, 0x81, 0x01, 0x00, 0x54,
+    };
+
+    ScopedMbFile fin(mb_file_new(), &mb_file_free);
+    ScopedMbFile fout(mb_file_new(), &mb_file_free);
+    // TODO: Replace with std::optional after switching to C++17
+    std::pair<bool, uint64_t> offset;
+    int ret;
+
+    if (!fin || !fout) {
+        LOGE("Failed to allocate input or output MbFile handle");
+        return false;
+    }
+
+    // Open input file
+    if (mb_file_open_filename(fin.get(), input_file.c_str(),
+                              MB_FILE_OPEN_READ_ONLY) != MB_FILE_OK) {
+        LOGE("%s: Failed to open for reading: %s",
+             input_file.c_str(), mb_file_error_string(fin.get()));
+        return false;
+    }
+
+    // Open output file
+    if (mb_file_open_filename(fout.get(), output_file.c_str(),
+                              MB_FILE_OPEN_WRITE_ONLY) != MB_FILE_OK) {
+        LOGE("%s: Failed to open for writing: %s",
+             output_file.c_str(), mb_file_error_string(fout.get()));
+        return false;
+    }
+
+    // Replace pattern
+    auto result_cb = [](MbFile *file, void *userdata, uint64_t offset) -> int {
+        (void) file;
+        std::pair<bool, uint64_t> *ptr =
+                static_cast<std::pair<bool, uint64_t> *>(userdata);
+        ptr->first = true;
+        ptr->second = offset;
+        return MB_FILE_OK;
+    };
+
+    ret = mb_file_search(fin.get(), -1, -1, 0, source_pattern,
+                         sizeof(source_pattern), 1, result_cb, &offset);
+    if (ret < 0) {
+        LOGE("%s: Error when searching for pattern: %s",
+             input_file.c_str(), mb_file_error_string(fin.get()));
+        return false;
+    }
+
+    // Copy data
+    ret = mb_file_seek(fin.get(), 0, SEEK_SET, nullptr);
+    if (ret != MB_FILE_OK) {
+        LOGE("%s: Failed to seek to beginning: %s",
+             input_file.c_str(), mb_file_error_string(fin.get()));
+        return false;
+    }
+
+    if (offset.first) {
+        LOGD("RKP pattern found at offset: 0x%" PRIx64, offset.second);
+
+        if (!copy_file_to_file(fin.get(), fout.get(), offset.second)) {
+            return false;
+        }
+
+        ret = mb_file_seek(fin.get(), sizeof(source_pattern), SEEK_CUR,
+                           nullptr);
+        if (ret != MB_FILE_OK) {
+            LOGE("%s: Failed to skip pattern: %s",
+                 input_file.c_str(), mb_file_error_string(fin.get()));
+            return false;
+        }
+
+        size_t n;
+        ret = mb_file_write_fully(fout.get(), target_pattern,
+                                  sizeof(target_pattern), &n);
+        if (ret != MB_FILE_OK || n != sizeof(target_pattern)) {
+            LOGE("%s: Failed to write target pattern: %s",
+                 output_file.c_str(), mb_file_error_string(fout.get()));
+            return false;
+        }
+    }
+
+    if (!copy_file_to_file_eof(fin.get(), fout.get())) {
+        return false;
+    }
+
+    ret = mb_file_close(fout.get());
+    if (ret != MB_FILE_OK) {
+        LOGE("%s: Failed to close file: %s",
+             output_file.c_str(), mb_file_error_string(fout.get()));
+        return false;
+    }
+
+    return true;
+}
+
+bool InstallerUtil::replace_file(const std::string &replace,
+                                 const std::string &with)
+{
+    struct stat sb;
+    int sb_ret;
+
+    sb_ret = stat(replace.c_str(), &sb);
+    if (sb_ret < 0 && errno != ENOENT) {
+        LOGE("%s: Failed to stat file: %s",
+             replace.c_str(), strerror(errno));
+        return false;
+    }
+
+    if (rename(with.c_str(), replace.c_str()) < 0) {
+        LOGE("%s: Failed to rename from %s: %s",
+             replace.c_str(), with.c_str(), strerror(errno));
+        return false;
+    }
+
+    if (sb_ret == 0) {
+        if (chown(replace.c_str(), sb.st_uid, sb.st_gid) < 0) {
+            LOGE("%s: Failed to chown file: %s",
+                 replace.c_str(), strerror(errno));
+            return false;
+        }
+
+        if (chmod(replace.c_str(), sb.st_mode & 0777) < 0) {
+            LOGE("%s: Failed to chmod file: %s",
+                 replace.c_str(), strerror(errno));
+            return false;
+        }
+    }
+
+    return true;
+}
+
+bool InstallerUtil::copy_file_to_file(MbFile *fin, MbFile *fout,
+                                      uint64_t to_copy)
+{
+    char buf[10240];
+    size_t n;
+    int ret;
+
+    while (to_copy > 0) {
+        size_t to_read = std::min<uint64_t>(to_copy, sizeof(buf));
+
+        ret = mb_file_read_fully(fin, buf, to_read, &n);
+        if (ret != MB_FILE_OK || n != to_read) {
+            LOGE("Failed to read data: %s", mb_file_error_string(fin));
+            return false;
+        }
+
+        ret = mb_file_write_fully(fout, buf, to_read, &n);
+        if (ret != MB_FILE_OK || n != to_read) {
+            LOGE("Failed to write data: %s", mb_file_error_string(fout));
+            return false;
+        }
+
+        to_copy -= to_read;
+    }
+
+    return true;
+}
+
+bool InstallerUtil::copy_file_to_file_eof(MbFile *fin, MbFile *fout)
+{
+    char buf[10240];
+    size_t n_read;
+    size_t n_written;
+    int ret;
+
+    while (true) {
+        ret = mb_file_read_fully(fin, buf, sizeof(buf), &n_read);
+        if (ret != MB_FILE_OK) {
+            LOGE("Failed to read data: %s", mb_file_error_string(fin));
+            return false;
+        } else if (n_read == 0) {
+            break;
+        }
+
+        ret = mb_file_write_fully(fout, buf, n_read, &n_written);
+        if (ret != MB_FILE_OK || n_written != n_read) {
+            LOGE("Failed to write data: %s", mb_file_error_string(fout));
+            return false;
+        }
+    }
+
+    return true;
+}
+
+}

--- a/mbtool/installer_util.h
+++ b/mbtool/installer_util.h
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2017  Andrew Gunnerson <andrewgunnerson@gmail.com>
+ *
+ * This file is part of MultiBootPatcher
+ *
+ * MultiBootPatcher is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MultiBootPatcher is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MultiBootPatcher.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "ramdisk_patcher.h"
+
+struct MbBiReader;
+struct MbBiWriter;
+struct MbFile;
+
+namespace mb
+{
+
+class InstallerUtil
+{
+public:
+    static bool unpack_ramdisk(const std::string &input_file,
+                               const std::string &output_dir,
+                               int &format_out,
+                               std::vector<int> &filters_out);
+    static bool pack_ramdisk(const std::string &input_dir,
+                             const std::string &output_file,
+                             int format,
+                             const std::vector<int> &filters);
+
+    static bool patch_boot_image(const std::string &input_file,
+                                 const std::string &output_file,
+                                 std::vector<std::function<RamdiskPatcherFn>> &rps);
+    static bool patch_ramdisk(const std::string &input_file,
+                              const std::string &output_file,
+                              unsigned int depth,
+                              std::vector<std::function<RamdiskPatcherFn>> &rps);
+    static bool patch_ramdisk_dir(const std::string &ramdisk_dir,
+                                  std::vector<std::function<RamdiskPatcherFn>> &rps);
+    static bool patch_kernel_rkp(const std::string &input_file,
+                                 const std::string &output_file);
+
+    static bool replace_file(const std::string &replace,
+                             const std::string &with);
+
+private:
+    static bool copy_file_to_file(MbFile *fin, MbFile *fout, uint64_t to_copy);
+    static bool copy_file_to_file_eof(MbFile *fin, MbFile *fout);
+};
+
+}

--- a/mbtool/ramdisk_patcher.cpp
+++ b/mbtool/ramdisk_patcher.cpp
@@ -1,0 +1,328 @@
+/*
+ * Copyright (C) 2017  Andrew Gunnerson <andrewgunnerson@gmail.com>
+ *
+ * This file is part of MultiBootPatcher
+ *
+ * MultiBootPatcher is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MultiBootPatcher is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MultiBootPatcher.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "ramdisk_patcher.h"
+
+#include <cerrno>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include "mbcommon/string.h"
+#include "mblog/logging.h"
+#include "mbutil/copy.h"
+
+#include "installer_util.h"
+
+namespace mb
+{
+
+static bool _rp_write_rom_id(const std::string &dir, const std::string &rom_id)
+{
+    std::string path(dir);
+    path += "/romid";
+
+    FILE *fp = fopen(path.c_str(), "wb");
+    if (!fp) {
+        LOGE("%s: Failed to open for writing: %s",
+             path.c_str(), strerror(errno));
+        return false;
+    }
+
+    if (fputs(rom_id.c_str(), fp) == EOF) {
+        LOGE("%s: Failed to write ROM ID: %s",
+             path.c_str(), strerror(errno));
+        fclose(fp);
+        return false;
+    }
+
+    if (fchmod(fileno(fp), 0664) < 0) {
+        LOGE("%s: Failed to chmod: %s",
+             path.c_str(), strerror(errno));
+        fclose(fp);
+        return false;
+    }
+
+    if (fclose(fp) < 0) {
+        LOGE("%s: Failed to close file: %s",
+             path.c_str(), strerror(errno));
+        return false;
+    }
+
+    return true;
+}
+
+std::function<RamdiskPatcherFn>
+rp_write_rom_id(const std::string &rom_id)
+{
+    using namespace std::placeholders;
+
+    return std::bind(_rp_write_rom_id, _1, rom_id);
+}
+
+static bool _rp_patch_default_prop(const std::string &dir,
+                                   const std::string &device_id,
+                                   bool use_fuse_exfat)
+{
+    char *tmp_path = nullptr;
+    int tmp_fd = -1;
+    FILE *fp_in = nullptr;
+    FILE *fp_out = nullptr;
+    char *buf = nullptr;
+    size_t buf_size = 0;
+    ssize_t n;
+    bool ret = false;
+
+    std::string path(dir);
+    path += "/default.prop";
+
+    tmp_path = mb_format("%s.XXXXXX", path.c_str());
+    if (!tmp_path) {
+        LOGE("Out of memory");
+        goto done;
+    }
+
+    tmp_fd = mkstemp(tmp_path);
+    if (tmp_fd < 0) {
+        LOGE("%s: Failed to create temporary file: %s",
+             path.c_str(), strerror(errno));
+        goto done;
+    }
+
+    fp_in = fopen(path.c_str(), "rb");
+    if (!fp_in) {
+        LOGE("%s: Failed to open for reading: %s",
+             path.c_str(), strerror(errno));
+        goto done;
+    }
+
+    fp_out = fdopen(tmp_fd, "wb");
+    if (!fp_out) {
+        LOGE("%s: Failed to open for writing: %s",
+             tmp_path, strerror(errno));
+        goto done;
+    }
+
+    tmp_fd = -1;
+
+    while ((n = getline(&buf, &buf_size, fp_in)) >= 0) {
+        // Remove old multiboot properties
+        if (mb_starts_with(buf, "ro.patcher.")) {
+            continue;
+        }
+
+        if (fwrite(buf, 1, n, fp_out) != static_cast<size_t>(n)) {
+            LOGE("%s: Failed to write file: %s",
+                 tmp_path, strerror(errno));
+            goto done;
+        }
+    }
+
+    // Write new properties
+    if (fputc('\n', fp_out) == EOF
+            || fprintf(fp_out, "ro.patcher.device=%s\n", device_id.c_str()) < 0
+            || fprintf(fp_out, "ro.patcher.use_fuse_exfat=%s\n",
+                       use_fuse_exfat ? "true" : "false") < 0) {
+        LOGE("%s: Failed to write properties: %s",
+             tmp_path, strerror(errno));
+        goto done;
+    }
+
+    if (fclose(fp_out) < 0) {
+        LOGE("%s: Failed to close file: %s",
+             tmp_path, strerror(errno));
+        goto done;
+    }
+
+    fp_out = nullptr;
+
+    if (!InstallerUtil::replace_file(path.c_str(), tmp_path)) {
+        goto done;
+    }
+
+    ret = true;
+
+done:
+    if (tmp_fd >= 0) {
+        close(tmp_fd);
+    }
+    if (fp_in) {
+        fclose(fp_in);
+    }
+    if (fp_out) {
+        fclose(fp_out);
+    }
+
+    unlink(tmp_path);
+
+    free(tmp_path);
+    free(buf);
+
+    return ret;
+}
+
+std::function<RamdiskPatcherFn>
+rp_patch_default_prop(const std::string &device_id, bool use_fuse_exfat)
+{
+    using namespace std::placeholders;
+
+    return std::bind(_rp_patch_default_prop, _1, device_id, use_fuse_exfat);
+}
+
+static bool _rp_add_binaries(const std::string &dir,
+                             const std::string &binaries_dir)
+{
+    struct CopySpec
+    {
+        std::string from;
+        std::string to;
+        mode_t perm;
+    };
+
+    std::vector<CopySpec> to_copy{
+        { "file-contexts-tool",     "sbin/file-contexts-tool",     0750 },
+        { "file-contexts-tool.sig", "sbin/file-contexts-tool.sig", 0640 },
+        { "fsck-wrapper",           "sbin/fsck-wrapper",           0750 },
+        { "fsck-wrapper.sig",       "sbin/fsck-wrapper.sig",       0640 },
+        { "mbtool",                 "mbtool",                      0750 },
+        { "mbtool.sig",             "mbtool.sig",                  0640 },
+        { "mount.exfat",            "sbin/mount.exfat",            0750 },
+        { "mount.exfat.sig",        "sbin/mount.exfat.sig",        0640 },
+    };
+
+    for (auto const &item : to_copy) {
+        std::string source(binaries_dir);
+        source += "/";
+        source += item.from;
+        std::string target(dir);
+        target += "/";
+        target += item.to;
+
+        if (!util::copy_file(source, target, 0)) {
+            return false;
+        }
+        if (chmod(target.c_str(), item.perm) < 0) {
+            LOGE("%s: Failed to chmod: %s", target.c_str(), strerror(errno));
+            return false;
+        }
+    }
+
+    return true;
+}
+
+std::function<RamdiskPatcherFn>
+rp_add_binaries(const std::string &binaries_dir)
+{
+    using namespace std::placeholders;
+
+    return std::bind(_rp_add_binaries, _1, binaries_dir);
+}
+
+static bool _rp_symlink_fuse_exfat(const std::string &dir)
+{
+    std::string fsck_exfat(dir);
+    fsck_exfat += "/sbin/fsck.exfat";
+    std::string fsck_exfat_sig(fsck_exfat);
+    fsck_exfat_sig += ".sig";
+
+    if ((unlink(fsck_exfat.c_str()) < 0 && errno != ENOENT)
+            || symlink("mount.exfat", fsck_exfat.c_str()) < 0
+            || (unlink(fsck_exfat_sig.c_str()) < 0 && errno != ENOENT)
+            || symlink("mount.exfat.sig", fsck_exfat_sig.c_str()) < 0) {
+        LOGE("Failed to symlink exfat fsck binaries: %s", strerror(errno));
+        return false;
+    }
+
+    return true;
+}
+
+std::function<RamdiskPatcherFn>
+rp_symlink_fuse_exfat()
+{
+    return _rp_symlink_fuse_exfat;
+}
+
+static bool _rp_symlink_init(const std::string &dir)
+{
+    // Symlink init
+    std::string init(dir);
+    init += "/init";
+    std::string init_orig(init);
+    init_orig += ".orig";
+
+    if (access(init_orig.c_str(), R_OK) < 0) {
+        if (errno != ENOENT) {
+            LOGE("%s: Failed to access file: %s",
+                 init_orig.c_str(), strerror(errno));
+            return false;
+        }
+
+        if (rename(init.c_str(), init_orig.c_str()) < 0) {
+            LOGE("%s: Failed to rename file: %s",
+                 init.c_str(), strerror(errno));
+            return false;
+        }
+
+        if (symlink("mbtool", init.c_str()) < 0) {
+            LOGE("%s: Failed to symlink mbtool: %s",
+                 init.c_str(), strerror(errno));
+            return false;
+        }
+    }
+
+    return true;
+}
+
+std::function<RamdiskPatcherFn>
+rp_symlink_init()
+{
+    return _rp_symlink_init;
+}
+
+static bool _rp_add_device_json(const std::string &dir,
+                                const std::string &device_json_file)
+{
+    std::string device_json(dir);
+    device_json += "/device.json";
+
+    if (!util::copy_file(device_json_file, device_json, 0)) {
+        return false;
+    }
+
+    if (chmod(device_json.c_str(), 0644) < 0) {
+        LOGE("%s: Failed to chmod file: %s",
+             device_json.c_str(), strerror(errno));
+        return false;
+    }
+
+    return true;
+}
+
+std::function<RamdiskPatcherFn>
+rp_add_device_json(const std::string &device_json_file)
+{
+    using namespace std::placeholders;
+
+    return std::bind(_rp_add_device_json, _1, device_json_file);
+}
+
+}

--- a/mbtool/ramdisk_patcher.h
+++ b/mbtool/ramdisk_patcher.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2017  Andrew Gunnerson <andrewgunnerson@gmail.com>
+ *
+ * This file is part of MultiBootPatcher
+ *
+ * MultiBootPatcher is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MultiBootPatcher is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MultiBootPatcher.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <functional>
+#include <string>
+//#include <vector>
+
+namespace mb
+{
+
+typedef bool (RamdiskPatcherFn)(const std::string &dir);
+
+std::function<RamdiskPatcherFn>
+rp_write_rom_id(const std::string &rom_id);
+
+std::function<RamdiskPatcherFn>
+rp_patch_default_prop(const std::string &device_id, bool use_fuse_exfat);
+
+std::function<RamdiskPatcherFn>
+rp_add_binaries(const std::string &binaries_dir);
+
+std::function<RamdiskPatcherFn>
+rp_symlink_fuse_exfat();
+
+std::function<RamdiskPatcherFn>
+rp_symlink_init();
+
+std::function<RamdiskPatcherFn>
+rp_add_device_json(const std::string &device_json_file);
+
+}


### PR DESCRIPTION
Boot images will no longer be patched by libmbp. Instead, the required
binaries will be added to the zip and mbtool will handle the patching of
the ramdisk. This allows us to guarantee that the ramdisk will be
patched correctly, regardless of how it's stored in the original zip
file.

The only remaining code that uses mbp::BootImage and mbp::CpioFile is
the ramdisk update feature. That will be ported to libmbbootimg in
another commit.