### PR TITLE
libmbcommon: Disable copy constructor and assignment operator for pimpl classes

### DIFF
--- a/libmbcommon/include/mbcommon/file/callbacks_p.h
+++ b/libmbcommon/include/mbcommon/file/callbacks_p.h
@@ -34,6 +34,8 @@ public:
     CallbackFilePrivate();
     virtual ~CallbackFilePrivate();
 
+    MB_DISABLE_COPY_CONSTRUCT_AND_ASSIGN(CallbackFilePrivate)
+
     void clear();
 
     CallbackFile::OpenCb open_cb;

--- a/libmbcommon/include/mbcommon/file/fd_p.h
+++ b/libmbcommon/include/mbcommon/file/fd_p.h
@@ -54,6 +54,8 @@ public:
     FdFilePrivate();
     virtual ~FdFilePrivate();
 
+    MB_DISABLE_COPY_CONSTRUCT_AND_ASSIGN(FdFilePrivate)
+
     void clear();
 
     static int convert_mode(FileOpenMode mode);

--- a/libmbcommon/include/mbcommon/file/memory_p.h
+++ b/libmbcommon/include/mbcommon/file/memory_p.h
@@ -34,6 +34,8 @@ public:
     MemoryFilePrivate();
     virtual ~MemoryFilePrivate();
 
+    MB_DISABLE_COPY_CONSTRUCT_AND_ASSIGN(MemoryFilePrivate)
+
     void clear();
 
     void *data;

--- a/libmbcommon/include/mbcommon/file/posix_p.h
+++ b/libmbcommon/include/mbcommon/file/posix_p.h
@@ -59,6 +59,8 @@ public:
     PosixFilePrivate();
     virtual ~PosixFilePrivate();
 
+    MB_DISABLE_COPY_CONSTRUCT_AND_ASSIGN(PosixFilePrivate)
+
     void clear();
 
 #ifdef _WIN32

--- a/libmbcommon/include/mbcommon/file/win32_p.h
+++ b/libmbcommon/include/mbcommon/file/win32_p.h
@@ -64,6 +64,8 @@ public:
     Win32FilePrivate();
     virtual ~Win32FilePrivate();
 
+    MB_DISABLE_COPY_CONSTRUCT_AND_ASSIGN(Win32FilePrivate)
+
     void clear();
 
     LPCWSTR win32_error_string(DWORD error_code);

--- a/libmbcommon/include/mbcommon/file_p.h
+++ b/libmbcommon/include/mbcommon/file_p.h
@@ -40,7 +40,10 @@ MB_DECLARE_OPERATORS_FOR_FLAGS(FileStates)
 class FilePrivate
 {
 public:
+    FilePrivate();
     virtual ~FilePrivate();
+
+    MB_DISABLE_COPY_CONSTRUCT_AND_ASSIGN(FilePrivate)
 
     FileState state;
 

--- a/libmbcommon/src/file.cpp
+++ b/libmbcommon/src/file.cpp
@@ -155,6 +155,10 @@ namespace mb
  */
 
 /*! \cond INTERNAL */
+FilePrivate::FilePrivate()
+{
+}
+
 FilePrivate::~FilePrivate()
 {
 }


### PR DESCRIPTION
Signed-off-by: Andrew Gunnerson <chenxiaolong@cxl.epac.to>