### PR TITLE
bootui: Fix all missing devices

### DIFF
--- a/data/devices/ark.yml
+++ b/data/devices/ark.yml
@@ -27,7 +27,7 @@
       - /dev/block/bootdevice/by-name/recovery
       - /dev/block/mmcblk0p21
 
-boot_ui:
+  boot_ui:
     supported: true
     flags:
       - TW_QCOM_RTC_FIX

--- a/data/devices/asus.yml
+++ b/data/devices/asus.yml
@@ -31,7 +31,7 @@
       - /dev/block/by-name/recovery
       - /dev/block/mmcblk0p2
 
-boot_ui:
+  boot_ui:
     supported: true
     graphics_backends:
       - fbdev

--- a/data/devices/cagabi.yml
+++ b/data/devices/cagabi.yml
@@ -35,5 +35,5 @@
       - fbdev
     brightness_path: /sys/class/leds/lcd-backlight/brightness
     max_brightness: 255
-    cpu_temp_path:  /sys/devices/virtual/thermal/thermal_zone1/temp
+    cpu_temp_path: /sys/devices/virtual/thermal/thermal_zone1/temp
     theme: portrait_hdpi

--- a/data/devices/coolpad.yml
+++ b/data/devices/coolpad.yml
@@ -66,7 +66,6 @@
       - fbdev
     theme: portrait_hdpi
 
-
 - name: Coolpad Note 3
   id: CP8676_I02
   codenames:
@@ -131,7 +130,6 @@
     graphics_backends:
       - fbdev
     theme: portrait_hdpi
-
 
 - name: Coolpad Note 3 Plus
   id: CP8676_I03

--- a/data/devices/dexp.yml
+++ b/data/devices/dexp.yml
@@ -24,7 +24,6 @@
       - /dev/block/bootdevice/by-name/recovery
       - /dev/block/mmcblk0p24
 
-
 - name: DEXP M LTE 5
   id: mlte5
   codenames:
@@ -50,7 +49,7 @@
       - /dev/block/bootdevice/by-name/recovery
       - /dev/block/mmcblk0p24
 
-boot_ui:
+  boot_ui:
     supported: true
     flags:
       - TW_QCOM_RTC_FIX

--- a/data/devices/doogee.yml
+++ b/data/devices/doogee.yml
@@ -34,7 +34,7 @@
       - fbdev
     brightness_path: /sys/class/leds/lcd-backlight/brightness
     max_brightness: 255
-    cpu_temp_path:  /sys/devices/virtual/thermal/thermal_zone1/temp
+    cpu_temp_path: /sys/devices/virtual/thermal/thermal_zone1/temp
     theme: portrait_hdpi
 
 - name: Doogee x6
@@ -74,5 +74,5 @@
       - fbdev
     brightness_path: /sys/class/leds/lcd-backlight/brightness
     max_brightness: 255
-    cpu_temp_path:  /sys/devices/virtual/thermal/thermal_zone1/temp
+    cpu_temp_path: /sys/devices/virtual/thermal/thermal_zone1/temp
     theme: portrait_hdpi

--- a/data/devices/elephone.yml
+++ b/data/devices/elephone.yml
@@ -40,11 +40,11 @@
       - /dev/block/platform/mtk-msdc.0/11230000.MSDC0/by-name/recovery
       - /dev/block/mmcblk0p8
 
-boot_ui:
+  boot_ui:
     supported: true
     graphics_backends:
       - fbdev
-    brightness_path: /sys/devices/platform/leds-mt65xx/leds/lcd-backlight/brightness/
+    brightness_path: /sys/devices/platform/leds-mt65xx/leds/lcd-backlight/brightness
     max_brightness: 255
     default_brightness: 162
     pixel_format: RGBX_8888
@@ -77,7 +77,7 @@ boot_ui:
       - /dev/block/platform/mtk-msdc.0/11230000.msdc0/by-name/recovery
       - /dev/block/mmcblk0p1
 
-boot_ui:
+  boot_ui:
     supported: true
     flags:
       - TW_NO_SCREEN_BLANK
@@ -113,7 +113,7 @@ boot_ui:
       - /dev/block/platform/mtk-msdc.0/by-name/recovery
       - /dev/block/mmcblk0p8
 
-boot_ui:
+  boot_ui:
     supported: true
     graphics_backends:
       - fbdev

--- a/data/devices/google.yml
+++ b/data/devices/google.yml
@@ -36,7 +36,6 @@
     cpu_temp_path:  /sys/devices/virtual/thermal/thermal_zone1/temp
     theme: portrait_hdpi
 
-
 - name: Android One 2nd Gen - IQ II, GM4G
   id: seed
   codenames:
@@ -62,7 +61,7 @@
       - /dev/block/platform/msm_sdcc.1/by-name/recovery
       - /dev/block/mmcblk0p26
 
-boot_ui:
+  boot_ui:
     supported: true
     flags:
       - TW_QCOM_RTC_FIX

--- a/data/devices/gree.yml
+++ b/data/devices/gree.yml
@@ -36,7 +36,7 @@
       - /dev/block/bootdevice/by-name/recovery
       - /dev/block/sde19
 
-boot_ui:
+  boot_ui:
     supported: true
     flags:
       - TW_NO_SCREEN_BLANK

--- a/data/devices/htc.yml
+++ b/data/devices/htc.yml
@@ -146,7 +146,7 @@
       - /dev/block/platform/msm_sdcc.1/by-name/recovery
       - /dev/block/mmcblk0p43
 
-boot_ui:
+  boot_ui:
     supported: true
     flags:
       - TW_NO_SCREEN_BLANK

--- a/data/devices/huawei.yml
+++ b/data/devices/huawei.yml
@@ -24,14 +24,13 @@
       - /dev/block/platform/hi_mci.0/by-name/recovery
       - /dev/block/mmcblk0p18
 
-boot_ui:
+  boot_ui:
     supported: true
     graphics_backends:
       - fbdev
     brightness_path: /sys/devices/platform/k3_fb.1/leds/lcd_backlight0/brightness
     max_brightness: 255
     default_brightness: 162
-    pixel_format: RGB_8888
     battery_path: /sys/devices/platform/bq_bci_battery.1/power_supply/Battery
     theme: portrait_hdpi
 
@@ -67,7 +66,7 @@ boot_ui:
       - /dev/block/platform/msm_sdcc.1/by-name/recovery
       - /dev/block/mmcblk0p19
 
-boot_ui:
+  boot_ui:
     supported: true
     graphics_backends:
       - fbdev
@@ -104,7 +103,7 @@ boot_ui:
       - /dev/block/platform/hi_mci.0/by-name/recovery
       - /dev/block/mmcblk0p29
 
-boot_ui:
+  boot_ui:
     supported: true
     graphics_backends:
       - fbdev
@@ -142,7 +141,7 @@ boot_ui:
       - /dev/block/platform/hi_mci.0/by-name/recovery
       - /dev/block/mmcblk0p29
 
-boot_ui:
+  boot_ui:
     supported: true
     graphics_backends:
       - fbdev
@@ -198,7 +197,7 @@ boot_ui:
       - /dev/block/bootdevice/by-name/recovery
       - /dev/block/mmcblk0p20
 
-boot_ui:
+  boot_ui:
     supported: true
     flags:
       - TW_NO_SCREEN_TIMEOUT
@@ -238,7 +237,7 @@ boot_ui:
       - /dev/block/platform/hi_mci.0/by-name/recovery
       - /dev/block/mmcblk0p29
 
-boot_ui:
+  boot_ui:
     supported: true
     graphics_backends:
       - fbdev
@@ -275,7 +274,7 @@ boot_ui:
       - /dev/block/platform/hi_mci.0/by-name/recovery
       - /dev/block/mmcblk0p29
 
-boot_ui:
+  boot_ui:
     supported: true
     graphics_backends:
       - fbdev
