### PR TITLE
Add support for the Kindle Fire HDX 7

### DIFF
--- a/data/devices/amazon.yml
+++ b/data/devices/amazon.yml
@@ -1,0 +1,34 @@
+- name: Amazon Kindle Fire HDX 7
+  id: thor
+  codenames:
+    - thor
+  architecture: armeabi-v7a
+  
+  block_devs:
+    base_dirs:
+      - /dev/block/platform/msm_sdcc.1/by-name
+      - /dev/block/bootdevice/by-name/
+    system:
+      - /dev/block/platform/msm_sdcc.1/by-name/system
+      - /dev/block/bootdevice/by-name/system
+      - /dev/block/mmcblk0p22
+    cache:
+      - /dev/block/platform/msm_sdcc.1/by-name/cache
+      - /dev/block/bootdevice/by-name/cache
+      - /dev/block/mmcblk0p21
+    data:
+      - /dev/block/platform/msm_sdcc.1/by-name/userdata
+      - /dev/block/bootdevice/by-name/userdata
+      - /dev/block/mmcblk0p23
+    boot:
+      - /dev/block/platform/msm_sdcc.1/by-name/boot
+      - /dev/block/bootdevice/by-name/boot
+      - /dev/block/mmcblk0p8
+    recovery:
+      - /dev/block/platform/msm_sdcc.1/by-name/recovery
+      - /dev/block/bootdevice/by-name/recovery
+      - /dev/block/mmcblk0p18
+
+    graphics_backends:
+      - fbdev
+    theme: portrait_hdpi


### PR DESCRIPTION
Hopefully this file will help to add support for the Amazon Kindle Fire HDX 7, so that DualBootPatcher will work with it and it will allow patching for ROMs with "thor" as a device option.