### PR TITLE
Add Support for some Moto E's

### DIFF
--- a/data/devices/motorola.yml
+++ b/data/devices/motorola.yml
@@ -212,6 +212,7 @@
     - surnia_umts
     - surnia_udstv
     - surnia_uds
+    - surnia
     - XT1514
     - XT1521
     - XT1523


### PR DESCRIPTION
My Moto E identifies itself as surnia in the recovery, which makes the
check fail, as surnia is not on the list.  This commit should fix that.