@@ -323,7 +322,7 @@ boot_ui:
       - /dev/block/platform/hi_mci.0/by-name/recovery
       - /dev/block/mmcblk0p28
 
-boot_ui:
+  boot_ui:
     supported: true
     flags:
       - TW_SCREEN_BLANK_ON_BOOT
@@ -374,7 +373,7 @@ boot_ui:
       - /dev/block/platform/hi_mci.0/by-name/recovery
       - /dev/block/mmcblk0p28
 
-boot_ui:
+  boot_ui:
     supported: true
     graphics_backends:
       - fbdev
@@ -421,7 +420,7 @@ boot_ui:
       - /dev/block/platform/hi_mci.0/by-name/recovery
       - /dev/block/mmcblk0p28
 
-boot_ui:
+  boot_ui:
     supported: true
     graphics_backends:
       - fbdev
@@ -429,7 +428,6 @@ boot_ui:
     max_brightness: 255
     default_brightness: 162
     battery_path: /sys/devices/platform/bq_bci_battery.1/power_supply/Battery
-    pixel_format: RGB_8888
     theme: portrait_hdpi
 
 - name: Huawei Y635
@@ -467,7 +465,7 @@ boot_ui:
       - /dev/block/platform/7824900.sdhci/by-name/recovery
       - /dev/block/mmcblk0p19
 
-boot_ui:
+  boot_ui:
     supported: true
     flags:
       - TW_QCOM_RTC_FIX
@@ -505,7 +503,7 @@ boot_ui:
       - /dev/block/platform/hi_mci.0/by-name/recovery
       - /dev/block/mmcblk0p29
 
-boot_ui:
+  boot_ui:
     supported: true
     graphics_backends:
       - fbdev
@@ -541,7 +539,7 @@ boot_ui:
       - /dev/block/platform/hi_mci.0/by-name/recovery
       - /dev/block/mmcblk0p29
 
-boot_ui:
+  boot_ui:
     supported: true
     graphics_backends:
       - fbdev

--- a/data/devices/infinix.yml
+++ b/data/devices/infinix.yml
@@ -182,6 +182,15 @@
       - /dev/block/platform/7824900.sdhci/by-name/recovery
       - /dev/block/mmcblk0p26
 
+  boot_ui:
+    supported: yes
+    graphics_backends:
+      - fbdev
+    brightness_path: /sys/class/leds/lcd-backlight/brightness
+    max_brightness: 255
+    cpu_temp_path:  /sys/devices/virtual/thermal/thermal_zone1/temp
+    theme: portrait_hdpi
+
 - name: Infinix Hot 4 X557
   id: Infinix_X557
   codenames:

--- a/data/devices/jiayu.yml
+++ b/data/devices/jiayu.yml
@@ -64,7 +64,6 @@
     cpu_temp_path: /sys/class/thermal/thermal_zone1/temp
     theme: portrait_hdpi
 
-
 - name: Jiayu S3plus
   id: n560a
   codenames:

--- a/data/devices/leeco.yml
+++ b/data/devices/leeco.yml
@@ -38,7 +38,7 @@
       - /dev/block/bootdevice/by-name/recovery
       - /dev/block/sde20
 
-boot_ui:
+  boot_ui:
     supported: true
     flags:
       - TW_QCOM_RTC_FIX
@@ -75,7 +75,7 @@ boot_ui:
       - /dev/block/platform/mtk-msdc.0/11230000.msdc0/by-name/recovery
       - /dev/block/mmcblk0p1
 
-boot_ui:
+  boot_ui:
     supported: true
     graphics_backends:
       - fbdev
@@ -152,7 +152,6 @@ boot_ui:
       - fbdev
       - drm
     theme: portrait_hdpi
-
 
 - name: LeEco Le 1S
   id: x3

--- a/data/devices/lenovo.yml
+++ b/data/devices/lenovo.yml
@@ -240,7 +240,6 @@
       - fbdev
     theme: portrait_hdpi
 
-
 - name: Lenovo ZUK Z1
   id: Z1
   codenames:
@@ -282,7 +281,6 @@
       - fbdev
     theme: portrait_hdpi
 
-
 - name: Lenovo Vibe P1 Turbo
   id: P1a42
   codenames:
@@ -304,6 +302,7 @@
       - /dev/block/bootdevice/by-name/boot
     recovery:
       - /dev/block/bootdevice/by-name/recovery
+
   boot_ui:
     supported: true
     flags:
@@ -316,7 +315,6 @@
     graphics_backends:
       - fbdev
     theme: portrait_hdpi
-
 
 - name: Lenovo Vibe P1
   id: P1a41
@@ -339,6 +337,7 @@
       - /dev/block/bootdevice/by-name/boot
     recovery:
       - /dev/block/bootdevice/by-name/recovery
+
   boot_ui:
     supported: true
     flags:
@@ -351,7 +350,6 @@
     graphics_backends:
       - fbdev
     theme: portrait_hdpi
-
 
 - name: Lenovo Vibe P2
   id: P2a42
@@ -378,7 +376,7 @@
     recovery:
       - /dev/block/bootdevice/by-name/recovery
 
-boot_ui:
+  boot_ui:
     supported: true
     flags:
       - TW_SCREEN_BLANK_ON_BOOT
@@ -417,7 +415,7 @@ boot_ui:
     recovery:
       - /dev/block/bootdevice/by-name/recovery
 
-boot_ui:
+  boot_ui:
     supported: true
     flags:
       - TW_QCOM_RTC_FIX
@@ -514,7 +512,7 @@ boot_ui:
       - /dev/block/bootdevice/by-name/recovery
       - /dev/block/mmcblk0p34
 
-boot_ui:
+  boot_ui:
     supported: true
     flags:
       - TW_QCOM_RTC_FIX
@@ -556,7 +554,7 @@ boot_ui:
       - /dev/block/platform/soc/7824900.sdhci/by-name/recovery
       - /dev/block/mmcblk0p35
 
-boot_ui:
+  boot_ui:
     supported: true
     flags:
       - TW_QCOM_RTC_FIX

--- a/data/devices/lg.yml
+++ b/data/devices/lg.yml
@@ -32,7 +32,7 @@
       - /dev/block/platform/msm_sdcc.1/by-name/recovery
       - /dev/block/mmcblk0p15
 
-boot_ui:
+  boot_ui:
     supported: true
     flags:
       - TW_QCOM_RTC_FIX
@@ -43,7 +43,6 @@ boot_ui:
     default_brightness: 2067
     pixel_format: RGBX_8888
     theme: portrait_hdpi
-
 
 - name: LG G2 (d802)
   id: lgg2_d802
@@ -75,7 +74,7 @@ boot_ui:
       - /dev/block/platform/msm_sdcc.1/by-name/aboot
       - /dev/block/platform/msm_sdcc.1/by-name/tz
 
-boot_ui:
+  boot_ui:
     supported: true
     flags:
       - TW_QCOM_RTC_FIX
@@ -129,7 +128,6 @@ boot_ui:
       - fbdev
     theme: portrait_hdpi
 
-
 - name: LG G3 S
   id: lgg3s
   codenames:
@@ -155,7 +153,7 @@ boot_ui:
       - /dev/block/platform/msm_sdcc.1/by-name/recovery
       - /dev/block/mmcblk0p17
 
-boot_ui:
+  boot_ui:
     supported: true
     flags:
       - TW_QCOM_RTC_FIX
@@ -166,7 +164,6 @@ boot_ui:
     default_brightness: 162
     pixel_format: RGBX_8888
     theme: portrait_hdpi
-
 
 - name: LG G4
   id: lgg4
@@ -200,7 +197,7 @@ boot_ui:
       - /dev/block/bootdevice/by-name/recovery
       - /dev/block/mmcblk0p39
 
-boot_ui:
+  boot_ui:
     supported: true
     flags:
       - TW_SCREEN_BLANK_ON_BOOT
