### PR TITLE
Please add support huawei p9 lite

### DIFF
--- a/data/devices/huawei.yml
+++ b/data/devices/huawei.yml
@@ -186,3 +186,39 @@
     recovery:
       - /dev/block/platform/hi_mci.0/by-name/recovery
       - /dev/block/mmcblk0p29
+      
+- name: Huawei P9 Lite
+  id: hi6250
+  codenames:
+    - HWVNS-H
+    - hi6250
+    - VNS
+  architecture: arm64-v8a
+
+  block_devs:
+    base_dirs:
+      - /dev/block/platform/hi_mci.0/by-name
+      - /dev/block/bootdevice/by-name
+    system:
+      - /dev/block/platform/hi_mci.0/by-name/system
+      - /dev/block/bootdevice/by-name/system
+      - /dev/block/mmcblk0p44
+      - /dev/block/mmcblk0p40
+    cache:
+      - /dev/block/platform/hi_mci.0/by-name/cache
+      - /dev/block/bootdevice/by-name/cache
+      - /dev/block/mmcblk0p36
+    data:
+      - /dev/block/platform/hi_mci.0/by-name/userdata
+      - /dev/block/bootdevice/by-name/userdata
+      - /dev/block/mmcblk0p49
+      - /dev/block/dm-0
+      - /dev/block/mmcblk0p42
+    boot:
+      - /dev/block/platform/hi_mci.0/by-name/boot
+      - /dev/block/bootdevice/by-name/boot
+      - /dev/block/mmcblk0p28
+    recovery:
+      - /dev/block/platform/hi_mci.0/by-name/recovery
+      - /dev/block/bootdevice/by-name/recovery
+      - /dev/block/mmcblk0p29


### PR DESCRIPTION
The Huawei p9 lite based on the android version running uses different mount points for userdata and system, but the rest of partition mounts are the same,ie:
                     android MM: userdata /dev/block/mmcblk0p42 and system /dev/block/mmcblk0p40
                            NOUGAT userdata /dev/block/mmcblk0p49 or /dev/block/dm-0 and system /dev/block/mmcblk0p44