### PR TITLE
libmbutil: selinux.cpp: Use mb::format() instead of asprintf()

### DIFF
--- a/libmbutil/src/selinux.cpp
+++ b/libmbutil/src/selinux.cpp
@@ -32,6 +32,7 @@
 
 #include "mbcommon/error.h"
 #include "mbcommon/finally.h"
+#include "mbcommon/string.h"
 #include "mblog/logging.h"
 #include "mbutil/fts.h"
 
@@ -376,41 +377,25 @@ static int open_attr(pid_t pid, SELinuxAttr attr, int flags)
         return false;
     }
 
-    int fd;
-    int ret;
-    char *path;
-    pid_t tid;
+    std::string path;
 
     if (pid > 0) {
-        ret = asprintf(&path, "/proc/%d/attr/%s", pid, attr_name);
+        path = format("/proc/%d/attr/%s", pid, attr_name);
     } else if (pid == 0) {
-        ret = asprintf(&path, "/proc/thread-self/attr/%s", attr_name);
-        if (ret < 0) {
-            return -1;
-        }
+        path = format("/proc/thread-self/attr/%s", attr_name);
 
-        fd = open(path, flags | O_CLOEXEC);
+        int fd = open(path.c_str(), flags | O_CLOEXEC);
         if (fd >= 0 || errno != ENOENT) {
-            goto out;
+            return fd;
         }
 
-        free(path);
-        tid = gettid();
-        ret = asprintf(&path, "/proc/self/task/%d/attr/%s", tid, attr_name);
+        path = format("/proc/self/task/%d/attr/%s", gettid(), attr_name);
     } else {
         errno = EINVAL;
         return -1;
     }
 
-    if (ret < 0) {
-        return -1;
-    }
-
-    fd = open(path, flags | O_CLOEXEC);
-
-out:
-    free(path);
-    return fd;
+    return open(path.c_str(), flags | O_CLOEXEC);
 }
 
 bool selinux_get_process_attr(pid_t pid, SELinuxAttr attr,


### PR DESCRIPTION
Signed-off-by: Andrew Gunnerson <chenxiaolong@cxl.epac.to>