### PR TITLE
Update Device Name for "Primo RX5"

### DIFF
--- a/data/devices/walton.yml
+++ b/data/devices/walton.yml
@@ -112,7 +112,7 @@
     cpu_temp_path:  /sys/devices/virtual/thermal/thermal_zone1/temp
     theme: portrait_hdpi
 
-- name: Primo RX5
+- name: Walton Primo RX5
   id: Primo_RX5
   codenames:
     - Primo_RX5


### PR DESCRIPTION
The Device Name "**Primo RX5**" was not complete and not easily find-able from the Download section.

I forgot to add the Vendor name "**Walton**" in the starting.
So, now I used the Complete Device Name as "**Walton Primo RX5**" which also includes Company name.