### PR TITLE
android: Use shared libstdc++ for android-app target

### DIFF
--- a/Android_GUI/build.gradle.in
+++ b/Android_GUI/build.gradle.in
@@ -22,6 +22,9 @@ android {
         // Both commons-lang3 and common-io want to include these file
         exclude 'META-INF/LICENSE.txt'
         exclude 'META-INF/NOTICE.txt'
+
+        // CMake will strip the libraries automatically for release builds
+        doNotStrip '**.so'
     }
 
     lintOptions {

--- a/android/CMakeLists.txt
+++ b/android/CMakeLists.txt
@@ -20,8 +20,10 @@ if(MBP_TOP_LEVEL_BUILD)
     # devices' ramdisks.
     if(${MBP_SYSTEM_BUILD_TYPE} STREQUAL debug)
         set(MBP_SYSTEM_CMAKE_BUILD_TYPE Debug)
+        set(install_target install)
     else()
         set(MBP_SYSTEM_CMAKE_BUILD_TYPE Release)
+        set(install_target install/strip)
     endif()
 
     # List of ExternalProject directories to run "make clean" in
@@ -84,7 +86,7 @@ if(MBP_TOP_LEVEL_BUILD)
             INSTALL_DIR ${CMAKE_CURRENT_BINARY_DIR}/result
             CMAKE_ARGS ${INTERNAL_ANDROID_SYSTEM_OPTIONS}
             BUILD_ALWAYS 1
-            INSTALL_COMMAND ${CMAKE_COMMAND} --build . --target install/strip
+            INSTALL_COMMAND ${CMAKE_COMMAND} --build . --target ${install_target}
             VERBATIM
         )
 
@@ -136,7 +138,7 @@ if(MBP_TOP_LEVEL_BUILD)
                 INSTALL_DIR ${CMAKE_CURRENT_BINARY_DIR}/result
                 CMAKE_ARGS ${INTERNAL_ANDROID_APP_OPTIONS}
                 BUILD_ALWAYS 1
-                INSTALL_COMMAND ${CMAKE_COMMAND} --build . --target install/strip
+                INSTALL_COMMAND ${CMAKE_COMMAND} --build . --target ${install_target}
                 VERBATIM
             )
 

--- a/android/CMakeLists.txt
+++ b/android/CMakeLists.txt
@@ -20,10 +20,18 @@ if(MBP_TOP_LEVEL_BUILD)
     # devices' ramdisks.
     if(${MBP_SYSTEM_BUILD_TYPE} STREQUAL debug)
         set(MBP_SYSTEM_CMAKE_BUILD_TYPE Debug)
-        set(install_target install)
+        set(system_install_target install)
     else()
         set(MBP_SYSTEM_CMAKE_BUILD_TYPE Release)
-        set(install_target install/strip)
+        set(system_install_target install/strip)
+    endif()
+
+    if(${MBP_BUILD_TARGET} STREQUAL android)
+        if(${CMAKE_BUILD_TYPE} STREQUAL Debug)
+            set(app_install_target install)
+        else()
+            set(app_install_target install/strip)
+        endif()
     endif()
 
     # List of ExternalProject directories to run "make clean" in
@@ -86,7 +94,7 @@ if(MBP_TOP_LEVEL_BUILD)
             INSTALL_DIR ${CMAKE_CURRENT_BINARY_DIR}/result
             CMAKE_ARGS ${INTERNAL_ANDROID_SYSTEM_OPTIONS}
             BUILD_ALWAYS 1
-            INSTALL_COMMAND ${CMAKE_COMMAND} --build . --target ${install_target}
+            INSTALL_COMMAND ${CMAKE_COMMAND} --build . --target ${system_install_target}
             VERBATIM
         )
 
@@ -138,7 +146,7 @@ if(MBP_TOP_LEVEL_BUILD)
                 INSTALL_DIR ${CMAKE_CURRENT_BINARY_DIR}/result
                 CMAKE_ARGS ${INTERNAL_ANDROID_APP_OPTIONS}
                 BUILD_ALWAYS 1
-                INSTALL_COMMAND ${CMAKE_COMMAND} --build . --target ${install_target}
+                INSTALL_COMMAND ${CMAKE_COMMAND} --build . --target ${app_install_target}
                 VERBATIM
             )
 