@@ -209,7 +206,6 @@ boot_ui:
       - fbdev
     pixel_format: RGBX_8888
     theme: portrait_hdpi
-
 
 - name: LG G4 (T-Mobile)
   id: lgg4_tmo
@@ -243,7 +239,7 @@ boot_ui:
       - /dev/block/bootdevice/by-name/recovery
       - /dev/block/mmcblk0p39
 
-boot_ui:
+  boot_ui:
     supported: true
     flags:
       - TW_SCREEN_BLANK_ON_BOOT
@@ -297,7 +293,6 @@ boot_ui:
     default_brightness: 162
     theme: portrait_hdpi
 
-
 - name: LG G5 (T-Mobile)
   id: lgg5_tmo
   codenames:
@@ -342,7 +337,6 @@ boot_ui:
     default_brightness: 149
     theme: portrait_hdpi
 
-
 - name: LG V20 (T-Mobile)
   id: elsa_tmo
   codenames:
@@ -375,7 +369,7 @@ boot_ui:
       - /dev/block/bootdevice/by-name/recovery
       - /dev/block/sde2
 
-boot_ui:
+  boot_ui:
     supported: true
     flags:
       - TW_QCOM_RTC_FIX
@@ -386,7 +380,6 @@ boot_ui:
     default_brightness: 149
     pixel_format: RGBX_8888
     theme: portrait_hdpi
-
 
 - name: LG V20 (Unlocked)
   id: elsa_omni
@@ -420,7 +413,7 @@ boot_ui:
       - /dev/block/bootdevice/by-name/recovery
       - /dev/block/sde2
 
-boot_ui:
+  boot_ui:
     supported: true
     flags:
       - TW_QCOM_RTC_FIX
@@ -475,7 +468,6 @@ boot_ui:
     pixel_format: RGBX_8888
     theme: portrait_hdpi
 
-
 - name: LG Optimus L7
   id: u0
   codenames:
@@ -518,7 +510,6 @@ boot_ui:
       - fbdev
     pixel_format: RGBX_8888
     theme: portrait_hdpi
-
 
 - name: LG Optimus L1 II
   id: v1
@@ -566,7 +557,6 @@ boot_ui:
     pixel_format: RGBX_8888
     theme: portrait_hdpi
 
-
 - name: LG Optimus L3 II
   id: vee3
   codenames:
@@ -612,7 +602,6 @@ boot_ui:
       - fbdev
     pixel_format: RGBX_8888
     theme: portrait_hdpi
-
 
 - name: LG Optimus L7 II
   id: vee7
@@ -663,8 +652,7 @@ boot_ui:
       - fbdev
     pixel_format: RGBX_8888
     theme: portrait_hdpi
-    
-    
+
 - name: LG Stylo 2 Plus (MetroPCS)
   id: ph2n
   codenames:

--- a/data/devices/motorola.yml
+++ b/data/devices/motorola.yml
@@ -114,6 +114,15 @@
       - /dev/block/platform/msm_sdcc.1/by-name/recovery
       - /dev/block/mmcblk0p32
 
+  boot_ui:
+    supported: true
+    flags:
+      - TW_QCOM_RTC_FIX
+      - TW_SCREEN_BLANK_ON_BOOT
+    graphics_backends:
+      - fbdev
+    theme: portrait_hdpi
+
 - name: Motorola Moto G (2014 LTE)
   id: thea
   codenames:
@@ -147,7 +156,7 @@
       - /dev/block/platform/msm_sdcc.1/by-name/recovery
       - /dev/block/mmcblk0p33
 
-boot_ui:
+  boot_ui:
     supported: true
     flags:
       - TW_QCOM_RTC_FIX
@@ -181,14 +190,14 @@ boot_ui:
       - /dev/block/platform/soc.0/by-name/recovery
       - /dev/block/mmcblk0p32
 
-boot_ui:
+  boot_ui:
     supported: true
     flags:
       - TW_SCREEN_BLANK_ON_BOOT
       - TW_QCOM_RTC_FIX
     graphics_backends:
       - fbdev
-    pixel_format: RGB_565
+    force_pixel_format: RGB_565
     theme: portrait_hdpi
 
 - name: Motorola Moto G4 Play
@@ -227,14 +236,14 @@ boot_ui:
       - /dev/block/platform/7824900.sdhci/by-name/recovery
       - /dev/block/mmcblk0p32
 
-boot_ui:
+  boot_ui:
     supported: true
     flags:
       - TW_SCREEN_BLANK_ON_BOOT
       - TW_QCOM_RTC_FIX
     graphics_backends:
       - fbdev
-    pixel_format: RGB_565
+    force_pixel_format: RGB_565
     theme: portrait_hdpi
 
 - name: Motorola Moto E (1st gen)
@@ -267,7 +276,7 @@ boot_ui:
       - /dev/block/platform/msm_sdcc.1/by-name/recovery
       - /dev/block/mmcblk0p32
 
-boot_ui:
+  boot_ui:
     supported: true
     flags:
       - TW_SCREEN_BLANK_ON_BOOT
@@ -306,7 +315,7 @@ boot_ui:
       - /dev/block/platform/msm_sdcc.1/by-name/recovery
       - /dev/block/mmcblk0p33
 
-boot_ui:
+  boot_ui:
     supported: true
     flags:
       - TW_SCREEN_BLANK_ON_BOOT
@@ -352,7 +361,7 @@ boot_ui:
       - /dev/block/platform/msm_sdcc.1/by-name/recovery
       - /dev/block/mmcblk0p34
 
-boot_ui:
+  boot_ui:
     supported: true
     flags:
       - TW_SCREEN_BLANK_ON_BOOT
@@ -401,7 +410,7 @@ boot_ui:
     recovery:
       - /dev/block/platform/msm_sdcc.1/by-name/recovery
 
-boot_ui:
+  boot_ui:
     supported: true
     flags:
       - TW_QCOM_RTC_FIX
@@ -437,6 +446,7 @@ boot_ui:
     recovery:
       - /dev/block/platform/msm_sdcc.1/by-name/recovery
       - /dev/block/mmcblk0p34
+
   boot_ui:
     supported: true
     flags:
@@ -488,7 +498,7 @@ boot_ui:
       - /dev/block/platform/soc.0/f9824900.sdhci/by-name/modem
       - /dev/block/mmcblk0p1
 
-boot_ui:
+  boot_ui:
     supported: true
     flags:
       - TW_SCREEN_BLANK_ON_BOOT
@@ -528,14 +538,14 @@ boot_ui:
       - /dev/block/platform/msm_sdcc.1/by-name/recovery
       - /dev/block/mmcblk0p37
 
-boot_ui:
+  boot_ui:
     supported: true
     flags:
       - TW_SCREEN_BLANK_ON_BOOT
       - TW_QCOM_RTC_FIX
     graphics_backends:
       - fbdev
-    pixel_format: RGB_565
+    force_pixel_format: RGB_565
     theme: portrait_hdpi
 
 - name: Motorola Moto X Pro
@@ -564,6 +574,16 @@ boot_ui:
       - /dev/block/platform/msm_sdcc.1/by-name/recovery
       - /dev/block/mmcblk0p37
 
+  boot_ui:
+    supported: true
+    flags:
+      - TW_QCOM_RTC_FIX
+    graphics_backends:
+      - fbdev
+    brightness_path: /sys/class/backlight/panel/brightness
+    default_brightness: 80
+    force_pixel_format: RGB_565
+    theme: portrait_hdpi
 
 - name: Motorola Moto G4 & G4 Plus Edition
   id: athene
@@ -607,7 +627,7 @@ boot_ui:
       - /dev/block/platform/soc.0/7824900.sdhci/by-name/recovery
       - /dev/block/mmcblk0p29
 
-boot_ui:
+  boot_ui:
     supported: true
     flags:
       - TW_QCOM_RTC_FIX
