### PR TITLE
Codename update for p9 lite

### DIFF
--- a/data/devices/huawei.yml
+++ b/data/devices/huawei.yml
@@ -395,8 +395,9 @@
   id: VNS
   codenames:
     - VNS
+    - venus
     - hi6250
-    - HWVNS-N
+    - HWVNS-H
   architecture: arm64-v8a
 
   block_devs:


### PR DESCRIPTION
The codename was mistyped(HWVNS-N) instead of HWVNS-H(correct codename) and also included other official codename: venus