### PR TITLE
libmbcommon: Cast enum class to integer before passing to printf

### DIFF
--- a/libmbcommon/src/file/fd.cpp
+++ b/libmbcommon/src/file/fd.cpp
@@ -313,7 +313,7 @@ bool FdFile::open(const std::string &filename, FileOpenMode mode)
         int flags = priv->convert_mode(mode);
         if (flags < 0) {
             set_error(make_error_code(FileError::InvalidMode),
-                      "Invalid mode: %d", mode);
+                      "Invalid mode: %d", static_cast<int>(mode));
             return false;
         }
 
@@ -357,7 +357,7 @@ bool FdFile::open(const std::wstring &filename, FileOpenMode mode)
         int flags = priv->convert_mode(mode);
         if (flags < 0) {
             set_error(make_error_code(FileError::InvalidMode),
-                      "Invalid mode: %d", mode);
+                      "Invalid mode: %d", static_cast<int>(mode));
             return false;
         }
 

--- a/libmbcommon/src/file/posix.cpp
+++ b/libmbcommon/src/file/posix.cpp
@@ -339,7 +339,7 @@ bool PosixFile::open(const std::string &filename, FileOpenMode mode)
         auto mode_str = priv->convert_mode(mode);
         if (!mode_str) {
             set_error(make_error_code(FileError::InvalidMode),
-                      "Invalid mode: %d", mode);
+                      "Invalid mode: %d", static_cast<int>(mode));
             return false;
         }
 
@@ -383,7 +383,7 @@ bool PosixFile::open(const std::wstring &filename, FileOpenMode mode)
         auto mode_str = priv->convert_mode(mode);
         if (!mode_str) {
             set_error(make_error_code(FileError::InvalidMode),
-                      "Invalid mode: %d", mode);
+                      "Invalid mode: %d", static_cast<int>(mode));
             return false;
         }
 

--- a/libmbcommon/src/file/win32.cpp
+++ b/libmbcommon/src/file/win32.cpp
@@ -355,7 +355,7 @@ bool Win32File::open(const std::string &filename, FileOpenMode mode)
         if (!priv->convert_mode(mode, access, sharing, sa, creation, attrib,
                                 append)) {
             set_error(make_error_code(FileError::InvalidMode),
-                      "Invalid mode: %d", mode);
+                      "Invalid mode: %d", static_cast<int>(mode));
             return false;
         }
 
@@ -396,7 +396,7 @@ bool Win32File::open(const std::wstring &filename, FileOpenMode mode)
         if (!priv->convert_mode(mode, access, sharing, sa, creation, attrib,
                                 append)) {
             set_error(make_error_code(FileError::InvalidMode),
-                      "Invalid mode: %d", mode);
+                      "Invalid mode: %d", static_cast<int>(mode));
             return false;
         }
 


### PR DESCRIPTION
Signed-off-by: Andrew Gunnerson <chenxiaolong@cxl.epac.to>