@@ -651,7 +671,7 @@ boot_ui:
       - /dev/block/platform/soc/7824900.sdhci/by-name/recovery
       - /dev/block/mmcblk0p38
 
-boot_ui:
+  boot_ui:
     supported: true
     flags:
       - TW_QCOM_RTC_FIX
@@ -697,7 +717,7 @@ boot_ui:
       - /dev/block/platform/624000.ufshc/by-name/recovery
       - /dev/block/sda14
       
-boot_ui:
+  boot_ui:
     supported: true
     flags:
       - TW_QCOM_RTC_FIX
@@ -740,7 +760,7 @@ boot_ui:
       - /dev/block/platform/soc/7824900.sdhci/by-name/recovery
       - /dev/block/mmcblk0p38
 
-boot_ui:
+  boot_ui:
     supported: true
     flags:
       - TW_SCREEN_BLANK_ON_BOOT
@@ -750,7 +770,7 @@ boot_ui:
     brightness_path: /sys/class/backlight/panel/brightness
     max_brightness: 255
     default_brightness: 162
-    pixel_format: RGB_565
+    force_pixel_format: RGB_565
     theme: portrait_hdpi
 
 - name: Motorola Moto C (4G)

--- a/data/devices/nexus.yml
+++ b/data/devices/nexus.yml
@@ -24,7 +24,7 @@
       - /dev/block/platform/msm_sdcc.1/by-name/recovery
       - /dev/block/mmcblk0p7
 
-boot_ui:
+  boot_ui:
     supported: true
     flags:
       - TW_QCOM_RTC_FIX
@@ -69,7 +69,7 @@ boot_ui:
       - /dev/block/platform/msm_sdcc.1/by-name/sdi
       - /dev/block/platform/msm_sdcc.1/by-name/tz
 
-boot_ui:
+  boot_ui:
     supported: true
     flags:
       - TW_QCOM_RTC_FIX
@@ -112,7 +112,7 @@ boot_ui:
       - /dev/block/bootdevice/by-name/recovery
       - /dev/block/mmcblk0p38
 
-boot_ui:
+  boot_ui:
     supported: true
     flags:
       - TW_NO_SCREEN_TIMEOUT
@@ -150,7 +150,7 @@ boot_ui:
       - /dev/block/platform/msm_sdcc.1/by-name/recovery
       - /dev/block/mmcblk0p35
 
-boot_ui:
+  boot_ui:
     supported: true
     flags:
       - TW_NO_SCREEN_TIMEOUT
@@ -160,7 +160,7 @@ boot_ui:
     brightness_path: /sys/class/backlight/panel/brightness
     max_brightness: 215
     default_brightness: 80
-    pixel_format: RGB_565
+    force_pixel_format: RGB_565
     theme: portrait_hdpi
 
 - name: Google/Huawei Nexus 6P
@@ -193,7 +193,7 @@ boot_ui:
       - /dev/block/platform/soc.0/f9824900.sdhci/by-name/recovery
       - /dev/block/mmcblk0p35
 
-boot_ui:
+  boot_ui:
     supported: true
     flags:
       - TW_QCOM_RTC_FIX
@@ -228,7 +228,7 @@ boot_ui:
       - /dev/block/platform/sdhci-tegra.3/by-name/SOS
       - /dev/block/mmcblk0p1
 
-boot_ui:
+  boot_ui:
     supported: true
     flags:
       - TW_QCOM_RTC_FIX
@@ -262,7 +262,7 @@ boot_ui:
     recovery:
       - /dev/block/platform/msm_sdcc.1/by-name/recovery
 
-boot_ui:
+  boot_ui:
     supported: true
     flags:
       - TW_NO_SCREEN_BLANK

--- a/data/devices/nubia.yml
+++ b/data/devices/nubia.yml
@@ -35,7 +35,7 @@
     extra:
       - /dev/block/bootdevice/by-name/modem
 
-boot_ui:
+  boot_ui:
     supported: true
     flags:
       - TW_QCOM_RTC_FIX
@@ -85,7 +85,7 @@ boot_ui:
       - /dev/block/bootdevice/by-name/recovery2
       - /dev/block/bootdevice/by-name/tz
       
-boot_ui:
+  boot_ui:
     supported: true
     flags:
       - TW_QCOM_RTC_FIX
@@ -133,7 +133,7 @@ boot_ui:
       - /dev/block/bootdevice/by-name/recovery2
       - /dev/block/bootdevice/by-name/tz
 
-boot_ui:
+  boot_ui:
     supported: true
     flags:
       - TW_QCOM_RTC_FIX
@@ -188,7 +188,7 @@ boot_ui:
       - /dev/block/bootdevice/by-name/recovery
       - /dev/block/bootdevice/by-name/tz
       
-boot_ui:
+  boot_ui:
     supported: true
     flags:
       - TW_QCOM_RTC_FIX
@@ -237,7 +237,7 @@ boot_ui:
       - /dev/block/bootdevice/by-name/recovery2
       - /dev/block/bootdevice/by-name/tz
 
-boot_ui:
+  boot_ui:
     supported: true
     flags:
       - TW_QCOM_RTC_FIX
@@ -272,7 +272,7 @@ boot_ui:
       - /dev/block/bootdevice/by-name/recovery
       - /dev/block/mmcblk0p22
 
-boot_ui:
+  boot_ui:
     supported: true
     flags:
       - TW_QCOM_RTC_FIX

--- a/data/devices/oneplus.yml
+++ b/data/devices/oneplus.yml
@@ -51,7 +51,6 @@
       - fbdev
     theme: portrait_hdpi
 
-
 - name: OnePlus 2
   id: OnePlus2
   codenames:
@@ -104,7 +103,6 @@
     theme: portrait_hdpi
     brightness_path: /sys/class/leds/lcd-backlight/brightness
 
-
 - name: OnePlus 3
   id: OnePlus3
   codenames:
@@ -145,7 +143,6 @@
     theme: portrait_hdpi
     brightness_path: /sys/class/leds/lcd-backlight/brightness
     default_brightness: 80
-
 
 - name: OnePlus 3T
   id: OnePlus3T
@@ -189,7 +186,6 @@
     brightness_path: /sys/class/leds/lcd-backlight/brightness
     default_brightness: 80
 
-
 - name: OnePlus X
   id: onyx
   codenames:
@@ -223,14 +219,14 @@
       - /dev/block/bootdevice/by-name/recovery
       - /dev/block/mmcblk0p16
 
-boot_ui:
+  boot_ui:
     supported: true
     flags:
       - TW_HAS_DOWNLOAD_MODE
       - TW_QCOM_RTC_FIX
     graphics_backends:
       - fbdev
-    pixel_format: RGB_565
+    force_pixel_format: RGB_565
     theme: portrait_hdpi
 
 - name: OnePlus 5

--- a/data/devices/oppo.yml
+++ b/data/devices/oppo.yml
@@ -24,8 +24,17 @@
     recovery:
       - /dev/block/platform/msm_sdcc.1/by-name/recovery
       - /dev/block/mmcblk0p17
-      
-      
+
+  boot_ui:
+    supported: true
+    flags:
+      - TW_QCOM_RTC_FIX
+    graphics_backends:
+      - fbdev
+    brightness_path: /sys/class/backlight/panel/brightness
+    pixel_format: RGBX_8888
+    theme: portrait_hdpi
+
 - name: OPPO find7/7a
   id: find7
   codenames:
@@ -58,8 +67,7 @@
       - /dev/block/platform/msm_sdcc.1/by-name/recovery
       - /dev/block/mmcblk0p17
 
-
-boot_ui:
+  boot_ui:
     supported: true
     flags:
       - TW_QCOM_RTC_FIX

--- a/data/devices/pantech.yml
+++ b/data/devices/pantech.yml
@@ -41,7 +41,6 @@
     default_brightness: 175
     theme: portrait_hdpi
 
-
 - name: Pantech Vega Iron
   id: A870
   codenames:

