### PR TITLE
libmblog: Revamp logging API and implementation

### DIFF
--- a/examples/libmbpatcher_test.cpp
+++ b/examples/libmbpatcher_test.cpp
@@ -22,6 +22,7 @@
 #include <cstring>
 
 #include <mbdevice/json.h>
+#include <mblog/base_logger.h>
 #include <mblog/logging.h>
 #include <mbpatcher/patcherconfig.h>
 #include <mbpatcher/patcherinterface.h>
@@ -30,11 +31,14 @@
 class BasicLogger : public mb::log::BaseLogger
 {
 public:
-    virtual void log(mb::log::LogLevel prio, const char *fmt, va_list ap) override
+    virtual void log(const mb::log::LogRecord &rec) override
     {
-        (void) prio;
-        vprintf(fmt, ap);
-        printf("\n");
+        printf("%s\n", rec.fmt_msg.c_str());
+    }
+
+    virtual bool formatted() override
+    {
+        return true;
     }
 };
 
@@ -106,7 +110,7 @@ int main(int argc, char *argv[]) {
     const char *input_path = argv[4];
     const char *output_path = argv[5];
 
-    mb::log::log_set_logger(std::make_shared<BasicLogger>());
+    mb::log::set_logger(std::make_shared<BasicLogger>());
 
     mb::device::Device device;
 

--- a/libmbcommon/CMakeLists.txt
+++ b/libmbcommon/CMakeLists.txt
@@ -9,6 +9,7 @@ configure_file(
 
 set(MBCOMMON_SOURCES
     src/capi/util.cpp
+    src/error.cpp
     src/file/callbacks.cpp
     src/file/fd.cpp
     src/file/memory.cpp

--- a/libmbcommon/include/mbcommon/error.h
+++ b/libmbcommon/include/mbcommon/error.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2017  Andrew Gunnerson <andrewgunnerson@gmail.com>
+ *
+ * This file is part of DualBootPatcher
+ *
+ * DualBootPatcher is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * DualBootPatcher is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with DualBootPatcher.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "mbcommon/common.h"
+
+namespace mb
+{
+
+class MB_EXPORT ErrorRestorer final
+{
+public:
+    ErrorRestorer();
+    ~ErrorRestorer();
+
+    MB_DISABLE_COPY_CONSTRUCT_AND_ASSIGN(ErrorRestorer)
+    MB_DISABLE_MOVE_CONSTRUCT_AND_ASSIGN(ErrorRestorer)
+
+private:
+    const int _saved_errno;
+#ifdef _WIN32
+    const unsigned int _saved_error;
+#endif
+};
+
+}

--- a/libmbcommon/include/mbcommon/error.h
+++ b/libmbcommon/include/mbcommon/error.h
@@ -36,7 +36,7 @@ public:
 private:
     const int _saved_errno;
 #ifdef _WIN32
-    const unsigned int _saved_error;
+    const unsigned long _saved_error;
 #endif
 };
 

--- a/libmbcommon/include/mbcommon/type_traits.h
+++ b/libmbcommon/include/mbcommon/type_traits.h
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2017  Andrew Gunnerson <andrewgunnerson@gmail.com>
+ *
+ * This file is part of DualBootPatcher
+ *
+ * DualBootPatcher is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * DualBootPatcher is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with DualBootPatcher.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <cstddef>
+
+namespace mb
+{
+
+// Based on https://stackoverflow.com/a/43526780
+
+// Get nth template argument type
+
+template <std::size_t N, typename T0, typename... Ts>
+struct TypeN
+{
+    using type = typename TypeN<N - 1, Ts...>::type;
+};
+
+template <typename T0, typename... Ts>
+struct TypeN<0, T0, Ts...>
+{
+    using type = T0;
+};
+
+// Get nth function argument type
+
+template <std::size_t, typename>
+struct ArgN;
+
+template <std::size_t N, typename R, typename... As>
+struct ArgN<N, R(As...)>
+{
+    using type = typename TypeN<N, As...>::type;
+};
+
+// Get function return type
+
+template <typename>
+struct ReturnType;
+
+template <typename R, typename... As>
+struct ReturnType<R(As...)>
+{
+    using type = R;
+};
+
+}

--- a/libmbcommon/include/mbcommon/type_traits.h
+++ b/libmbcommon/include/mbcommon/type_traits.h
@@ -62,4 +62,12 @@ struct ReturnType<R(As...)>
     using type = R;
 };
 
+#ifdef _WIN32
+template <typename R, typename... As>
+struct ReturnType<__stdcall R(As...)>
+{
+    using type = R;
+};
+#endif
+
 }

