### PR TITLE
cmake: Ensure that DT_RPATH is used instead of DT_RUNPATH (fixes #546)

### DIFF
--- a/cmake/CompilerFlags.cmake
+++ b/cmake/CompilerFlags.cmake
@@ -17,6 +17,9 @@ if(CMAKE_COMPILER_IS_GNUCXX OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
         # Visibility
         add_compile_options(-fvisibility=hidden)
 
+        # Use DT_RPATH instead of DT_RUNPATH because the latter is not transitive
+        set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--disable-new-dtags")
+
         # Does not work on Windows:
         # https://sourceware.org/bugzilla/show_bug.cgi?id=11539
         add_compile_options(-ffunction-sections -fdata-sections)


### PR DESCRIPTION
DT_RUNPATH is not transitive, which causes issues with the hosttools
builds. signtool links against libmbsign.so, which can be found via the
$ORIGIN/../lib RPATH. However, libmbsign.so links against libmblog.so
and this second dependency level does not respect DT_RUNPATH.

This commit forces the build to always use RPATH.

For more information:
* https://sourceware.org/bugzilla/show_bug.cgi?id=13945
* https://www.blaenkdenum.com/notes/cmake/

Signed-off-by: Andrew Gunnerson <chenxiaolong@cxl.epac.to>