### PR TITLE
utilities: Don't download AROMA to build directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,8 +30,8 @@
 # makepkg custom configuration file
 /thirdparty/makepkg.local.conf
 
-# Downloaded or built tarballs
-/thirdparty/**/*.tar*
+# Prebuilts
+/thirdparty/prebuilts
 
 # makepkg build and output files
 /thirdparty/*/src/

--- a/thirdparty/CMakeLists.txt
+++ b/thirdparty/CMakeLists.txt
@@ -340,3 +340,24 @@ if(MBP_TOP_LEVEL_BUILD)
 else()
     set(THIRD_PARTY_PROCPS_NG_DIR "${MBP_PREBUILTS_BINARY_DIR}/procps-ng" PARENT_SCOPE)
 endif()
+
+################################################################################
+# AROMA for Android
+################################################################################
+
+set(AROMA_VER "2.70RC2")
+
+if(MBP_TOP_LEVEL_BUILD)
+    file(
+        DOWNLOAD
+        #"http://forum.xda-developers.com/devdb/project/dl/?id=286&task=get"
+        "https://dbp.noobdev.io/mirror/aroma-${AROMA_VER}.zip"
+        ${MBP_PREBUILTS_DIR}/aroma-${AROMA_VER}.zip
+        EXPECTED_HASH MD5=a77c4993803db28d53cd7e6a37ec73b5
+        EXPECTED_HASH SHA512=44abff7bd536908ae8cde9a17e1fb334b59561e115f54b23bf910e1f7920b6f35ab078d3353db65c3526e25c0be27cd592470145063cafd4e05418e4bece775f
+        TLS_VERIFY ON
+        SHOW_PROGRESS
+    )
+
+    set(THIRD_PARTY_AROMA_FILE "${MBP_PREBUILTS_DIR}/aroma-${AROMA_VER}.zip" PARENT_SCOPE)
+endif()

--- a/thirdparty/CMakeLists.txt
+++ b/thirdparty/CMakeLists.txt
@@ -80,8 +80,10 @@ execute_process(
 )
 
 ################################################################################
-message(STATUS "Locking prebuilts directory: ${MBP_PREBUILTS_DIR}")
-file(LOCK ${MBP_PREBUILTS_DIR} DIRECTORY)
+if(MBP_TOP_LEVEL_BUILD)
+    message(STATUS "Locking prebuilts directory: ${MBP_PREBUILTS_DIR}")
+    file(LOCK ${MBP_PREBUILTS_DIR} DIRECTORY)
+endif()
 ################################################################################
 
 ################################################################################
@@ -367,6 +369,8 @@ if(MBP_TOP_LEVEL_BUILD)
 endif()
 
 ################################################################################
-message(STATUS "Unlocking prebuilts directory: ${MBP_PREBUILTS_DIR}")
-file(LOCK ${MBP_PREBUILTS_DIR} DIRECTORY RELEASE)
+if(MBP_TOP_LEVEL_BUILD)
+    message(STATUS "Unlocking prebuilts directory: ${MBP_PREBUILTS_DIR}")
+    file(LOCK ${MBP_PREBUILTS_DIR} DIRECTORY RELEASE)
+endif()
 ################################################################################

--- a/thirdparty/CMakeLists.txt
+++ b/thirdparty/CMakeLists.txt
@@ -79,6 +79,10 @@ execute_process(
     COMMAND ${CMAKE_COMMAND} -E make_directory ${MBP_PREBUILTS_BINARY_DIR}
 )
 
+################################################################################
+message(STATUS "Locking prebuilts directory: ${MBP_PREBUILTS_DIR}")
+file(LOCK ${MBP_PREBUILTS_DIR} DIRECTORY)
+################################################################################
 
 ################################################################################
 # fuse-exfat for Android
@@ -361,3 +365,8 @@ if(MBP_TOP_LEVEL_BUILD)
 
     set(THIRD_PARTY_AROMA_FILE "${MBP_PREBUILTS_DIR}/aroma-${AROMA_VER}.zip" PARENT_SCOPE)
 endif()
+
+################################################################################
+message(STATUS "Unlocking prebuilts directory: ${MBP_PREBUILTS_DIR}")
+file(LOCK ${MBP_PREBUILTS_DIR} DIRECTORY RELEASE)
+################################################################################

--- a/utilities/CMakeLists.txt
+++ b/utilities/CMakeLists.txt
@@ -1,17 +1,4 @@
 if(MBP_TOP_LEVEL_BUILD)
-    set(AROMA_VER "2.70RC2")
-
-    file(
-        DOWNLOAD
-        #"http://forum.xda-developers.com/devdb/project/dl/?id=286&task=get"
-        "https://snapshots.noobdev.io/mirror/aroma-2.70RC2.zip"
-        ${CMAKE_CURRENT_BINARY_DIR}/aroma-${AROMA_VER}.zip
-        EXPECTED_HASH MD5=a77c4993803db28d53cd7e6a37ec73b5
-        EXPECTED_HASH SHA512=44abff7bd536908ae8cde9a17e1fb334b59561e115f54b23bf910e1f7920b6f35ab078d3353db65c3526e25c0be27cd592470145063cafd4e05418e4bece775f
-        TLS_VERIFY ON
-        SHOW_PROGRESS
-    )
-
     configure_file(
         ${CMAKE_CURRENT_SOURCE_DIR}/create.sh.in
         ${CMAKE_CURRENT_BINARY_DIR}/create.sh

--- a/utilities/create.sh.in
+++ b/utilities/create.sh.in
@@ -4,7 +4,7 @@ set -e
 
 version='@MBP_VERSION@'
 zip_file="@CMAKE_CURRENT_BINARY_DIR@/DualBootUtilities-${version}.zip"
-aroma='@CMAKE_CURRENT_BINARY_DIR@/aroma-@AROMA_VER@.zip'
+aroma='@THIRD_PARTY_AROMA_FILE@'
 temp_dir="$(mktemp -d "@CMAKE_CURRENT_BINARY_DIR@/tmp.XXXXXXXXXX")"
 
 rm -f "${zip_file}"


### PR DESCRIPTION
AROMA was the only file remaining that was downloaded to `CMAKE_BINARY_DIR`. This commit fixes the CMake files so that it is downloaded to the prebuilts directory.