--- a/data/devices/samsung/00_galaxy_s.yml
+++ b/data/devices/samsung/00_galaxy_s.yml
@@ -1,5 +1,5 @@
 ---
-- name: Samsung Galaxy S 3 Neo (Qcom)
+- name: Samsung Galaxy S3 Neo (Qcom)
   id: s3ve3g
   codenames:
     - s3ve3g
@@ -40,7 +40,7 @@
     pixel_format: RGBX_8888
     theme: portrait_hdpi
 
-- name: Samsung Galaxy S 3 (Qcom)
+- name: Samsung Galaxy S3 (Qcom)
   id: d2
   codenames:
     - d2
@@ -95,7 +95,7 @@
     pixel_format: RGBX_8888
     theme: portrait_hdpi
 
-- name: Samsung Galaxy S 3 (i9300)
+- name: Samsung Galaxy S3 (i9300)
   id: m0
   codenames:
     - m0
@@ -137,7 +137,7 @@
     pixel_format: RGBX_8888
     theme: portrait_hdpi
 
-- name: Samsung Galaxy S 3 (i9305)
+- name: Samsung Galaxy S3 (i9305)
   id: m3
   codenames:
     - m3
@@ -179,7 +179,7 @@
     pixel_format: RGBX_8888
     theme: portrait_hdpi
 
-- name: Samsung Galaxy S 3 Mini
+- name: Samsung Galaxy S3 Mini
   id: golden
   codenames:
     - golden
@@ -209,7 +209,7 @@
     pixel_format: RGBX_8888
     theme: portrait_hdpi
 
-- name: Samsung Galaxy S 4 (Qcom)
+- name: Samsung Galaxy S4 (Qcom)
   id: jflte
   codenames:
     # Regular variant
@@ -266,8 +266,7 @@
       - fbdev
     theme: portrait_hdpi
 
-
-- name: Samsung Galaxy S 4 (Exynos)
+- name: Samsung Galaxy S4 (Exynos)
   id: i9500
   codenames:
     # i9500
@@ -314,7 +313,7 @@
     pixel_format: RGBX_8888
     theme: portrait_hdpi
 
-- name: Samsung Galaxy S 4 LTE-A
+- name: Samsung Galaxy S4 LTE-A
   id: ks01lte
   codenames:
     - ks01lte
@@ -354,7 +353,7 @@
     pixel_format: RGBX_8888
     theme: portrait_hdpi
 
-- name: Samsung Galaxy S 4 Active (SKT Variant)
+- name: Samsung Galaxy S4 Active (SKT Variant)
   id: jactivelteskt
   codenames:
     - jactivelteskt
@@ -392,7 +391,7 @@
     pixel_format: RGBX_8888
     theme: portrait_hdpi
 
-- name: Samsung Galaxy S 4 Mini
+- name: Samsung Galaxy S4 Mini
   id: serrano
   codenames:
     # Regular variant
@@ -437,7 +436,7 @@
     pixel_format: RGBX_8888
     theme: portrait_hdpi
 
-- name: Samsung Galaxy S 5 (Qcom)
+- name: Samsung Galaxy S5 (Qcom)
   id: klte
   codenames:
     - klte
@@ -484,7 +483,7 @@
     default_brightness: 162
 
 
-- name: Samsung Galaxy S 5 Mini (Qcom)
+- name: Samsung Galaxy S5 Mini (Qcom)
   id: kmini3g
   codenames:
     - kmini3g
@@ -522,7 +521,7 @@
     pixel_format: ABGR_8888
     theme: portrait_hdpi
 
-- name: Samsung Galaxy S 5 (Exynos)
+- name: Samsung Galaxy S5 (Exynos)
   id: k3g
   codenames:
     - k3g
@@ -563,7 +562,7 @@
     pixel_format: ABGR_8888
     theme: portrait_hdpi
 
-- name: Samsung Galaxy S 5 Mini LTE (Exynos)
+- name: Samsung Galaxy S5 Mini LTE (Exynos)
   id: kminilte
   codenames:
     - kminilte
@@ -604,7 +603,7 @@
     pixel_format: ABGR_8888
     theme: portrait_hdpi
 
-- name: Samsung Galaxy S 5 Broadband LTE-A
+- name: Samsung Galaxy S5 Broadband LTE-A
   id: lentislte
   codenames:
     - lentislte
@@ -644,7 +643,7 @@
     pixel_format: RGBX_8888
     theme: portrait_hdpi
 
-- name: Samsung Galaxy S 5 4G+
+- name: Samsung Galaxy S5 4G+
   id: kccat6
   codenames:
     - kccat6
@@ -683,7 +682,7 @@
     pixel_format: RGBX_8888
     theme: portrait_hdpi
 
-- name: Samsung Galaxy S 6 Flat/Edge
+- name: Samsung Galaxy S6 Flat/Edge
   id: zerolte
   codenames:
     # Regular variant
@@ -731,7 +730,7 @@
     pixel_format: ABGR_8888
     theme: portrait_hdpi
 
-- name: Samsung Galaxy S 6 Flat/Edge (CN/JP Variant)
+- name: Samsung Galaxy S6 Flat/Edge (CN/JP Variant)
   id: zeroltechn
   codenames:
     # Flat china variant
@@ -785,7 +784,7 @@
     theme: portrait_hdpi
 
 
-- name: Samsung Galaxy S 6 Flat/Edge (Sprint)
+- name: Samsung Galaxy S6 Flat/Edge (Sprint)
   id: zeroltespr
   codenames:
     # Regular variant
@@ -827,7 +826,7 @@
     pixel_format: ABGR_8888
     theme: portrait_hdpi
 
-- name: Samsung Galaxy S 6 Edge+
+- name: Samsung Galaxy S6 Edge+
   id: zenlte
   codenames:
     - zenlte
@@ -867,7 +866,7 @@
     pixel_format: ABGR_8888
     theme: portrait_hdpi
 
-- name: Samsung Galaxy S 7 Flat/Edge (Exynos)
+- name: Samsung Galaxy S7 Flat/Edge (Exynos)
   id: herolte
   codenames:
     # Regular variant

--- a/data/devices/samsung/01_galaxy_note.yml
+++ b/data/devices/samsung/01_galaxy_note.yml
@@ -131,7 +131,6 @@
     default_brightness: 162
     theme: portrait_hdpi
 
-
 - name: Samsung Galaxy Note 3 (Exynos)
   id: ha3g
   codenames:
@@ -209,7 +208,6 @@
     max_brightness: 255
     default_brightness: 162
     theme: portrait_hdpi
-
 
 - name: Samsung Galaxy Note 3 Neo
   id: hllte

--- a/data/devices/samsung/02_galaxy_a_j.yml
+++ b/data/devices/samsung/02_galaxy_a_j.yml
@@ -165,6 +165,7 @@
     recovery:
       - /dev/block/bootdevice/by-name/recovery
       - /dev/block/mmcblk0p17
+
   boot_ui:
     supported: true
     flags:

--- a/data/devices/samsung/05_galaxy_tab_tablet.yml
+++ b/data/devices/samsung/05_galaxy_tab_tablet.yml
@@ -36,7 +36,7 @@
       - /dev/block/platform/omap/omap_hsmmc.1/by-name/RECOVERY
       - /dev/block/mmcblk0p6
 
-boot_ui:
+  boot_ui:
     supported: true
     flags:
       - TW_HAS_DOWNLOAD_MODE
@@ -45,7 +45,7 @@ boot_ui:
     max_brightness: 255
     default_brightness: 162
     pixel_format: BGRA_8888
-    theme: landscape_hdpi
+    theme: portrait_hdpi
 
 - name: Samsung Galaxy Tab 3 8.0 (Wifi)
   id: lt01wifi
@@ -73,7 +73,7 @@ boot_ui:
       - /dev/block/platform/dw_mmc/by-name/RECOVERY
       - /dev/block/mmcblk0p10
 
