### PR TITLE
add support for moto g4 plus athene

### DIFF
--- a/data/devices/motorola.yml
+++ b/data/devices/motorola.yml
@@ -563,3 +563,4 @@
       - /dev/block/bootdevice/by-name/recovery
       - /dev/block/platform/624000.ufshc/by-name/recovery
       - /dev/block/sda14
+      


### PR DESCRIPTION
i am now using dual boot on moto g4 plus. xt1643. 
everything working fine except your official support .