### PR TITLE
Update docs: docker is release 2

### DIFF
--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -26,10 +26,10 @@ Note that building the docker images will take a long time and consume a lot of 
 Once the images have been built, the resulting image tags are written to `docker/generated/images.properties`. It will look something like the following:
 
 ```dosini
-android=chenxiaolong/dualbootpatcher:9.2.0-1-android
-base=chenxiaolong/dualbootpatcher:9.2.0-1-base
-linux=chenxiaolong/dualbootpatcher:9.2.0-1-linux
-mingw=chenxiaolong/dualbootpatcher:9.2.0-1-mingw
+android=chenxiaolong/dualbootpatcher:9.2.0-2-android
+base=chenxiaolong/dualbootpatcher:9.2.0-2-base
+linux=chenxiaolong/dualbootpatcher:9.2.0-2-linux
+mingw=chenxiaolong/dualbootpatcher:9.2.0-2-mingw
 ```
 
 The following table describes the images that are built:
@@ -54,7 +54,7 @@ docker run --rm -it \
     -v "${HOME}/.android:/builder/.android:rw,z" \
     -v "${HOME}/.ccache:/builder/.ccache:rw,z" \
     -v "${HOME}/.gradle:/builder/.gradle:rw,z" \
-    chenxiaolong/dualbootpatcher:9.2.0-1-android \
+    chenxiaolong/dualbootpatcher:9.2.0-2-android \
     bash
 ```
 


### PR DESCRIPTION
docker doc should updated, i was trying to build and faced error can't find image chenxiaolong/dualbootpatcher:9.2.0-1-android
so it should be chenxiaolong/dualbootpatcher:9.2.0-2-android