-boot_ui:
+  boot_ui:
     supported: true
     flags:
       - TW_HAS_DOWNLOAD_MODE
@@ -82,7 +82,7 @@ boot_ui:
     max_brightness: 255
     default_brightness: 162
     pixel_format: BGRA_8888
-    theme: landscape_hdpi
+    theme: portrait_hdpi
 
 - name: Samsung Galaxy Tab 3 10.1
   id: santos
@@ -119,7 +119,7 @@ boot_ui:
     extra:
       - '/dev/block/pci/pci0000:00/0000:00:01.0/by-name/RADIO'
 
-boot_ui:
+  boot_ui:
     supported: true
     flags:
       - TW_HAS_DOWNLOAD_MODE
@@ -128,7 +128,7 @@ boot_ui:
     max_brightness: 255
     default_brightness: 162
     pixel_format: BGRA_8888
-    theme: landscape_hdpi
+    theme: portrait_hdpi
 
 - name: Samsung Galaxy Tab 4 10.1 (Wifi)
   id: matissewifi
@@ -156,7 +156,7 @@ boot_ui:
       - /dev/block/platform/msm_sdcc.1/by-name/recovery
       - /dev/block/mmcblk0p15
 
-boot_ui:
+  boot_ui:
     supported: true
     flags:
       - TW_QCOM_RTC_FIX
@@ -167,8 +167,7 @@ boot_ui:
     max_brightness: 255
     default_brightness: 162
     pixel_format: RGBX_8888
-    theme: landscape_hdpi
-
+    theme: portrait_hdpi
 
 - name: Samsung Galaxy Tab Pro 8.4 (Wifi)
   id: mondrianwifi
@@ -197,7 +196,7 @@ boot_ui:
       - /dev/block/platform/msm_sdcc.1/by-name/recovery
       - /dev/block/mmcblk0p15
 
-boot_ui:
+  boot_ui:
     supported: true
     flags:
       - TW_QCOM_RTC_FIX
@@ -208,8 +207,7 @@ boot_ui:
     max_brightness: 255
     default_brightness: 162
     pixel_format: RGBX_8888
-    theme: landscape_hdpi
-
+    theme: portrait_hdpi
 
 - name: Samsung Galaxy Tab Pro 10.1 (Wifi)
   id: picassowifi
@@ -240,7 +238,7 @@ boot_ui:
       - /dev/block/platform/dw_mmc.0/by-name/RADIO
       - /dev/block/platform/dw_mmc.0/by-name/CDMA-RADIO
 
-boot_ui:
+  boot_ui:
     supported: true
     flags:
       - TW_HAS_DOWNLOAD_MODE
@@ -250,7 +248,7 @@ boot_ui:
     max_brightness: 255
     default_brightness: 162
     pixel_format: BGRA_8888
-    theme: landscape_hdpi
+    theme: portrait_hdpi
 
 - name: Samsung Galaxy Tab Pro 10.1 (LTE)
   id: picassolte
@@ -278,7 +276,7 @@ boot_ui:
       - /dev/block/platform/msm_sdcc.1/by-name/recovery
       - /dev/block/mmcblk0p15
 
-boot_ui:
+  boot_ui:
     supported: true
     flags:
       - TW_HAS_DOWNLOAD_MODE
@@ -287,7 +285,7 @@ boot_ui:
     max_brightness: 255
     default_brightness: 162
     pixel_format: BGRA_8888
-    theme: landscape_hdpi
+    theme: portrait_hdpi
 
 - name: Samsung Galaxy Tab Pro 12.2 (Wifi)
   id: v2wifi
@@ -317,7 +315,7 @@ boot_ui:
       - /dev/block/platform/dw_mmc.0/by-name/RECOVERY
       - /dev/block/mmcblk0p10
 
-boot_ui:
+  boot_ui:
     supported: true
     flags:
       - TW_HAS_DOWNLOAD_MODE
@@ -326,7 +324,7 @@ boot_ui:
     max_brightness: 255
     default_brightness: 162
     pixel_format: BGRA_8888
-    theme: landscape_hdpi
+    theme: portrait_hdpi
 
 - name: Samsung Galaxy Tab S 8.4/10.5
   id: tab_s
@@ -367,7 +365,7 @@ boot_ui:
       - /dev/block/platform/dw_mmc.0/by-name/RADIO
       - /dev/block/platform/dw_mmc.0/by-name/CDMA-RADIO
 
-boot_ui:
+  boot_ui:
     supported: true
     flags:
       - TW_HAS_DOWNLOAD_MODE
@@ -416,7 +414,7 @@ boot_ui:
       - /dev/block/platform/15540000.dwmmc0/by-name/RADIO
       - /dev/block/platform/15540000.dwmmc0/by-name/CDMA-RADIO
       
-boot_ui:
+  boot_ui:
     supported: true
     flags:
       - TW_HAS_DOWNLOAD_MODE
@@ -465,8 +463,8 @@ boot_ui:
       - /dev/block/platform/soc.0/7824900.sdhci/by-name/modem
       - /dev/block/mmcblk0p33
 
-boot_ui:
-supported: true
+  boot_ui:
+    supported: true
     flags:
       - TW_QCOM_RTC_FIX
       - TW_HAS_DOWNLOAD_MODE
@@ -476,7 +474,7 @@ supported: true
     brightness_path: /sys/class/leds/lcd-backlight/brightness
     max_brightness: 394
     default_brightness: 190
-    theme: landscape_hdpi
+    theme: portrait_hdpi
 
 - name: Samsung Galaxy Tab Active 8.0 (LTE)
   id: SM-T365

--- a/data/devices/samsung/06_galaxy_note_tablet.yml
+++ b/data/devices/samsung/06_galaxy_note_tablet.yml
@@ -36,11 +36,11 @@
       - /dev/block/platform/dw_mmc/by-name/RADIO
       - /dev/block/mmcblk0p7
 
-boot_ui:
+  boot_ui:
     supported: true
     graphics_backends:
       - fbdev
-    theme: landscape_hdpi
+    theme: portrait_hdpi
 
 - name: Samsung Galaxy Note 10.1
   id: p4noterf
@@ -70,14 +70,14 @@ boot_ui:
     extra:
       - /dev/block/platform/dw_mmc/by-name/RADIO
 
-boot_ui:
+  boot_ui:
     supported: true
     graphics_backends:
       - fbdev
     brightness_path: /sys/class/backlight/panel/brightness
     max_brightness: 255
     default_brightness: 162
-    theme: landscape_hdpi
+    theme: portrait_hdpi
 
 - name: Samsung Galaxy Note 10.1 Wifi (2014 Edition)
   id: lt03wifi
@@ -108,14 +108,14 @@ boot_ui:
       - /dev/block/platform/dw_mmc.0/by-name/RADIO
       - /dev/block/platform/dw_mmc.0/by-name/CDMA-RADIO
 
-boot_ui:
+  boot_ui:
     supported: true
     flags:
       - TW_HAS_DOWNLOAD_MODE
     graphics_backends:
       - fbdev
     pixel_format: BGRA_8888
-    theme: landscape_hdpi
+    theme: portrait_hdpi
 
 - name: Samsung Galaxy Note 10.1 3G (2014 Edition)
   id: lt033g
@@ -146,14 +146,14 @@ boot_ui:
       - /dev/block/platform/dw_mmc.0/by-name/RADIO
       - /dev/block/platform/dw_mmc.0/by-name/CDMA-RADIO
 
-boot_ui:
+  boot_ui:
     supported: true
     flags:
       - TW_HAS_DOWNLOAD_MODE
     graphics_backends:
       - fbdev
     pixel_format: BGRA_8888
-    theme: landscape_hdpi
+    theme: portrait_hdpi
 
 - name: Samsung Galaxy Note 10.1 LTE (2014 Edition)
   id: lt03lte