--- a/android/CMakeLists.txt
+++ b/android/CMakeLists.txt
@@ -46,8 +46,6 @@ if(MBP_TOP_LEVEL_BUILD)
             #-DCMAKE_TOOLCHAIN_FILE=${ndk_path}/build/cmake/android.toolchain.cmake
             -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
             -DANDROID_ABI=${abi}
-            -DANDROID_STL=gnustl_static
-            #-DANDROID_STL=c++_static
             -DMBP_BUILD_TYPE=${MBP_BUILD_TYPE}
             -DMBP_ENABLE_TESTS=OFF
             -DMBP_PREBUILTS_BINARY_DIR=${MBP_PREBUILTS_BINARY_DIR}
@@ -71,6 +69,8 @@ if(MBP_TOP_LEVEL_BUILD)
             -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
             -DANDROID_PIE=ON
             -DANDROID_PLATFORM=android-17
+            -DANDROID_STL=gnustl_shared
+            #-DANDROID_STL=c++_shared
             -DMBP_BUILD_TARGET=android-app
         )
 
@@ -79,6 +79,8 @@ if(MBP_TOP_LEVEL_BUILD)
             -DCMAKE_BUILD_TYPE=${MBP_SYSTEM_CMAKE_BUILD_TYPE}
             -DANDROID_PIE=OFF
             -DANDROID_PLATFORM=android-21
+            -DANDROID_STL=gnustl_static
+            #-DANDROID_STL=c++_static
             -DMBP_BUILD_TARGET=android-system
         )
 
@@ -246,5 +248,33 @@ if(MBP_TOP_LEVEL_BUILD)
         clean-android
         ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_BINARY_DIR}/clean-android.cmake
         VERBATIM
+    )
+elseif(${MBP_BUILD_TARGET} STREQUAL android-app)
+    # Install gnustl. We do this in the android-app target because we have
+    # access to the CMAKE_LINKER variable.
+    set(gnustl_source "$ENV{ANDROID_NDK}/sources/cxx-stl/gnu-libstdc++/4.9/libs/${ANDROID_ABI}/libgnustl_shared.so")
+    set(gnustl_target "${CMAKE_CURRENT_BINARY_DIR}/libgnustl_shared.stripped.so")
+
+    add_custom_command(
+        OUTPUT "${gnustl_target}"
+        COMMAND "${CMAKE_STRIP}" -s "${gnustl_source}" -o "${gnustl_target}"
+        COMMENT "Strip gnustl_shared library"
+        VERBATIM
+    )
+
+    add_custom_target(
+        strip_gnustl_shared
+        ALL
+        DEPENDS "${gnustl_target}"
+    )
+
+    install(
+        FILES "${gnustl_target}"
+        DESTINATION ${LIB_INSTALL_DIR}
+        RENAME libgnustl_shared.so
+        PERMISSIONS OWNER_EXECUTE OWNER_WRITE OWNER_READ
+                    GROUP_EXECUTE             GROUP_READ
+                    WORLD_EXECUTE             WORLD_READ
+        COMPONENT Libraries
     )
 endif()

--- a/libmbcommon/include/mbcommon/common.h
+++ b/libmbcommon/include/mbcommon/common.h
@@ -55,7 +55,7 @@
 #  define MB_END_C_DECLS
 #endif
 
-#if defined(__GNUC__) && defined(__clang__)
+#if defined(__GNUC__) || defined(__clang__)
 #  define MB_PRINTF(fmt_arg, var_arg) \
     __attribute__((format(printf, fmt_arg, var_arg)))
 #  define MB_SCANF(fmt_arg, var_arg) \


### PR DESCRIPTION
This was an oversight when DualBootPatcher switched from having just
libmbp.so to having several different libraries. When linked against
static libstdc++, symbols that were meant to be globally unique got
duplicated in each library.

This was particularly problematic for the
_ZNSs4_Rep20_S_empty_rep_storageE symbol. It's a statically allocated
buffer used as the representation for empty strings. If an empty
std::string is passed from one library to another and the second
library performs an action that causes a reallocation, then the second
library will free() the _S_empty_rep_storage buffer and crash. The
normal `this != &_S_empty_rep()` guard doesn't work because each
library has its own _S_empty_rep_storage.

Signed-off-by: Andrew Gunnerson <chenxiaolong@cxl.epac.to>