--- a/libmbcommon/src/error.cpp
+++ b/libmbcommon/src/error.cpp
@@ -38,7 +38,7 @@ ErrorRestorer::ErrorRestorer()
 {
 #ifdef _WIN32
     // We don't include windows.h in the header
-    static_assert(std::is_same<DWORD, decltype(_saved_error)>::value,
+    static_assert(std::is_same<const DWORD, decltype(_saved_error)>::value,
                   "Unexpected type for DWORD");
 #endif
 }

--- a/libmbcommon/src/error.cpp
+++ b/libmbcommon/src/error.cpp
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2017  Andrew Gunnerson <andrewgunnerson@gmail.com>
+ *
+ * This file is part of DualBootPatcher
+ *
+ * DualBootPatcher is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * DualBootPatcher is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with DualBootPatcher.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "mbcommon/error.h"
+
+#include <type_traits>
+
+#include <cerrno>
+
+#ifdef _WIN32
+#include <windows.h>
+#endif
+
+namespace mb
+{
+
+ErrorRestorer::ErrorRestorer()
+    : _saved_errno(errno)
+#ifdef _WIN32
+    , _saved_error(GetLastError())
+#endif
+{
+#ifdef _WIN32
+    // We don't include windows.h in the header
+    static_assert(std::is_same<DWORD, decltype(_saved_error)>::value,
+                  "Unexpected type for DWORD");
+#endif
+}
+
+ErrorRestorer::~ErrorRestorer()
+{
+    errno = _saved_errno;
+#ifdef _WIN32
+    SetLastError(_saved_error);
+#endif
+}
+
+}

--- a/libmbcommon/src/locale.cpp
+++ b/libmbcommon/src/locale.cpp
@@ -31,6 +31,11 @@
 #include <iconv.h>
 #endif
 
+#include "mbcommon/error.h"
+
+namespace mb
+{
+
 #ifdef _WIN32
 
 static wchar_t * win32_convert_to_wcs(UINT code_page,
@@ -73,13 +78,11 @@ static wchar_t * win32_convert_to_wcs(UINT code_page,
     result = out_buf;
 
 done:
-    DWORD saved_error = GetLastError();
+    ErrorRestorer restorer;
 
     if (!result) {
         free(out_buf);
     }
-
-    SetLastError(saved_error);
 
     return result;
 }
@@ -126,13 +129,11 @@ static char * win32_convert_to_mbs(UINT code_page,
     result = out_buf;
 
 done:
-    DWORD saved_error = GetLastError();
+    ErrorRestorer restorer;
 
     if (!result) {
         free(out_buf);
     }
-
-    SetLastError(saved_error);
 
     return result;
 }
@@ -247,7 +248,7 @@ static char * iconv_convert(const char *from_code, const char *to_code,
     result = out_buf;
 
 done:
-    int saved_errno = errno;
+    ErrorRestorer restorer;
 
     if (cd) {
         iconv_close(cd);
@@ -256,15 +257,10 @@ done:
         free(out_buf);
     }
 
-    errno = saved_errno;
-
     return result;
 }
 
 #endif
-
-namespace mb
-{
 
 bool mbs_to_wcs_n(std::wstring &out, const char *str, size_t len)
 {

--- a/libmblog/CMakeLists.txt
+++ b/libmblog/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(MBLOG_SOURCES
+    src/base_logger.cpp
     src/logging.cpp
     src/stdio_logger.cpp
 )

--- a/libmblog/include/mblog/android_logger.h
+++ b/libmblog/include/mblog/android_logger.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2016  Andrew Gunnerson <andrewgunnerson@gmail.com>
+ * Copyright (C) 2014-2017  Andrew Gunnerson <andrewgunnerson@gmail.com>
  *
  * This file is part of DualBootPatcher
  *
@@ -19,7 +19,7 @@
 
 #pragma once
 
-#include "mblog/stdio_logger.h"
+#include "mblog/base_logger.h"
 
 namespace mb
 {
@@ -29,7 +29,9 @@ namespace log
 class MB_EXPORT AndroidLogger : public BaseLogger
 {
 public:
-    virtual void log(LogLevel prio, const char *fmt, va_list ap) override;
+    virtual void log(const LogRecord &rec) override;
+
+    virtual bool formatted() override;
 };
 
 }

--- a/libmblog/include/mblog/base_logger.h
+++ b/libmblog/include/mblog/base_logger.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2016  Andrew Gunnerson <andrewgunnerson@gmail.com>
+ * Copyright (C) 2014-2017  Andrew Gunnerson <andrewgunnerson@gmail.com>
  *
  * This file is part of DualBootPatcher
  *
@@ -20,9 +20,9 @@
 #pragma once
 
 #include "mbcommon/common.h"
-#include "mblog/log_level.h"
 
-#include <cstdarg>
+#include "mblog/log_level.h"
+#include "mblog/log_record.h"
 
 namespace mb
 {
@@ -32,7 +32,12 @@ namespace log
 class MB_EXPORT BaseLogger
 {
 public:
-    virtual void log(LogLevel prio, const char *fmt, va_list ap) = 0;
+    BaseLogger();
+    virtual ~BaseLogger();
+
+    virtual void log(const LogRecord &rec) = 0;
+
+    virtual bool formatted() = 0;
 };
 
 }

--- a/libmblog/include/mblog/kmsg_logger.h
+++ b/libmblog/include/mblog/kmsg_logger.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2016  Andrew Gunnerson <andrewgunnerson@gmail.com>
+ * Copyright (C) 2014-2017  Andrew Gunnerson <andrewgunnerson@gmail.com>
  *
  * This file is part of DualBootPatcher
  *
@@ -21,8 +21,6 @@
 
 #include "mblog/base_logger.h"
 
-#define KMSG_BUF_SIZE 512
-
 namespace mb
 {
 namespace log
@@ -32,14 +30,14 @@ class MB_EXPORT KmsgLogger : public BaseLogger
 {
 public:
     KmsgLogger(bool force_error_prio);
-
     virtual ~KmsgLogger();
 
-    virtual void log(LogLevel prio, const char *fmt, va_list ap) override;
+    virtual void log(const LogRecord &rec) override;
+
+    virtual bool formatted() override;
 
 private:
     int _fd;
-    char _buf[KMSG_BUF_SIZE];
     bool _force_error_prio;
 };
 

--- a/libmblog/include/mblog/log_record.h
+++ b/libmblog/include/mblog/log_record.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2017  Andrew Gunnerson <andrewgunnerson@gmail.com>
+ * Copyright (C) 2017  Andrew Gunnerson <andrewgunnerson@gmail.com>
  *
  * This file is part of DualBootPatcher
  *
@@ -19,18 +19,25 @@
 
 #pragma once
 
+#include <chrono>
+#include <string>
+
+#include "mblog/log_level.h"
+
 namespace mb
 {
 namespace log
 {
 
-enum class LogLevel
+struct LogRecord
 {
-    Error,
-    Warning,
-    Info,
-    Debug,
-    Verbose
+    std::chrono::system_clock::time_point time;
+    uint64_t pid;
+    uint64_t tid;
+    LogLevel prio;
+    std::string tag;
+    std::string msg;
+    std::string fmt_msg;
 };
 
 }

--- a/libmblog/include/mblog/logging.h
+++ b/libmblog/include/mblog/logging.h
@@ -24,32 +24,62 @@
 #include <cstdarg>
 
 #include "mbcommon/common.h"
-#include "mblog/base_logger.h"
+
 #include "mblog/log_level.h"
 
-#define LOGE(...) mb::log::log(mb::log::LogLevel::Error, __VA_ARGS__)
-#define LOGW(...) mb::log::log(mb::log::LogLevel::Warning, __VA_ARGS__)
-#define LOGI(...) mb::log::log(mb::log::LogLevel::Info, __VA_ARGS__)
-#define LOGD(...) mb::log::log(mb::log::LogLevel::Debug, __VA_ARGS__)
-#define LOGV(...) mb::log::log(mb::log::LogLevel::Verbose, __VA_ARGS__)
+#define TLOGE(TAG, ...) \
+    mb::log::log(mb::log::LogLevel::Error, (TAG), __VA_ARGS__)
+#define TLOGW(TAG, ...) \
+    mb::log::log(mb::log::LogLevel::Warning, (TAG), __VA_ARGS__)
+#define TLOGI(TAG, ...) \
+    mb::log::log(mb::log::LogLevel::Info, (TAG), __VA_ARGS__)
+#define TLOGD(TAG, ...) \
+    mb::log::log(mb::log::LogLevel::Debug, (TAG), __VA_ARGS__)
+#define TLOGV(TAG, ...) \
+    mb::log::log(mb::log::LogLevel::Verbose, (TAG), __VA_ARGS__)
 
-#define VLOGE(...) mb::log::logv(mb::log::LogLevel::Error, __VA_ARGS__)
-#define VLOGW(...) mb::log::logv(mb::log::LogLevel::Warning, __VA_ARGS__)
-#define VLOGI(...) mb::log::logv(mb::log::LogLevel::Info, __VA_ARGS__)
-#define VLOGD(...) mb::log::logv(mb::log::LogLevel::Debug, __VA_ARGS__)
-#define VLOGV(...) mb::log::logv(mb::log::LogLevel::Verbose, __VA_ARGS__)
+#define LOGE(...) TLOGE(LOG_TAG, __VA_ARGS__)
+#define LOGW(...) TLOGW(LOG_TAG, __VA_ARGS__)
+#define LOGI(...) TLOGI(LOG_TAG, __VA_ARGS__)
+#define LOGD(...) TLOGD(LOG_TAG, __VA_ARGS__)
+#define LOGV(...) TLOGV(LOG_TAG, __VA_ARGS__)
+
+#define TVLOGE(TAG, ...) \
+    mb::log::log_v(mb::log::LogLevel::Error, (TAG), __VA_ARGS__)
+#define TVLOGW(TAG, ...) \
+    mb::log::log_v(mb::log::LogLevel::Warning, (TAG), __VA_ARGS__)
+#define TVLOGI(TAG, ...) \
+    mb::log::log_v(mb::log::LogLevel::Info, (TAG), __VA_ARGS__)
+#define TVLOGD(TAG, ...) \
+    mb::log::log_v(mb::log::LogLevel::Debug, (TAG), __VA_ARGS__)
+#define TVLOGV(TAG, ...) \
+    mb::log::log_v(mb::log::LogLevel::Verbose, (TAG), __VA_ARGS__)
+
+#define VLOGE(...) TVLOGE(LOG_TAG, __VA_ARGS__)
+#define VLOGW(...) TVLOGW(LOG_TAG, __VA_ARGS__)
+#define VLOGI(...) TVLOGI(LOG_TAG, __VA_ARGS__)
+#define VLOGD(...) TVLOGD(LOG_TAG, __VA_ARGS__)
+#define VLOGV(...) TVLOGV(LOG_TAG, __VA_ARGS__)
 
 namespace mb
 {
 namespace log
 {
 
-MB_EXPORT const char * get_log_tag();
-MB_EXPORT void set_log_tag(const char *tag);
-MB_EXPORT void log_set_logger(std::shared_ptr<BaseLogger> logger);
-MB_PRINTF(2, 3)
-MB_EXPORT void log(LogLevel prio, const char *fmt, ...);
-MB_EXPORT void logv(LogLevel prio, const char *fmt, va_list ap);
+class BaseLogger;
+
+MB_EXPORT std::shared_ptr<BaseLogger> logger();
+MB_EXPORT void set_logger(std::shared_ptr<BaseLogger> logger);
+
+MB_PRINTF(3, 4)
+MB_EXPORT void log(LogLevel prio, const char *tag, const char *fmt, ...);
+MB_EXPORT void log_v(LogLevel prio, const char *tag, const char *fmt, va_list ap);
+
+MB_EXPORT std::string time_format();
+MB_EXPORT void set_time_format(std::string fmt);
+
+MB_EXPORT std::string format();
+MB_EXPORT void set_format(std::string fmt);
 
 }
 }

--- a/libmblog/include/mblog/stdio_logger.h
+++ b/libmblog/include/mblog/stdio_logger.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2016  Andrew Gunnerson <andrewgunnerson@gmail.com>
+ * Copyright (C) 2014-2017  Andrew Gunnerson <andrewgunnerson@gmail.com>
  *
  * This file is part of DualBootPatcher
  *
@@ -31,13 +31,14 @@ namespace log
 class MB_EXPORT StdioLogger : public BaseLogger
 {
 public:
-    StdioLogger(std::FILE *stream, bool show_timestamps);
+    StdioLogger(std::FILE *stream);
 
-    virtual void log(LogLevel prio, const char *fmt, va_list ap) override;
+    virtual void log(const LogRecord &rec) override;
+
+    virtual bool formatted() override;
 
 private:
     std::FILE *_stream;
-    bool _show_timestamps;
 };
 
 }

--- a/libmblog/src/android_logger.cpp
+++ b/libmblog/src/android_logger.cpp
@@ -21,18 +21,16 @@
 
 #include <android/log.h>
 
-#include "mblog/logging.h"
-
 namespace mb
 {
 namespace log
 {
 
-void AndroidLogger::log(LogLevel prio, const char *fmt, va_list ap)
+void AndroidLogger::log(const LogRecord &rec)
 {
     int logcatprio;
 
-    switch (prio) {
+    switch (rec.prio) {
     case LogLevel::Error:
         logcatprio = ANDROID_LOG_ERROR;
         break;
@@ -52,7 +50,12 @@ void AndroidLogger::log(LogLevel prio, const char *fmt, va_list ap)
         return;
     }
 
-    __android_log_vprint(logcatprio, get_log_tag(), fmt, ap);
+    __android_log_write(logcatprio, rec.tag.c_str(), rec.msg.c_str());
+}
+
+bool AndroidLogger::formatted()
+{
+    return false;
 }
 
 }

--- a/libmblog/src/base_logger.cpp
+++ b/libmblog/src/base_logger.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2017  Andrew Gunnerson <andrewgunnerson@gmail.com>
+ * Copyright (C) 2017  Andrew Gunnerson <andrewgunnerson@gmail.com>
  *
  * This file is part of DualBootPatcher
  *
@@ -17,21 +17,20 @@
  * along with DualBootPatcher.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#pragma once
+#include "mblog/base_logger.h"
 
 namespace mb
 {
 namespace log
 {
 
-enum class LogLevel
+BaseLogger::BaseLogger()
 {
-    Error,
-    Warning,
-    Info,
-    Debug,
-    Verbose
-};
+}
+
+BaseLogger::~BaseLogger()
+{
+}
 
 }
 }

--- a/libmblog/src/kmsg_logger.cpp
+++ b/libmblog/src/kmsg_logger.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2016  Andrew Gunnerson <andrewgunnerson@gmail.com>
+ * Copyright (C) 2014-2017  Andrew Gunnerson <andrewgunnerson@gmail.com>
  *
  * This file is part of DualBootPatcher
  *
@@ -19,37 +19,41 @@
 
 #include "mblog/kmsg_logger.h"
 
+#include <array>
+
+#include <cstddef>
 #include <cstdio>
 #include <cstring>
 
 #include <fcntl.h>
 #include <sys/stat.h>
 #include <sys/sysmacros.h>
+#include <sys/uio.h>
 #include <unistd.h>
-
-#include "mblog/logging.h"
 
 namespace mb
 {
 namespace log
 {
 
-#define KMSG_LEVEL_DEBUG    "<7>"
-#define KMSG_LEVEL_INFO     "<6>"
-#define KMSG_LEVEL_NOTICE   "<5>"
-#define KMSG_LEVEL_WARNING  "<4>"
-#define KMSG_LEVEL_ERROR    "<3>"
-#define KMSG_LEVEL_CRITICAL "<2>"
-#define KMSG_LEVEL_ALERT    "<1>"
-#define KMSG_LEVEL_EMERG    "<0>"
-#define KMSG_LEVEL_DEFAULT  "<d>"
+static constexpr std::size_t KMSG_BUF_SIZE            = 512;
+
+static constexpr char KMSG_LEVEL_DEBUG[]              = "<7>";
+static constexpr char KMSG_LEVEL_INFO[]               = "<6>";
+static constexpr char KMSG_LEVEL_NOTICE[] MB_UNUSED   = "<5>";
+static constexpr char KMSG_LEVEL_WARNING[]            = "<4>";
+static constexpr char KMSG_LEVEL_ERROR[]              = "<3>";
+static constexpr char KMSG_LEVEL_CRITICAL[] MB_UNUSED = "<2>";
+static constexpr char KMSG_LEVEL_ALERT[] MB_UNUSED    = "<1>";
+static constexpr char KMSG_LEVEL_EMERG[] MB_UNUSED    = "<0>";
+static constexpr char KMSG_LEVEL_DEFAULT[]            = "<d>";
 
 KmsgLogger::KmsgLogger(bool force_error_prio)
     : _force_error_prio(force_error_prio)
 {
-    static int open_mode = O_WRONLY | O_NOCTTY | O_CLOEXEC;
-    static const char *kmsg = "/dev/kmsg";
-    static const char *kmsg2 = "/dev/kmsg.mbtool";
+    static constexpr int open_mode = O_WRONLY | O_NOCTTY | O_CLOEXEC;
+    static constexpr char kmsg[] = "/dev/kmsg";
+    static constexpr char kmsg2[] = "/dev/kmsg.mblog";
 
     _fd = open(kmsg, open_mode);
     if (_fd < 0) {
@@ -71,20 +75,18 @@ KmsgLogger::~KmsgLogger()
     }
 }
 
-void KmsgLogger::log(LogLevel prio, const char *fmt, va_list ap)
+void KmsgLogger::log(const LogRecord &rec)
 {
     if (_fd < 0) {
         return;
     }
 
-    const char *kprio;
+    const char *kprio = KMSG_LEVEL_DEFAULT;
 
     if (_force_error_prio) {
         kprio = KMSG_LEVEL_ERROR;
     } else {
-        kprio = KMSG_LEVEL_DEFAULT;
-
-        switch (prio) {
+        switch (rec.prio) {
         case LogLevel::Error:
             kprio = KMSG_LEVEL_ERROR;
             break;
@@ -103,23 +105,27 @@ void KmsgLogger::log(LogLevel prio, const char *fmt, va_list ap)
         }
     }
 
-    char new_fmt[64];
-    if (snprintf(new_fmt, sizeof(new_fmt), "%s%s: %s\n",
-                 kprio, get_log_tag(), fmt) >= (int) sizeof(new_fmt)) {
-        // Doesn't fit
-        return;
+    std::array<iovec, 3> iov;
+    iov[0].iov_base = const_cast<char *>(kprio);
+    iov[0].iov_len = strlen(kprio);
+    iov[1].iov_base = const_cast<char *>(rec.fmt_msg.c_str());
+    iov[1].iov_len = rec.fmt_msg.size();
+    iov[2].iov_base = const_cast<char *>("\n");
+    iov[2].iov_len = 1;
+
+    if (iov[0].iov_len + iov[1].iov_len >= KMSG_BUF_SIZE) {
+        static constexpr char trunc[] = " [trunc...]\n";
+        iov[1].iov_len = KMSG_BUF_SIZE - iov[0].iov_len - sizeof(trunc) + 1;
+        iov[2].iov_base = const_cast<char *>(trunc);
+        iov[2].iov_len = sizeof(trunc) - 1;
     }
 
-    std::size_t len = vsnprintf(_buf, KMSG_BUF_SIZE, new_fmt, ap);
+    writev(_fd, iov.data(), iov.size());
+}
 
-    // Make user aware of any truncation
-    if (len >= KMSG_BUF_SIZE) {
-        static const char trunc[] = " [trunc...]\n";
-        memcpy(_buf + sizeof(_buf) - sizeof(trunc), trunc, sizeof(trunc));
-    }
-
-    write(_fd, _buf, strlen(_buf));
-    //vdprintf(_fd, new_fmt.c_str(), ap);
+bool KmsgLogger::formatted()
+{
+    return true;
 }
 
 }

--- a/libmblog/src/stdio_logger.cpp
+++ b/libmblog/src/stdio_logger.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2016  Andrew Gunnerson <andrewgunnerson@gmail.com>
+ * Copyright (C) 2014-2017  Andrew Gunnerson <andrewgunnerson@gmail.com>
  *
  * This file is part of DualBootPatcher
  *
@@ -19,67 +19,29 @@
 
 #include "mblog/stdio_logger.h"
 
-#include <ctime>
-
 namespace mb
 {
 namespace log
 {
 
-#define STDLOG_LEVEL_ERROR   "[E]"
-#define STDLOG_LEVEL_WARNING "[W]"
-#define STDLOG_LEVEL_INFO    "[I]"
-#define STDLOG_LEVEL_DEBUG   "[D]"
-#define STDLOG_LEVEL_VERBOSE "[V]"
-
-StdioLogger::StdioLogger(std::FILE *stream, bool show_timestamps)
-    : _stream(stream), _show_timestamps(show_timestamps)
+StdioLogger::StdioLogger(std::FILE *stream)
+    : _stream(stream)
 {
 }
 
-void StdioLogger::log(LogLevel prio, const char *fmt, va_list ap)
+void StdioLogger::log(const LogRecord &rec)
 {
     if (!_stream) {
         return;
     }
 
-    const char *stdprio = "";
-
-    switch (prio) {
-    case LogLevel::Error:
-        stdprio = STDLOG_LEVEL_ERROR;
-        break;
-    case LogLevel::Warning:
-        stdprio = STDLOG_LEVEL_WARNING;
-        break;
-    case LogLevel::Info:
-        stdprio = STDLOG_LEVEL_INFO;
-        break;
-    case LogLevel::Debug:
-        stdprio = STDLOG_LEVEL_DEBUG;
-        break;
-    case LogLevel::Verbose:
-        stdprio = STDLOG_LEVEL_VERBOSE;
-        break;
-    }
-
-#ifndef _WIN32
-    if (_show_timestamps) {
-        struct timespec res;
-        struct tm tm;
-        clock_gettime(CLOCK_REALTIME, &res);
-        localtime_r(&res.tv_sec, &tm);
-
-        char buf[100];
-        strftime(buf, sizeof(buf), "%Y/%m/%d %H:%M:%S %Z", &tm);
-        fprintf(_stream, "[%s]", buf);
-    }
-#endif
-
-    fprintf(_stream, "%s ", stdprio);
-    vfprintf(_stream, fmt, ap);
-    fprintf(_stream, "\n");
+    fprintf(_stream, "%s\n", rec.fmt_msg.c_str());
     fflush(_stream);
+}
+
+bool StdioLogger::formatted()
+{
+    return true;
 }
 
 }

--- a/libmbpatcher/src/autopatchers/standardpatcher.cpp
+++ b/libmbpatcher/src/autopatchers/standardpatcher.cpp
@@ -28,6 +28,8 @@
 #include "mbpatcher/private/fileutils.h"
 #include "mbpatcher/private/stringutils.h"
 
+#define LOG_TAG "mbpatcher/autopatchers/standardpatcher"
+
 #define DUMP_DEBUG 0
 
 

--- a/libmbpatcher/src/edify/tokenizer.cpp
+++ b/libmbpatcher/src/edify/tokenizer.cpp
@@ -28,6 +28,8 @@
 
 #include "mbpatcher/private/stringutils.h"
 
+#define LOG_TAG "mbpatcher/edify/tokenizer"
+
 namespace mb
 {
 namespace patcher

--- a/libmbpatcher/src/patchers/odinpatcher.cpp
+++ b/libmbpatcher/src/patchers/odinpatcher.cpp
@@ -57,6 +57,8 @@
 // minizip
 #include "minizip/zip.h"
 
+#define LOG_TAG "mbpatcher/patchers/odinpatcher"
+
 class ar;
 
 namespace mb

--- a/libmbpatcher/src/patchers/ramdiskupdater.cpp
+++ b/libmbpatcher/src/patchers/ramdiskupdater.cpp
@@ -31,6 +31,8 @@
 #include "mbpatcher/patchers/zippatcher.h"
 #include "mbpatcher/private/miniziputils.h"
 
+#define LOG_TAG "mbpatcher/patchers/ramdiskupdater"
+
 
 namespace mb
 {

--- a/libmbpatcher/src/patchers/zippatcher.cpp
+++ b/libmbpatcher/src/patchers/zippatcher.cpp
@@ -40,6 +40,8 @@
 #include "minizip/unzip.h"
 #include "minizip/zip.h"
 
+#define LOG_TAG "mbpatcher/patchers/zippatcher"
+
 
 namespace mb
 {

--- a/libmbpatcher/src/private/fileutils.cpp
+++ b/libmbpatcher/src/private/fileutils.cpp
@@ -35,6 +35,8 @@
 #include <sys/stat.h>
 #endif
 
+#define LOG_TAG "mbpatcher/private/fileutils"
+
 
 namespace mb
 {

--- a/libmbpatcher/src/private/miniziputils.cpp
+++ b/libmbpatcher/src/private/miniziputils.cpp
@@ -58,6 +58,8 @@
 
 #include "mbpatcher/private/fileutils.h"
 
+#define LOG_TAG "mbpatcher/private/miniziputils"
+
 
 namespace mb
 {

--- a/libmbsign/src/mbsign.cpp
+++ b/libmbsign/src/mbsign.cpp
@@ -31,6 +31,8 @@
 
 #include "mblog/logging.h"
 
+#define LOG_TAG                 "mbsign"
+
 #define BUFSIZE                 1024 * 8
 
 #define MAGIC                   "!MBSIGN!"
@@ -69,7 +71,7 @@ static int password_callback(char *buf, int size, int rwflag, void *userdata)
     (void) rwflag;
 
     if (userdata) {
-        const char *password = (const char *) userdata;
+        const char *password = static_cast<const char *>(userdata);
 
         int res = strlen(password);
         if (res > size) {

--- a/libmbsign/tests/test_sign.cpp
+++ b/libmbsign/tests/test_sign.cpp
@@ -26,6 +26,8 @@
 #include "mblog/logging.h"
 #include "mbsign/mbsign.h"
 
+#define LOG_TAG "test_sign"
+
 static int log_callback(const char *str, size_t len, void *userdata)
 {
     (void) userdata;

--- a/libmbutil/src/archive.cpp
+++ b/libmbutil/src/archive.cpp
@@ -30,6 +30,8 @@
 #include "mbutil/directory.h"
 #include "mbutil/path.h"
 
+#define LOG_TAG "mbutil/archive"
+
 #define LIBARCHIVE_DISK_WRITER_FLAGS \
     ARCHIVE_EXTRACT_TIME \
     | ARCHIVE_EXTRACT_SECURE_SYMLINKS \

--- a/libmbutil/src/blkid.cpp
+++ b/libmbutil/src/blkid.cpp
@@ -27,6 +27,7 @@
 #include <fcntl.h>
 #include <unistd.h>
 
+#include "mbcommon/error.h"
 #include "mbcommon/finally.h"
 
 // NOTE: We don't use libblkid from util-linux because we don't need most of its
@@ -143,9 +144,8 @@ bool blkid_get_fs_type(const std::string &path, optional<std::string> &type)
     }
 
     auto close_fd = finally([&]{
-        int saved_errno = errno;
+        ErrorRestorer restorer;
         close(fd);
-        errno = saved_errno;
     });
 
     ssize_t n = read_all(fd, buf.data(), buf.size());

--- a/libmbutil/src/chmod.cpp
+++ b/libmbutil/src/chmod.cpp
@@ -31,6 +31,8 @@
 #include "mbutil/fts.h"
 #include "mbutil/string.h"
 
+#define LOG_TAG "mbutil/chmod"
+
 namespace mb
 {
 namespace util

--- a/libmbutil/src/chown.cpp
+++ b/libmbutil/src/chown.cpp
@@ -33,6 +33,8 @@
 #include "mbutil/fts.h"
 #include "mbutil/string.h"
 
+#define LOG_TAG "mbutil/chown"
+
 namespace mb
 {
 namespace util

--- a/libmbutil/src/cmdline.cpp
+++ b/libmbutil/src/cmdline.cpp
@@ -31,6 +31,8 @@
 #include "mbutil/file.h"
 #include "mbutil/string.h"
 
+#define LOG_TAG "mbutil/cmdline"
+
 namespace mb
 {
 namespace util

--- a/libmbutil/src/command.cpp
+++ b/libmbutil/src/command.cpp
@@ -35,6 +35,8 @@
 #include "mblog/logging.h"
 #include "mbutil/string.h"
 
+#define LOG_TAG "mbutil/command"
+
 #define LOG_COMMANDS 0
 
 namespace mb

--- a/libmbutil/src/copy.cpp
+++ b/libmbutil/src/copy.cpp
@@ -35,6 +35,8 @@
 #include "mbutil/path.h"
 #include "mbutil/string.h"
 
+#define LOG_TAG "mbutil/copy"
+
 // WARNING: Everything operates on paths, so it's subject to race conditions
 // Directory copy operations will not cross mountpoint boundaries
 

--- a/libmbutil/src/delete.cpp
+++ b/libmbutil/src/delete.cpp
@@ -29,6 +29,8 @@
 #include "mbutil/fts.h"
 #include "mbutil/string.h"
 
+#define LOG_TAG "mbutil/delete"
+
 namespace mb
 {
 namespace util

--- a/libmbutil/src/external/system_properties.cpp
+++ b/libmbutil/src/external/system_properties.cpp
@@ -60,6 +60,8 @@
 #include "mbutil/external/bionic_lock.h"
 #include "mbutil/external/bionic_macros.h"
 
+#define LOG_TAG "mbutil/external/system_properties"
+
 // NOTE: Not wanted for DualBootPatcher since the properties service
 // initializes before SELinux
 #define MB_ENABLE_SELINUX_OPERATIONS 0

--- a/libmbutil/src/fstab.cpp
+++ b/libmbutil/src/fstab.cpp
@@ -35,6 +35,8 @@
 #include "mbutil/autoclose/file.h"
 #include "mbutil/string.h"
 
+#define LOG_TAG "mbutil/fstab"
+
 
 namespace mb
 {

--- a/libmbutil/src/hash.cpp
+++ b/libmbutil/src/hash.cpp
@@ -23,9 +23,12 @@
 
 #include <cerrno>
 #include <cstdio>
+#include <cstring>
 
 #include "mblog/logging.h"
 #include "mbutil/autoclose/file.h"
+
+#define LOG_TAG "mbutil/hash"
 
 namespace mb
 {

--- a/libmbutil/src/mount.cpp
+++ b/libmbutil/src/mount.cpp
@@ -43,6 +43,8 @@
 #include "mbutil/loopdev.h"
 #include "mbutil/string.h"
 
+#define LOG_TAG "mbutil/mount"
+
 #define MAX_UNMOUNT_TRIES 5
 
 #define DELETED_SUFFIX " (deleted)"

--- a/libmbutil/src/mount.cpp
+++ b/libmbutil/src/mount.cpp
@@ -33,6 +33,7 @@
 #include <sys/vfs.h>
 #include <unistd.h>
 
+#include "mbcommon/error.h"
 #include "mbcommon/finally.h"
 #include "mbcommon/string.h"
 #include "mblog/logging.h"
@@ -292,7 +293,7 @@ bool umount(const std::string &target)
 
     int ret = ::umount(target.c_str());
 
-    int saved_errno = errno;
+    ErrorRestorer restorer;
 
     if (!source.empty()) {
         struct stat sb;
@@ -307,8 +308,6 @@ bool umount(const std::string &target)
             }
         }
     }
-
-    errno = saved_errno;
 
     return ret == 0;
 }

--- a/libmbutil/src/path.cpp
+++ b/libmbutil/src/path.cpp
@@ -30,6 +30,8 @@
 #include "mblog/logging.h"
 #include "mbutil/time.h"
 
+#define LOG_TAG "mbutil/path"
+
 namespace mb
 {
 namespace util

--- a/libmbutil/src/properties.cpp
+++ b/libmbutil/src/properties.cpp
@@ -29,7 +29,6 @@
 #include "mbcommon/common.h"
 #include "mbcommon/finally.h"
 #include "mbcommon/string.h"
-#include "mblog/logging.h"
 #include "mbutil/string.h"
 
 #define _REALLY_INCLUDE_SYS__SYSTEM_PROPERTIES_H_

--- a/libmbutil/src/reboot.cpp
+++ b/libmbutil/src/reboot.cpp
@@ -31,6 +31,8 @@
 
 #include "external/android_reboot.h"
 
+#define LOG_TAG "mbutil/reboot"
+
 namespace mb
 {
 namespace util

--- a/libmbutil/src/selinux.cpp
+++ b/libmbutil/src/selinux.cpp
@@ -35,6 +35,8 @@
 #include "mblog/logging.h"
 #include "mbutil/fts.h"
 
+#define LOG_TAG "mbutil/selinux"
+
 #define SELINUX_XATTR           "security.selinux"
 
 #define OPEN_ATTEMPTS           5

--- a/libmbutil/src/selinux.cpp
+++ b/libmbutil/src/selinux.cpp
@@ -30,6 +30,7 @@
 
 #include <sepol/sepol.h>
 
+#include "mbcommon/error.h"
 #include "mbcommon/finally.h"
 #include "mblog/logging.h"
 #include "mbutil/fts.h"
@@ -419,9 +420,8 @@ bool selinux_get_process_attr(pid_t pid, SELinuxAttr attr,
     }
 
     auto close_fd = finally([&]{
-        int saved_errno = errno;
+        ErrorRestorer restorer;
         close(fd);
-        errno = saved_errno;
     });
 
     std::vector<char> buf(sysconf(_SC_PAGE_SIZE));
@@ -449,9 +449,8 @@ bool selinux_set_process_attr(pid_t pid, SELinuxAttr attr,
     }
 
     auto close_fd = finally([&]{
-        int saved_errno = errno;
+        ErrorRestorer restorer;
         close(fd);
-        errno = saved_errno;
     });
 
     ssize_t n;

--- a/libmbutil/src/vibrate.cpp
+++ b/libmbutil/src/vibrate.cpp
@@ -29,6 +29,8 @@
 #include "mbcommon/finally.h"
 #include "mblog/logging.h"
 
+#define LOG_TAG "mbutil/vibrate"
+
 #define VIBRATOR_PATH           "/sys/class/timed_output/vibrator/enable"
 
 namespace mb

--- a/libmiscstuff-jni/constants.cpp
+++ b/libmiscstuff-jni/constants.cpp
@@ -31,6 +31,8 @@
 
 #include "mblog/logging.h"
 
+#define LOG_TAG "libmiscstuff-jni/constants"
+
 #define CLASS_METHOD(method) \
     Java_com_github_chenxiaolong_dualbootpatcher_nativelib_libmiscstuff_Constants_ ## method
 

--- a/libmiscstuff-jni/jni_load.cpp
+++ b/libmiscstuff-jni/jni_load.cpp
@@ -29,8 +29,7 @@ JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM *vm, void *reserved)
     (void) vm;
     (void) reserved;
 
-    mb::log::set_log_tag("libmiscstuff");
-    mb::log::log_set_logger(std::make_shared<mb::log::AndroidLogger>());
+    mb::log::set_logger(std::make_shared<mb::log::AndroidLogger>());
 
     return JNI_VERSION_1_6;
 }

--- a/libmiscstuff-jni/libmiscstuff.cpp
+++ b/libmiscstuff-jni/libmiscstuff.cpp
@@ -38,6 +38,7 @@
 #include "mblog/android_logger.h"
 #include "mblog/logging.h"
 
+#define LOG_TAG "libmiscstuff-jni/libmiscstuff"
 
 #define CLASS_METHOD(method) \
     Java_com_github_chenxiaolong_dualbootpatcher_nativelib_libmiscstuff_LibMiscStuff_ ## method
@@ -212,8 +213,7 @@ CLASS_METHOD(mblogSetLogcat)(JNIEnv *env, jclass clazz)
     (void) env;
     (void) clazz;
 
-    mb::log::set_log_tag("libmbpatcher");
-    mb::log::log_set_logger(std::make_shared<mb::log::AndroidLogger>());
+    mb::log::set_logger(std::make_shared<mb::log::AndroidLogger>());
 }
 
 struct LaBootImgCtx

--- a/mbbootui/daemon_connection.cpp
+++ b/mbbootui/daemon_connection.cpp
@@ -37,6 +37,8 @@
 #include "../mbtool/protocol/request_generated.h"
 #include "../mbtool/protocol/response_generated.h"
 
+#define LOG_TAG "mbbootui/daemon_connection"
+
 #define SOCKET_ADDRESS                  "mbtool.daemon"
 #define PROTOCOL_VERSION                3
 

--- a/mbbootui/data.cpp
+++ b/mbbootui/data.cpp
@@ -42,6 +42,8 @@
 #include "twrp-functions.hpp"
 #include "variables.h"
 
+#define LOG_TAG "mbbootui/data"
+
 #define DEVID_MAX 64
 #define HWID_MAX 32
 

--- a/mbbootui/find_file.cpp
+++ b/mbbootui/find_file.cpp
@@ -28,6 +28,8 @@
 #include "find_file.hpp"
 #include "twrp-functions.hpp"
 
+#define LOG_TAG "mbbootui/find_file"
+
 std::string Find_File::Find(const std::string& file_name, const std::string& start_path)
 {
     return Find_File().Find_Internal(file_name, start_path);

--- a/mbbootui/gui/action.cpp
+++ b/mbbootui/gui/action.cpp
@@ -46,6 +46,8 @@
 #include "gui/gui.h"
 #include "gui/hardwarekeyboard.hpp"
 
+#define LOG_TAG "mbbootui/gui/action"
+
 GUIAction::mapFunc GUIAction::mf;
 std::unordered_set<std::string> GUIAction::setActionsRunningInCallerThread;
 

--- a/mbbootui/gui/button.cpp
+++ b/mbbootui/gui/button.cpp
@@ -23,6 +23,8 @@
 #include "data.hpp"
 #include "variables.h"
 
+#define LOG_TAG "mbbootui/gui/button"
+
 GUIButton::GUIButton(xml_node<>* node) : GUIObject(node)
 {
     mButtonImg = nullptr;

--- a/mbbootui/gui/fileselector.cpp
+++ b/mbbootui/gui/fileselector.cpp
@@ -29,6 +29,8 @@
 
 #include "data.hpp"
 
+#define LOG_TAG "mbbootui/gui/fileselector"
+
 int GUIFileSelector::mSortOrder = 0;
 
 GUIFileSelector::GUIFileSelector(xml_node<>* node) : GUIScrollList(node)

--- a/mbbootui/gui/fill.cpp
+++ b/mbbootui/gui/fill.cpp
@@ -4,6 +4,8 @@
 
 #include "mblog/logging.h"
 
+#define LOG_TAG "mbbootui/gui/fill"
+
 GUIFill::GUIFill(xml_node<>* node) : GUIObject(node)
 {
     bool has_color = false;

--- a/mbbootui/gui/gui.cpp
+++ b/mbbootui/gui/gui.cpp
@@ -41,6 +41,8 @@
 #include "gui/objects.hpp"
 #include "gui/pages.hpp"
 
+#define LOG_TAG "mbbootui/gui/gui"
+
 // Enable to print render time of each frame to the log file
 //#define PRINT_RENDER_TIME 1
 

--- a/mbbootui/gui/keyboard.cpp
+++ b/mbbootui/gui/keyboard.cpp
@@ -29,6 +29,8 @@
 
 #include "gui/gui.h"
 
+#define LOG_TAG "mbbootui/gui/keyboard"
+
 bool GUIKeyboard::CtrlActive = false;
 
 GUIKeyboard::GUIKeyboard(xml_node<>* node)

--- a/mbbootui/gui/monotonic_cond.cpp
+++ b/mbbootui/gui/monotonic_cond.cpp
@@ -24,6 +24,8 @@
 
 #include "mblog/logging.h"
 
+#define LOG_TAG "mbbootui/gui/monotonic_cond"
+
 MonotonicCond::MonotonicCond::MonotonicCond() : m_initialized(false)
 {
     if (pthread_condattr_init(&m_condattr) < 0) {

--- a/mbbootui/gui/pages.cpp
+++ b/mbbootui/gui/pages.cpp
@@ -65,6 +65,8 @@
 #include "gui/text.hpp"
 #include "gui/textbox.hpp"
 
+#define LOG_TAG "mbbootui/gui/pages"
+
 #define TW_THEME_VERSION 1
 #define TW_THEME_VER_ERR -2
 

--- a/mbbootui/gui/patternpassword.cpp
+++ b/mbbootui/gui/patternpassword.cpp
@@ -7,6 +7,8 @@
 
 #include "config/config.hpp"
 
+#define LOG_TAG "mbbootui/gui/patternpassword"
+
 GUIPatternPassword::GUIPatternPassword(xml_node<>* node) : GUIObject(node)
 {
     xml_node<>* child;

--- a/mbbootui/gui/progressbar.cpp
+++ b/mbbootui/gui/progressbar.cpp
@@ -7,6 +7,8 @@
 #include "data.hpp"
 #include "variables.h"
 
+#define LOG_TAG "mbbootui/gui/progressbar"
+
 GUIProgressBar::GUIProgressBar(xml_node<>* node) : GUIObject(node)
 {
     xml_node<>* child;

--- a/mbbootui/gui/resources.cpp
+++ b/mbbootui/gui/resources.cpp
@@ -14,6 +14,8 @@
 
 #include "gui/gui.h"
 
+#define LOG_TAG "mbbootui/gui/resources"
+
 #define TMP_RESOURCE_NAME   "/tmp/extract.bin"
 
 Resource::Resource(xml_node<>* node, ZipArchive* pZip __unused)

--- a/mbbootui/gui/slider.cpp
+++ b/mbbootui/gui/slider.cpp
@@ -8,6 +8,8 @@
 #include "data.hpp"
 #include "variables.h"
 
+#define LOG_TAG "mbbootui/gui/slider"
+
 GUISlider::GUISlider(xml_node<>* node) : GUIObject(node)
 {
     xml_node<>* child;

--- a/mbbootui/gui/slidervalue.cpp
+++ b/mbbootui/gui/slidervalue.cpp
@@ -8,6 +8,8 @@
 
 #include "mblog/logging.h"
 
+#define LOG_TAG "mbbootui/gui/slidervalue"
+
 GUISliderValue::GUISliderValue(xml_node<>* node) : GUIObject(node)
 {
     xml_attribute<>* attr;

--- a/mbbootui/gui/terminal.cpp
+++ b/mbbootui/gui/terminal.cpp
@@ -35,6 +35,8 @@
 #include "data.hpp"
 #include "variables.h"
 
+#define LOG_TAG "mbbootui/gui/terminal"
+
 #if 0
 #define debug_printf printf
 #else

--- a/mbbootui/infomanager.cpp
+++ b/mbbootui/infomanager.cpp
@@ -26,6 +26,8 @@
 
 #include "infomanager.hpp"
 
+#define LOG_TAG "mbbootui/infomanager"
+
 InfoManager::InfoManager()
 {
     file_version = 0;

--- a/mbbootui/main.cpp
+++ b/mbbootui/main.cpp
@@ -51,6 +51,8 @@
 
 #include "config/config.hpp"
 
+#define LOG_TAG "mbbootui/main"
+
 #define APPEND_TO_LOG               1
 
 #define MAX_LOG_SIZE                (1024 * 1024) /* 1MiB */
@@ -537,14 +539,7 @@ static int log_bridge(int prio, const char *tag, const char *fmt, va_list ap)
         break;
     }
 
-    char newfmt[512];
-    if (snprintf(newfmt, sizeof(newfmt), "[%s] %s", tag, fmt)
-            >= (int) sizeof(newfmt)) {
-        // Doesn't fit
-        return -1;
-    }
-
-    mb::log::logv(level, newfmt, ap);
+    mb::log::log(level, "[%s] %s", tag, mb::format_v(fmt, ap).c_str());
     return 0;
 }
 

--- a/mbbootui/twrp-functions.cpp
+++ b/mbbootui/twrp-functions.cpp
@@ -40,6 +40,8 @@
 #include "data.hpp"
 #include "variables.h"
 
+#define LOG_TAG "mbbootui/twrp-functions"
+
 std::string TWFunc::get_resource_path(const std::string &res_path)
 {
     std::string result;

--- a/mbtool/appsync.cpp
+++ b/mbtool/appsync.cpp
@@ -63,6 +63,8 @@
 #include "romconfig.h"
 #include "roms.h"
 
+#define LOG_TAG "mbtool/appsync"
+
 #define ANDROID_SOCKET_ENV_PREFIX       "ANDROID_SOCKET_"
 #define ANDROID_SOCKET_DIR              "/dev/socket"
 
@@ -933,7 +935,7 @@ int appsync_main(int argc, char *argv[])
     fix_multiboot_permissions();
 
     // mbtool logging
-    log::log_set_logger(std::make_shared<log::StdioLogger>(fp.get(), true));
+    log::set_logger(std::make_shared<log::StdioLogger>(fp.get()));
 
     LOGI("=== APPSYNC VERSION %s ===", version());
 

--- a/mbtool/appsyncmanager.cpp
+++ b/mbtool/appsyncmanager.cpp
@@ -33,6 +33,8 @@
 #include "mbutil/fts.h"
 #include "mbutil/selinux.h"
 
+#define LOG_TAG "mbtool/appsyncmanager"
+
 #define APP_SHARING_DATA_DIR            "/data/multiboot/_appsharing/data"
 
 #define USER_DATA_DIR                   "/data/data"

--- a/mbtool/archive_util.cpp
+++ b/mbtool/archive_util.cpp
@@ -24,6 +24,8 @@
 
 #include "mblog/logging.h"
 
+#define LOG_TAG "mbtool/archive_util"
+
 #define BUF_SIZE    10240
 
 namespace mb

--- a/mbtool/auditd.cpp
+++ b/mbtool/auditd.cpp
@@ -32,6 +32,8 @@
 
 #include "external/audit/libaudit.h"
 
+#define LOG_TAG "mbtool/auditd"
+
 
 namespace mb
 {

--- a/mbtool/backup.cpp
+++ b/mbtool/backup.cpp
@@ -54,6 +54,8 @@
 #include "roms.h"
 #include "wipe.h"
 
+#define LOG_TAG "mbtool/backup"
+
 #define BACKUP_MNT_DIR          "/mb_mnt"
 
 namespace mb

--- a/mbtool/bootimg_util.cpp
+++ b/mbtool/bootimg_util.cpp
@@ -27,6 +27,8 @@
 
 #include "mblog/logging.h"
 
+#define LOG_TAG "mbtool/bootimg_util"
+
 #define BUF_SIZE    10240
 
 typedef std::unique_ptr<FILE, decltype(fclose) *> ScopedFILE;

--- a/mbtool/daemon.cpp
+++ b/mbtool/daemon.cpp
@@ -52,6 +52,8 @@
 #include "sepolpatch.h"
 #include "validcerts.h"
 
+#define LOG_TAG "mbtool/daemon"
+
 #define RESPONSE_ALLOW "ALLOW"                  // Credentials allowed
 #define RESPONSE_DENY "DENY"                    // Credentials denied
 #define RESPONSE_OK "OK"                        // Generic accepted response
@@ -343,7 +345,7 @@ static bool daemon_init()
     if (log_to_stdio) {
         // Default; do nothing
     } else if (log_to_kmsg) {
-        log::log_set_logger(std::make_shared<log::KmsgLogger>(false));
+        log::set_logger(std::make_shared<log::KmsgLogger>(false));
     } else {
         if (!util::mkdir_parent(MULTIBOOT_LOG_DAEMON, 0775)
                 && errno != EEXIST) {
@@ -363,8 +365,7 @@ static bool daemon_init()
         fix_multiboot_permissions();
 
         // mbtool logging
-        log::log_set_logger(
-                std::make_shared<log::StdioLogger>(log_fp.get(), true));
+        log::set_logger(std::make_shared<log::StdioLogger>(log_fp.get()));
     }
 
     LOGD("Initialized daemon");

--- a/mbtool/daemon_v3.cpp
+++ b/mbtool/daemon_v3.cpp
@@ -55,6 +55,8 @@
 #include "protocol/request_generated.h"
 #include "protocol/response_generated.h"
 
+#define LOG_TAG "mbtool/daemon_v3"
+
 namespace mb
 {
 

--- a/mbtool/emergency.cpp
+++ b/mbtool/emergency.cpp
@@ -42,6 +42,8 @@
 #include "multiboot.h"
 #include "reboot.h"
 
+#define LOG_TAG "mbtool/emergency"
+
 using namespace mb::device;
 
 namespace mb

--- a/mbtool/external/legacy_property_service.cpp
+++ b/mbtool/external/legacy_property_service.cpp
@@ -38,6 +38,7 @@
 
 #include "legacy_property_service.h"
 
+#include "mbcommon/error.h"
 #include "mbutil/properties.h"
 
 
@@ -45,11 +46,10 @@
 extern "C" int
 __futex_wake(volatile void *ftx, int count)
 {
-    int saved_errno = errno;
+    mb::ErrorRestorer restorer;
     int result = syscall(__NR_futex, ftx, FUTEX_WAKE, count, NULL);
     if (__builtin_expect(result == -1, 0)) {
         result = -errno;
-        errno = saved_errno;
     }
     return result;
 }

--- a/mbtool/external/property_service.cpp
+++ b/mbtool/external/property_service.cpp
@@ -51,6 +51,8 @@
 
 #include "property_service.h"
 
+#define LOG_TAG "mbtool/external/property_service"
+
 #define ALLOW_LOCAL_PROP_OVERRIDE 1
 
 static int property_set_fd = -1;

--- a/mbtool/image.cpp
+++ b/mbtool/image.cpp
@@ -34,6 +34,8 @@
 #include "mbutil/path.h"
 #include "mbutil/string.h"
 
+#define LOG_TAG "mbtool/image"
+
 namespace mb
 {
 

--- a/mbtool/init.cpp
+++ b/mbtool/init.cpp
@@ -88,6 +88,8 @@
 #error Unknown PCRE path for architecture
 #endif
 
+#define LOG_TAG "mbtool/init"
+
 using namespace mb::device;
 
 namespace mb
@@ -1164,7 +1166,7 @@ int init_main(int argc, char *argv[])
     open_devnull_stdio();
 
     // Log to kmsg
-    log::log_set_logger(std::make_shared<log::KmsgLogger>(true));
+    log::set_logger(std::make_shared<log::KmsgLogger>(true));
     if (klogctl(KLOG_CONSOLE_LEVEL, nullptr, 7) < 0) {
         LOGE("Failed to set loglevel: %s", strerror(errno));
     }

--- a/mbtool/initwrapper/devices.cpp
+++ b/mbtool/initwrapper/devices.cpp
@@ -42,6 +42,8 @@
 #include "initwrapper/cutils/uevent.h"
 #include "initwrapper/util.h"
 
+#define LOG_TAG "mbtool/initwrapper/devices"
+
 #define DEVPATH_LEN 96
 
 #define UEVENT_LOGGING 0

--- a/mbtool/initwrapper/util.cpp
+++ b/mbtool/initwrapper/util.cpp
@@ -26,6 +26,8 @@
 #include "mbutil/directory.h"
 #include "mbutil/path.h"
 
+#define LOG_TAG "mbtool/initwrapper/util"
+
 /*
  * replaces any unacceptable characters with '_', the
  * length of the resulting string is equal to the input string

--- a/mbtool/installer.cpp
+++ b/mbtool/installer.cpp
@@ -78,6 +78,7 @@
 #include "switcher.h"
 #include "wipe.h"
 
+#define LOG_TAG "mbtool/installer"
 
 // Set to 1 to spawn a shell after installation
 // NOTE: This should ONLY be used through adb. For example:

--- a/mbtool/installer_util.cpp
+++ b/mbtool/installer_util.cpp
@@ -50,6 +50,8 @@
 #include "bootimg_util.h"
 #include "multiboot.h"
 
+#define LOG_TAG "mbtool/installer_util"
+
 using namespace mb::bootimg;
 
 typedef std::unique_ptr<archive, decltype(archive_free) *> ScopedArchive;

--- a/mbtool/main.cpp
+++ b/mbtool/main.cpp
@@ -44,7 +44,6 @@
 #endif
 
 #include "mbcommon/version.h"
-#include "mblog/logging.h"
 #include "mbutil/process.h"
 #include "mbutil/string.h"
 

--- a/mbtool/miniadbd.cpp
+++ b/mbtool/miniadbd.cpp
@@ -39,6 +39,8 @@
 #include "mbutil/mount.h"
 #include "mbutil/properties.h"
 
+#define LOG_TAG "mbtool/miniadbd"
+
 
 namespace mb
 {

--- a/mbtool/miniadbd/adb_log.h
+++ b/mbtool/miniadbd/adb_log.h
@@ -18,6 +18,8 @@
 
 #include "mblog/logging.h"
 
+#define LOG_TAG "mbtool/miniadbd"
+
 enum AdbComponents : int
 {
     ADB_LLIO    = 0x1u,  // Low-level I/O

--- a/mbtool/mount_fstab.cpp
+++ b/mbtool/mount_fstab.cpp
@@ -60,6 +60,8 @@
 #include "signature.h"
 #include "initwrapper/devices.h"
 
+#define LOG_TAG "mbtool/mount_fstab"
+
 #define SYSTEM_MOUNT_POINT          "/raw/system"
 #define CACHE_MOUNT_POINT           "/raw/cache"
 #define DATA_MOUNT_POINT            "/raw/data"

--- a/mbtool/multiboot.cpp
+++ b/mbtool/multiboot.cpp
@@ -33,6 +33,8 @@
 #include "mbutil/selinux.h"
 #include "mbutil/string.h"
 
+#define LOG_TAG "mbtool/multiboot"
+
 
 namespace mb
 {

--- a/mbtool/packages.cpp
+++ b/mbtool/packages.cpp
@@ -30,6 +30,8 @@
 
 #include "mblog/logging.h"
 
+#define LOG_TAG "mbtool/packages"
+
 
 namespace mb
 {

--- a/mbtool/properties.cpp
+++ b/mbtool/properties.cpp
@@ -28,8 +28,8 @@
 #include <getopt.h>
 
 #include "mbcommon/string.h"
-#include "mblog/logging.h"
 #include "mbutil/properties.h"
+
 
 namespace mb
 {
@@ -134,7 +134,7 @@ int properties_main(int argc, char *argv[])
             return EXIT_FAILURE;
         }
     } else {
-        LOGE("Unknown action: %s", action);
+        fprintf(stderr, "Unknown action: %s\n", action);
         properties_usage(stderr);
         return EXIT_FAILURE;
     }

--- a/mbtool/ramdisk_patcher.cpp
+++ b/mbtool/ramdisk_patcher.cpp
@@ -36,6 +36,8 @@
 
 #include "installer_util.h"
 
+#define LOG_TAG "mbtool/ramdisk_patcher"
+
 namespace mb
 {
 

--- a/mbtool/reboot.cpp
+++ b/mbtool/reboot.cpp
@@ -21,7 +21,6 @@
 
 #include <unistd.h>
 
-#include "mblog/logging.h"
 #include "mbutil/reboot.h"
 
 

--- a/mbtool/rom_installer.cpp
+++ b/mbtool/rom_installer.cpp
@@ -50,6 +50,7 @@
 #include "installer.h"
 #include "multiboot.h"
 
+#define LOG_TAG "mbtool/rom_installer"
 
 #define DEBUG_LEAVE_STDIN_OPEN 0
 #define DEBUG_ENABLE_PASSTHROUGH 0
@@ -606,7 +607,7 @@ int rom_installer_main(int argc, char *argv[])
 #endif
 
     // mbtool logging
-    log::log_set_logger(std::make_shared<log::StdioLogger>(fp.get(), false));
+    log::set_logger(std::make_shared<log::StdioLogger>(fp.get()));
 
     // Start installing!
     RomInstaller ri(zip_file, rom_id, fp.get(), flags);

--- a/mbtool/romconfig.cpp
+++ b/mbtool/romconfig.cpp
@@ -26,6 +26,8 @@
 
 #include "mblog/logging.h"
 
+#define LOG_TAG "mbtool/romconfig"
+
 #define CONFIG_KEY_ID                      "id"
 #define CONFIG_KEY_NAME                    "name"
 #define CONFIG_KEY_APP_SHARING             "app_sharing"

--- a/mbtool/roms.cpp
+++ b/mbtool/roms.cpp
@@ -37,6 +37,8 @@
 
 #include "multiboot.h"
 
+#define LOG_TAG "mbtool/roms"
+
 #define BUILD_PROP "build.prop"
 
 static std::vector<std::string> extsd_mount_points{

--- a/mbtool/sepolpatch.cpp
+++ b/mbtool/sepolpatch.cpp
@@ -47,6 +47,8 @@
 
 #include "multiboot.h"
 
+#define LOG_TAG "mbtool/sepolpatch"
+
 
 extern "C" int policydb_index_decls(policydb_t *p);
 

--- a/mbtool/signature.cpp
+++ b/mbtool/signature.cpp
@@ -33,6 +33,8 @@
 
 #include "validcerts.h"
 
+#define LOG_TAG "mbtool/signature"
+
 #define COMPILE_ERROR_STRINGS 0
 
 namespace mb

--- a/mbtool/switcher.cpp
+++ b/mbtool/switcher.cpp
@@ -44,6 +44,8 @@
 #include "multiboot.h"
 #include "roms.h"
 
+#define LOG_TAG "mbtool/switcher"
+
 #define CHECKSUMS_PATH "/data/multiboot/checksums.prop"
 
 namespace mb

--- a/mbtool/uevent_dump.cpp
+++ b/mbtool/uevent_dump.cpp
@@ -23,7 +23,6 @@
 #include <getopt.h>
 
 #include "mbcommon/version.h"
-#include "mblog/logging.h"
 
 #include "initwrapper/devices.h"
 
@@ -71,7 +70,7 @@ int uevent_dump_main(int argc, char *argv[])
         return EXIT_FAILURE;
     }
 
-    LOGV("mbtool version %s (%s)", version(), git_version());
+    printf("mbtool version %s (%s)\n", version(), git_version());
 
     // Start probing for devices
     device_init(true);

--- a/mbtool/update_binary.cpp
+++ b/mbtool/update_binary.cpp
@@ -41,6 +41,8 @@
 #include "multiboot.h"
 #include "sepolpatch.h"
 
+#define LOG_TAG "mbtool/update_binary"
+
 
 namespace mb
 {
@@ -214,7 +216,7 @@ int update_binary_main(int argc, char *argv[])
     zip_file = argv[3];
 
     // stdout is messed up when it's appended to /tmp/recovery.log
-    log::log_set_logger(std::make_shared<log::StdioLogger>(stderr, false));
+    log::set_logger(std::make_shared<log::StdioLogger>(stderr));
 
     RecoveryInstaller ri(zip_file, interface, output_fd);
     return ri.start_installation() ? EXIT_SUCCESS : EXIT_FAILURE;

--- a/mbtool/update_binary_tool.cpp
+++ b/mbtool/update_binary_tool.cpp
@@ -36,6 +36,8 @@
 #include "wipe.h"
 
 
+#define LOG_TAG "mbtool/update_binary_tool"
+
 #define ACTION_MOUNT "mount"
 #define ACTION_UNMOUNT "unmount"
 #define ACTION_FORMAT "format"
@@ -218,7 +220,7 @@ int update_binary_tool_main(int argc, char *argv[])
     }
 
     // Log to stderr, so the output is ordered correctly in /tmp/recovery.log
-    log::log_set_logger(std::make_shared<log::StdioLogger>(stderr, false));
+    log::set_logger(std::make_shared<log::StdioLogger>(stderr));
 
     const char *action = argv[optind];
     const char *mountpoint = argv[optind + 1];

--- a/mbtool/utilities.cpp
+++ b/mbtool/utilities.cpp
@@ -50,6 +50,8 @@
 #include "switcher.h"
 #include "wipe.h"
 
+#define LOG_TAG "mbtool/utilities"
+
 using namespace mb::device;
 
 namespace mb
@@ -463,7 +465,7 @@ int utilities_main(int argc, char *argv[])
     // Make stdout unbuffered
     setvbuf(stdout, nullptr, _IONBF, 0);
 
-    log::log_set_logger(std::make_shared<log::StdioLogger>(stdout, false));
+    log::set_logger(std::make_shared<log::StdioLogger>(stdout));
 
     bool force = false;
 

--- a/mbtool/wipe.cpp
+++ b/mbtool/wipe.cpp
@@ -36,6 +36,8 @@
 
 #include "multiboot.h"
 
+#define LOG_TAG "mbtool/wipe"
+
 namespace mb
 {
 
@@ -159,7 +161,7 @@ static bool log_wipe_file(const std::string &path)
  *       deletion does not follow symlinks.
  *
  * \param mountpoint Mountpoint root to wipe
- * \param wipe_media Whether the first-level "media" path should be deleted
+ * \param exclusions List of first-level paths to exclude
  *
  * \return True if the path was wiped or doesn't exist. False, otherwise
  */


### PR DESCRIPTION
* Every log call must provide a tag to indicate the source of the
  message
* Function have been renamed to match the conventions set by the other
  libraries
* All loggers, aside from the logcat logger, log in the same format now
* The time format and the log message format are both customizable
* Each logger has access to the raw log record, which includes the
  time, process ID, thread ID, log priority, log tag, raw log message,
  and, optionally, the formatted log message