### PR TITLE
devices: Add Motorola Moto X Pro (shamu_t)

### DIFF
--- a/data/devices/motorola.yml
+++ b/data/devices/motorola.yml
@@ -452,6 +452,33 @@
       - /dev/block/mmcblk0p37
 
 
+- name: Motorola Moto X Pro
+  id: shamu_t
+  codenames:
+    - shamu_t
+    - shamu_cn
+  architecture: armeabi-v7a
+
+  block_devs:
+    base_dirs:
+      - /dev/block/platform/msm_sdcc.1/by-name
+    system:
+      - /dev/block/platform/msm_sdcc.1/by-name/system
+      - /dev/block/mmcblk0p40
+    cache:
+      - /dev/block/platform/msm_sdcc.1/by-name/cache
+      - /dev/block/mmcblk0p39
+    data:
+      - /dev/block/platform/msm_sdcc.1/by-name/userdata
+      - /dev/block/mmcblk0p41
+    boot:
+      - /dev/block/platform/msm_sdcc.1/by-name/boot
+      - /dev/block/mmcblk0p36
+    recovery:
+      - /dev/block/platform/msm_sdcc.1/by-name/recovery
+      - /dev/block/mmcblk0p37
+
+
 - name: Motorola Moto G4 & G4 Plus Edition
   id: athene
   codenames:


### PR DESCRIPTION
Add Moto X Pro support.
This is a old device, the hardware almost like nexus 6, released in 2015, china retail version.