@@ -181,7 +181,7 @@ boot_ui:
       - /dev/block/platform/msm_sdcc.1/by-name/recovery
       - /dev/block/mmcblk0p15
 
-boot_ui:
+  boot_ui:
     supported: true
     flags:
       - TW_HAS_DOWNLOAD_MODE
@@ -189,7 +189,7 @@ boot_ui:
     graphics_backends:
       - fbdev
     pixel_format: RGBX_8888
-    theme: landscape_hdpi
+    theme: portrait_hdpi
 
 - name: Samsung Galaxy Note Pro 12.2 (LTE)
   id: viennalte
@@ -217,7 +217,7 @@ boot_ui:
       - /dev/block/platform/msm_sdcc.1/by-name/recovery
       - /dev/block/mmcblk0p15
 
-boot_ui:
+  boot_ui:
     supported: true
     flags:
       - TW_QCOM_RTC_FIX
@@ -228,7 +228,7 @@ boot_ui:
     max_brightness: 255
     default_brightness: 162
     pixel_format: RGBX_8888
-    theme: landscape_hdpi
+    theme: portrait_hdpi
 
 - name: Samsung Galaxy Note Pro 12.2 (Wifi)
   id: v1awifi
@@ -257,7 +257,7 @@ boot_ui:
       - /dev/block/platform/dw_mmc.0/by-name/RECOVERY
       - /dev/block/mmcblk0p10
 
-boot_ui:
+  boot_ui:
     supported: true
     flags:
       - TW_HAS_DOWNLOAD_MODE
@@ -267,4 +267,4 @@ boot_ui:
     max_brightness: 255
     default_brightness: 162
     pixel_format: BGRA_8888
-    theme: landscape_hdpi
+    theme: portrait_hdpi

--- a/data/devices/samsung/07_other.yml
+++ b/data/devices/samsung/07_other.yml
@@ -25,7 +25,7 @@
       - /dev/block/platform/msm_sdcc.1/by-name/recovery
       - /dev/block/mmcblk0p15
 
-boot_ui:
+  boot_ui:
     supported: true
     flags:
       - TW_HAS_DOWNLOAD_MODE
@@ -52,7 +52,7 @@ boot_ui:
     recovery:
       - /dev/block/mmcblk0p6
 
-boot_ui:
+  boot_ui:
     supported: true
     flags:
       - TW_HAS_DOWNLOAD_MODE
@@ -97,7 +97,7 @@ boot_ui:
       - /dev/block/platform/15540000.dwmmc0/by-name/RADIO
       - /dev/block/platform/15540000.dwmmc0/by-name/CDMA-RADIO
 
-boot_ui:
+  boot_ui:
     supported: true
     flags:
       - TW_HAS_DOWNLOAD_MODE
@@ -136,7 +136,7 @@ boot_ui:
       - /dev/block/platform/sdio_emmc/by-name/RECOVERY
       - /dev/block/mmcblk0p21
 
-boot_ui:
+  boot_ui:
     supported: true
     flags:
       - TW_HAS_DOWNLOAD_MODE

--- a/data/devices/sony.yml
+++ b/data/devices/sony.yml
@@ -19,7 +19,7 @@
     boot:
       - /dev/block/mmcblk0p9
 
-boot_ui:
+  boot_ui:
     supported: true
     flags:
       - TW_QCOM_RTC_FIX
@@ -116,7 +116,6 @@ boot_ui:
     pixel_format: RGBX_8888
     theme: portrait_hdpi
 
-
 - name: Sony Xperia T2 Ultra
   id: tianchi
   codenames:
@@ -167,7 +166,6 @@ boot_ui:
     pixel_format: RGBX_8888
     theme: portrait_hdpi
 
-
 - name: Sony Xperia SP
   id: huashan
   codenames:
@@ -201,7 +199,7 @@ boot_ui:
       - /dev/block/platform/msm_sdcc.1/by-name/TA
       - /dev/block/platform/msm_sdcc.1/by-name/TZ
 
-boot_ui:
+  boot_ui:
     supported: true
     flags:
       - TW_NO_SCREEN_BLANK

--- a/data/devices/symphony.yml
+++ b/data/devices/symphony.yml
@@ -74,4 +74,3 @@
     max_brightness: 255
     cpu_temp_path:  /sys/devices/virtual/thermal/thermal_zone1/temp
     theme: portrait_hdpi
-

--- a/data/devices/tecno.yml
+++ b/data/devices/tecno.yml
@@ -95,7 +95,6 @@
     cpu_temp_path:  /sys/devices/virtual/thermal/thermal_zone1/temp
     theme: portrait_hdpi
 
-
 - name: Tecno L8 Lite
   id: l8_lite
   codenames:

--- a/data/devices/wileyfox.yml
+++ b/data/devices/wileyfox.yml
@@ -36,7 +36,6 @@
     default_brightness: 162
     theme: portrait_hdpi
 
-
 - name: Wileyfox Storm
   id: kipper
   codenames:
@@ -62,7 +61,7 @@
       - /dev/block/bootdevice/by-name/recovery
       - /dev/block/mmcblk0p21
 
-boot_ui:
+  boot_ui:
     supported: true
     flags:
       - TW_QCOM_RTC_FIX
@@ -73,7 +72,6 @@ boot_ui:
     default_brightness: 162
     pixel_format: RGBX_8888
     theme: portrait_hdpi
-
 
 - name: Wileyfox Swift2
   id: marmite

--- a/data/devices/xiaomi/00_mi.yml
+++ b/data/devices/xiaomi/00_mi.yml
@@ -24,7 +24,7 @@
       - /dev/block/platform/msm_sdcc.1/by-name/recovery
       - /dev/block/mmcblk0p18
 
-boot_ui:
+  boot_ui:
     supported: true
     flags:
       - TW_QCOM_RTC_FIX
@@ -79,7 +79,6 @@ boot_ui:
     default_brightness: 162
     theme: portrait_hdpi
 
-
 - name: Xiaomi Mi4C
   id: libra
   codenames:
@@ -116,7 +115,6 @@ boot_ui:
     max_brightness: 255
     default_brightness: 162
     theme: portrait_hdpi
-
 
 - name: Xiaomi Mi4i
   id: ferrari
@@ -155,7 +153,6 @@ boot_ui:
     max_brightness: 255
     default_brightness: 162
     theme: portrait_hdpi
-
 
 - name: Xiaomi Mi4S
   id: aqua
@@ -200,7 +197,6 @@ boot_ui:
     default_brightness: 162
     theme: portrait_hdpi
 
-
 - name: Xiaomi Mi 5
   id: gemini
   codenames:
@@ -232,7 +228,7 @@ boot_ui:
       - /dev/block/bootdevice/by-name/recovery
       - /dev/block/sde37
 
-boot_ui:
+  boot_ui:
     supported: true
     flags:
       - TW_QCOM_RTC_FIX
@@ -286,7 +282,7 @@ boot_ui:
       - /dev/block/platform/soc/624000.ufshc/sda13
       - /dev/block/platform/soc/624000.ufshc/by-num/p13
 
-boot_ui:
+  boot_ui:
     supported: true
     flags:
       - TW_QCOM_RTC_FIX
@@ -329,7 +325,7 @@ boot_ui:
       - /dev/block/bootdevice/by-name/recovery
       - /dev/block/sda13
 
-boot_ui:
+  boot_ui:
     supported: true
     flags:
       - TW_QCOM_RTC_FIX
@@ -376,6 +372,7 @@ boot_ui:
       - /dev/block/sda15
       - /dev/block/platform/soc/1da4000.ufshc/by-num/p15
       - /dev/block/platform/soc/1da4000.ufshc/by-name/recovery
+
   boot_ui:
     supported: yes
     graphics_backends:

--- a/data/devices/xiaomi/01_mi_note.yml
+++ b/data/devices/xiaomi/01_mi_note.yml
@@ -42,7 +42,6 @@
     default_brightness: 162
     theme: portrait_hdpi
 
