### PR TITLE
data: Add support for Samsung Galaxy Note Pro 12.2 LTE/Wifi

### DIFF
--- a/data/devices/samsung/06_galaxy_note_tablet.yml
+++ b/data/devices/samsung/06_galaxy_note_tablet.yml
@@ -147,3 +147,57 @@
     recovery:
       - /dev/block/platform/msm_sdcc.1/by-name/recovery
       - /dev/block/mmcblk0p15
+
+
+- name: Samsung Galaxy Note Pro 12.2 (LTE)
+  id: viennalte
+  codenames:
+    - viennalte
+    - viennaltexx
+  architecture: armeabi-v7a
+
+  block_devs:
+    base_dirs:
+      - /dev/block/platform/msm_sdcc.1/by-name
+    system:
+      - /dev/block/platform/msm_sdcc.1/by-name/system
+      - /dev/block/mmcblk0p23
+    cache:
+      - /dev/block/platform/msm_sdcc.1/by-name/cache
+      - /dev/block/mmcblk0p24
+    data:
+      - /dev/block/platform/msm_sdcc.1/by-name/userdata
+      - /dev/block/mmcblk0p26
+    boot:
+      - /dev/block/platform/msm_sdcc.1/by-name/boot
+      - /dev/block/mmcblk0p14
+    recovery:
+      - /dev/block/platform/msm_sdcc.1/by-name/recovery
+      - /dev/block/mmcblk0p15
+
+
+- name: Samsung Galaxy Note Pro 12.2 (Wifi)
+  id: v1awifi
+  codenames:
+    - v1awifi
+    - v1awifixx
+  architecture: armeabi-v7a
+
+  block_devs:
+    base_dirs:
+      - /dev/block/platform/dw_mmc.0/by-name
+    system:
+      - /dev/block/platform/dw_mmc.0/by-name/SYSTEM
+      - /dev/block/mmcblk0p18
+    cache:
+      - /dev/block/platform/dw_mmc.0/by-name/CACHE
+      - /dev/block/mmcblk0p19
+    data:
+      - /dev/block/platform/dw_mmc.0/by-name/USERDATA
+      - /dev/block/mmcblk0p21
+    boot:
+      - /dev/block/platform/dw_mmc.0/by-name/BOOT
+      - /dev/block/mmcblk0p9
+    recovery:
+      - /dev/block/platform/dw_mmc.0/by-name/RECOVERY
+      - /dev/block/mmcblk0p10


### PR DESCRIPTION
Hello.
Please add support for Samsung Galaxy Note Pro 12.2 LTE/Wifi.

I compiled the Dual Boot Patcher (debug) with my changes and checked for Samsung Galaxy Note Pro 12.2 LTE - works great, thank you.