### PR TITLE
libmbcommon,libmbsparse: Fix zero-length format string warnings

### DIFF
--- a/libmbcommon/CMakeLists.txt
+++ b/libmbcommon/CMakeLists.txt
@@ -105,6 +105,11 @@ foreach(variant ${variants})
     # Export symbols
     target_compile_definitions(${lib_target} PRIVATE -DMB_LIBRARY)
 
+    # Don't warn on empty format strings
+    if(NOT MSVC)
+        target_compile_options(${lib_target} PRIVATE -Wno-format-zero-length)
+    endif()
+
     # Win32 DLL export
     if(${variant} STREQUAL shared)
         target_compile_definitions(${lib_target} PRIVATE -DMB_DYNAMIC_LINK)
@@ -151,6 +156,11 @@ if(variants AND MBP_ENABLE_TESTS)
         mbcommon_tests
         ${MBCOMMON_TESTS_SOURCES}
     )
+
+    # Don't warn on empty format strings
+    if(NOT MSVC)
+        target_compile_options(mbcommon_tests PRIVATE -Wno-format-zero-length)
+    endif()
 
     # Link dependencies
     target_link_libraries(

--- a/libmbsparse/tests/test_sparse.cpp
+++ b/libmbsparse/tests/test_sparse.cpp
@@ -53,7 +53,8 @@ protected:
             return false;
         }
 
-        set_error(mb::make_error_code(mb::FileError::UnsupportedSeek), "");
+        set_error(mb::make_error_code(mb::FileError::UnsupportedSeek),
+                  "seek not supported");
         return false;
     }
 


### PR DESCRIPTION
Signed-off-by: Andrew Gunnerson <chenxiaolong@cxl.epac.to>