-
 - name: Xiaomi Mi Note Pro
   id: leo
   codenames:
@@ -79,7 +78,6 @@
     max_brightness: 255
     default_brightness: 162
     theme: portrait_hdpi
-
 
 - name: Xiaomi Mi Note 2
   id: scorpio
@@ -123,7 +121,7 @@
       - /dev/block/platform/soc/624000.ufshc/sda13
       - /dev/block/platform/soc/624000.ufshc/by-num/p13
 
-boot_ui:
+  boot_ui:
     supported: true
     flags:
       - TW_QCOM_RTC_FIX

--- a/data/devices/xiaomi/02_mi_max.yml
+++ b/data/devices/xiaomi/02_mi_max.yml
@@ -52,7 +52,6 @@
     brightness_path: /sys/class/leds/lcd-backlight/brightness
     theme: portrait_hdpi
 
-
 - name: Xiaomi Mi Max Pro
   id: helium
   codenames:
@@ -100,7 +99,6 @@
     brightness_path: /sys/class/leds/lcd-backlight/brightness
     theme: portrait_hdpi
 
-
 - name: Xiaomi Mi Max 2
   id: oxygen
   codenames:
@@ -136,7 +134,7 @@
       - /dev/block/bootdevice/by-name/cust
       - /dev/block/mmcblk0p64
 
-boot_ui:
+  boot_ui:
     supported: true
     flags:
       - TW_QCOM_RTC_FIX

--- a/data/devices/xiaomi/03_redmi.yml
+++ b/data/devices/xiaomi/03_redmi.yml
@@ -24,7 +24,7 @@
       - /dev/block/platform/msm_sdcc.1/by-name/recovery
       - /dev/block/mmcblk0p25
 
-boot_ui:
+  boot_ui:
     supported: true
     flags:
       - TW_QCOM_RTC_FIX
@@ -100,7 +100,6 @@ boot_ui:
     brightness_path: /sys/class/leds/lcd-backlight/brightness
     theme: portrait_hdpi
 
-
 - name: Xiaomi Redmi 3
   id: ido
   codenames:
@@ -170,7 +169,6 @@ boot_ui:
     brightness_path: /sys/class/leds/lcd-backlight/brightness
     theme: portrait_hdpi
 
-
 - name: Xiaomi Redmi 3s Prime
   id: land
   codenames:
@@ -221,7 +219,6 @@ boot_ui:
     max_brightness: 255
     brightness_path: /sys/class/leds/lcd-backlight/brightness
     theme: portrait_hdpi
-
 
 - name: Xiaomi Redmi 4
   id: markw
@@ -315,8 +312,7 @@ boot_ui:
     brightness_path: /sys/class/leds/lcd-backlight/brightness
     theme: portrait_hdpi
 
-
-- name: Xiaomi Redmi 4a
+- name: Xiaomi Redmi 4A
   id: rolex
   codenames:
     - rolex
@@ -335,6 +331,7 @@ boot_ui:
       - /dev/block/bootdevice/by-name/boot
     recovery:
       - /dev/block/bootdevice/by-name/recovery
+
   boot_ui:
     supported: yes
     graphics_backends:
@@ -346,7 +343,6 @@ boot_ui:
     max_brightness: 255
     brightness_path: /sys/class/leds/lcd-backlight/brightness
     theme: portrait_hdpi
-
 
 - name: Xiaomi Redmi 4X
   id: santoni
@@ -525,7 +521,6 @@ boot_ui:
     brightness_path: /sys/class/leds/lcd-backlight/brightness
     theme: portrait_hdpi
 
-
 - name: Xiaomi Redmi Pro
   id: omega
   codenames:
@@ -550,6 +545,7 @@ boot_ui:
     recovery:
       - /dev/block/platform/mtk-msdc.0/11230000.msdc0/by-name/recovery
       - /dev/block/mmcblk0p1
+
   boot_ui:
     supported: yes
     graphics_backends:

--- a/data/devices/xiaomi/04_redmi_note.yml
+++ b/data/devices/xiaomi/04_redmi_note.yml
@@ -51,7 +51,6 @@
       - fbdev
     theme: portrait_hdpi
 
-
 - name: Xiaomi Redmi Note 3 (MTK)
   id: hennessy
   codenames:
@@ -134,7 +133,7 @@
       - /dev/block/bootdevice/by-name/recovery
       - /dev/block/mmcblk0p22
 
-boot_ui:
+  boot_ui:
     supported: yes
     graphics_backends:
       - fbdev
@@ -177,7 +176,7 @@ boot_ui:
       - /dev/block/bootdevice/by-name/recovery
       - /dev/block/mmcblk0p22
 
-boot_ui:
+  boot_ui:
     supported: yes
     graphics_backends:
       - fbdev
@@ -271,7 +270,6 @@ boot_ui:
     brightness_path: /sys/class/leds/lcd-backlight/brightness
     theme: portrait_hdpi
 
-
 - name: Xiaomi Redmi Note 4 (MTK)
   id: nikel
   codenames:
@@ -330,7 +328,7 @@ boot_ui:
       - /dev/block/platform/msm_sdcc.1/by-name/recovery
       - /dev/block/mmcblk0p25
 
-boot_ui:
+  boot_ui:
     supported: true
     flags:
       - TW_QCOM_RTC_FIX
@@ -382,7 +380,6 @@ boot_ui:
     max_brightness: 160
     brightness_path: /sys/class/leds/lcd-backlight/brightness
     theme: portrait_hdpi
-
 
 - name: Xiaomi Redmi Note 4G TD/W (Dual SIM)
   id: gucci

--- a/data/devices/xiaomi/05_other.yml
+++ b/data/devices/xiaomi/05_other.yml
@@ -19,7 +19,7 @@
     recovery:
       - /dev/block/bootdevice/by-name/recovery
 
-boot_ui:
+  boot_ui:
     supported: true
     flags:
       - TW_QCOM_RTC_FIX

--- a/data/devices/zte.yml
+++ b/data/devices/zte.yml
@@ -30,6 +30,18 @@
       - /dev/block/bootdevice/by-name/recovery
       - /dev/block/sde14
 
+  boot_ui:
+    supported: true
+    flags:
+      - TW_QCOM_RTC_FIX
+    pixel_format: RGBX_8888
+    brightness_path: /sys/devices/soc/900000.qcom\x2cmdss_mdp/900000.qcom\x2cmdss_mdp:qcom\x2cmdss_fb_primary/leds/lcd-backlight/brightness
+    max_brightness: 255
+    default_brightness: 153
+    graphics_backends:
+      - fbdev
+    theme: portrait_hdpi
+
 - name: Z11
   id: NX531J
   codenames:
@@ -54,7 +66,17 @@
     recovery:
       - /dev/block/bootdevice/by-name/recovery
       - /dev/block/mmcblk0p15
-      
+
+  boot_ui:
+    supported: true
+    flags:
+      - TW_QCOM_RTC_FIX
+    pixel_format: RGBX_8888
+    brightness_path: /sys/class/leds/lcd-backlight/brightness
+    graphics_backends:
+      - fbdev
+    theme: portrait_hdpi
+
 - name: ZTE BA510
   id: P635T39
   codenames:

--- a/data/devices/zuk.yml
+++ b/data/devices/zuk.yml
@@ -75,7 +75,7 @@
       - /dev/block/bootdevice/by-name/recovery
       - /dev/block/sde19
 
-boot_ui:
+  boot_ui:
     supported: true
     flags:
       - TW_QCOM_RTC_FIX


### PR DESCRIPTION
Fix the"disappeared devices" problem after merging Bootui.
The problem was "no space before 'boot_ui:' " so the whole device was being ignored 

And add bootui for more devices:
- Infinix Hot 3 LTE X553
-  Motorola Moto G (2014)
- Motorola Moto X Pro
- Zte Z11