### PR TITLE
Add extra codename for HTC One M8

### DIFF
--- a/data/devices/htc.yml
+++ b/data/devices/htc.yml
@@ -83,6 +83,7 @@
 - name: HTC one M8
   id: M8
   codenames:
+    - m8
     - M8
     - htc_m8
     - htc_m8whl


### PR DESCRIPTION
This codename is used by TWRP