### PR TITLE
Fix OnePlus 3T support

### DIFF
--- a/data/devices/oneplus.yml
+++ b/data/devices/oneplus.yml
@@ -155,6 +155,7 @@
   id: OnePlus3T
   codenames:
     - OnePlus3T
+    - oneplus3t
   architecture: arm64-v8a
 
   block_devs:


### PR DESCRIPTION
Some ROMs use "oneplus3t" as the codename instead of "OnePlus3T", so when you try to switch ROMs it will say "Could not determine the boot partition because this device's codename 'oneplus3t' is not recognized"

![screenshot_20170318-155202](https://cloud.githubusercontent.com/assets/17073328/24076341/5201d0ee-0bf3-11e7-92e1-62449fbffbb4.png)