### PR TITLE
motorola: Fix moto z play data partition

### DIFF
--- a/data/devices/motorola.yml
+++ b/data/devices/motorola.yml
@@ -518,8 +518,8 @@
       - /dev/block/platform/soc/7824900.sdhci/by-name/cache
       - /dev/block/mmcblk0p52
     data:
-      - /dev/block/bootdevice/by-name/data
-      - /dev/block/platform/soc/7824900.sdhci/by-name/data
+      - /dev/block/bootdevice/by-name/userdata
+      - /dev/block/platform/soc/7824900.sdhci/by-name/userdata
       - /dev/block/mmcblk0p54
     boot:
       - /dev/block/bootdevice/by-name/boot


### PR DESCRIPTION
My mistake
lrwxrwxrwx 1 root root 21 1970-01-19 14:51 userdata -> /dev/block/mmcblk0p54
/dev/block/bootdevice/by-name/userdata /data f2fs rw,seclabel,nosuid,nodev,noatime...