### PR TITLE
gui,bootimgtool: Add manifests to .exe's to prevent unnecessary UAC prompts

### DIFF
--- a/bootimgtool/CMakeLists.txt
+++ b/bootimgtool/CMakeLists.txt
@@ -2,6 +2,10 @@ set(BOOTIMGTOOL_SOURCES
     bootimgtool.cpp
 )
 
+if(WIN32)
+    list(APPEND BOOTIMGTOOL_SOURCES bootimgtool.rc)
+endif()
+
 set(variants)
 
 if(${MBP_BUILD_TARGET} STREQUAL android-system)

--- a/bootimgtool/bootimgtool.manifest
+++ b/bootimgtool/bootimgtool.manifest
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+
+    <assemblyIdentity
+        version="1.0.0.0"
+        processorArchitecture="*"
+        name="io.noobdev.DualBootPatcher.bootimgtool"
+        type="win32" />
+
+    <!-- Identify the application security requirements. -->
+    <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
+        <security>
+            <requestedPrivileges>
+                <requestedExecutionLevel
+                    level="asInvoker"
+                    uiAccess="false" />
+            </requestedPrivileges>
+        </security>
+    </trustInfo>
+
+</assembly>

--- a/bootimgtool/bootimgtool.rc
+++ b/bootimgtool/bootimgtool.rc
@@ -1,0 +1,4 @@
+#include <windows.h>
+
+IDI_ICON1 ICON DISCARDABLE "../icons/icon.ico"
+CREATEPROCESS_MANIFEST_RESOURCE_ID RT_MANIFEST "bootimgtool.manifest"

--- a/gui/main.manifest
+++ b/gui/main.manifest
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+
+    <assemblyIdentity
+        version="1.0.0.0"
+        processorArchitecture="*"
+        name="io.noobdev.DualBootPatcher.QtGUI"
+        type="win32" />
+
+    <!-- Identify the application security requirements. -->
+    <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
+        <security>
+            <requestedPrivileges>
+                <requestedExecutionLevel
+                    level="asInvoker"
+                    uiAccess="false" />
+            </requestedPrivileges>
+        </security>
+    </trustInfo>
+
+</assembly>

--- a/gui/main.rc
+++ b/gui/main.rc
@@ -1,1 +1,4 @@
+#include <windows.h>
+
 IDI_ICON1 ICON DISCARDABLE "../icons/icon.ico"
+CREATEPROCESS_MANIFEST_RESOURCE_ID RT_MANIFEST "main.manifest"


### PR DESCRIPTION
DualBootPatcher never needs to run as admin, but because "patch" is in
the filename, Windows assumes that admin privileges are needed. This
commit adds manifests to all .exe's that are built to indicate that
they should run with the invoking user's privileges.

Signed-off-by: Andrew Gunnerson <chenxiaolong@cxl.epac.to>