### PR TITLE
libmbcommon: file: Use asserts for invalid arguments instead of runtime errors

### DIFF
--- a/libmbcommon/include/mbcommon/file_error.h
+++ b/libmbcommon/include/mbcommon/file_error.h
@@ -30,8 +30,6 @@ enum class FileError
 {
     ArgumentOutOfRange      = 10,
     CannotConvertEncoding   = 11,
-    InvalidMode             = 12,
-    InvalidWhence           = 13,
 
     InvalidState            = 20,
 

--- a/libmbcommon/src/file/fd.cpp
+++ b/libmbcommon/src/file/fd.cpp
@@ -312,9 +312,7 @@ bool FdFile::open(const std::string &filename, FileOpenMode mode)
         // Convert mode to flags
         int flags = priv->convert_mode(mode);
         if (flags < 0) {
-            set_error(make_error_code(FileError::InvalidMode),
-                      "Invalid mode: %d", static_cast<int>(mode));
-            return false;
+            MB_UNREACHABLE("Invalid mode: %d", static_cast<int>(mode));
         }
 
         priv->fd = -1;
@@ -356,9 +354,7 @@ bool FdFile::open(const std::wstring &filename, FileOpenMode mode)
         // Convert mode to flags
         int flags = priv->convert_mode(mode);
         if (flags < 0) {
-            set_error(make_error_code(FileError::InvalidMode),
-                      "Invalid mode: %d", static_cast<int>(mode));
-            return false;
+            MB_UNREACHABLE("Invalid mode: %d", static_cast<int>(mode));
         }
 
         priv->fd = -1;

--- a/libmbcommon/src/file/memory.cpp
+++ b/libmbcommon/src/file/memory.cpp
@@ -289,9 +289,7 @@ bool MemoryFile::on_seek(int64_t offset, int whence, uint64_t &new_offset)
         new_offset = priv->pos = priv->size + static_cast<size_t>(offset);
         break;
     default:
-        set_error(make_error_code(FileError::InvalidWhence),
-                  "Invalid whence argument: %d", whence);
-        return false;
+        MB_UNREACHABLE("Invalid whence argument: %d", whence);
     }
 
     return true;

--- a/libmbcommon/src/file/posix.cpp
+++ b/libmbcommon/src/file/posix.cpp
@@ -336,9 +336,7 @@ bool PosixFile::open(const std::string &filename, FileOpenMode mode)
         // Convert mode to fopen-compatible mode string
         auto mode_str = priv->convert_mode(mode);
         if (!mode_str) {
-            set_error(make_error_code(FileError::InvalidMode),
-                      "Invalid mode: %d", static_cast<int>(mode));
-            return false;
+            MB_UNREACHABLE("Invalid mode: %d", static_cast<int>(mode));
         }
 
         priv->fp = nullptr;
@@ -380,9 +378,7 @@ bool PosixFile::open(const std::wstring &filename, FileOpenMode mode)
         // Convert mode to fopen-compatible mode string
         auto mode_str = priv->convert_mode(mode);
         if (!mode_str) {
-            set_error(make_error_code(FileError::InvalidMode),
-                      "Invalid mode: %d", static_cast<int>(mode));
-            return false;
+            MB_UNREACHABLE("Invalid mode: %d", static_cast<int>(mode));
         }
 
         priv->fp = nullptr;

--- a/libmbcommon/src/file/win32.cpp
+++ b/libmbcommon/src/file/win32.cpp
@@ -359,9 +359,7 @@ bool Win32File::open(const std::string &filename, FileOpenMode mode)
 
         if (!priv->convert_mode(mode, access, sharing, sa, creation, attrib,
                                 append)) {
-            set_error(make_error_code(FileError::InvalidMode),
-                      "Invalid mode: %d", static_cast<int>(mode));
-            return false;
+            MB_UNREACHABLE("Invalid mode: %d", static_cast<int>(mode));
         }
 
         priv->handle = INVALID_HANDLE_VALUE;
@@ -400,9 +398,7 @@ bool Win32File::open(const std::wstring &filename, FileOpenMode mode)
 
         if (!priv->convert_mode(mode, access, sharing, sa, creation, attrib,
                                 append)) {
-            set_error(make_error_code(FileError::InvalidMode),
-                      "Invalid mode: %d", static_cast<int>(mode));
-            return false;
+            MB_UNREACHABLE("Invalid mode: %d", static_cast<int>(mode));
         }
 
         priv->handle = INVALID_HANDLE_VALUE;
@@ -535,9 +531,7 @@ bool Win32File::on_seek(int64_t offset, int whence, uint64_t &new_offset)
         move_method = FILE_END;
         break;
     default:
-        set_error(make_error_code(FileError::InvalidWhence),
-                  "Invalid whence argument: %d", whence);
-        return false;
+        MB_UNREACHABLE("Invalid whence argument: %d", whence);
     }
 
     pos.QuadPart = offset;

--- a/libmbcommon/src/file_error.cpp
+++ b/libmbcommon/src/file_error.cpp
@@ -54,10 +54,6 @@ std::string FileErrorCategory::message(int ev) const
         return "argument out of range";
     case FileError::CannotConvertEncoding:
         return "cannot convert string encoding";
-    case FileError::InvalidMode:
-        return "invalid mode";
-    case FileError::InvalidWhence:
-        return "invalid whence";
     case FileError::InvalidState:
         return "invalid state";
     case FileError::UnsupportedRead:
@@ -83,8 +79,6 @@ FileErrorCategory::default_error_condition(int code) const noexcept
     switch (static_cast<FileError>(code)) {
     case FileError::ArgumentOutOfRange:
     case FileError::CannotConvertEncoding:
-    case FileError::InvalidMode:
-    case FileError::InvalidWhence:
         return FileErrorC::InvalidArgument;
     case FileError::InvalidState:
         return FileErrorC::InvalidState;

--- a/libmbcommon/tests/file/mock_test_file.cpp
+++ b/libmbcommon/tests/file/mock_test_file.cpp
@@ -131,9 +131,7 @@ bool TestFile::on_seek(int64_t offset, int whence, uint64_t &new_offset)
         new_offset = _position = _buf.size() + offset;
         break;
     default:
-        set_error(mb::make_error_code(mb::FileError::InvalidWhence),
-                  "Invalid whence argument: %d", whence);
-        return false;
+        MB_UNREACHABLE("Invalid whence argument: %d", whence);
     }
 
     return true;

--- a/libmbcommon/tests/file/test_fd.cpp
+++ b/libmbcommon/tests/file/test_fd.cpp
@@ -173,12 +173,15 @@ TEST_F(FileFdTest, OpenFilenameMbsFailure)
     ASSERT_EQ(file.error(), std::errc::io_error);
 }
 
+#ifndef NDEBUG
 TEST_F(FileFdTest, OpenFilenameMbsInvalidMode)
 {
-    TestableFdFile file(&_funcs);
-    ASSERT_FALSE(file.open("x", static_cast<mb::FileOpenMode>(-1)));
-    ASSERT_EQ(file.error(), mb::FileError::InvalidMode);
+    ASSERT_DEATH({
+        TestableFdFile file(&_funcs);
+        ASSERT_FALSE(file.open("x", static_cast<mb::FileOpenMode>(-1)));
+    }, "Invalid mode");
 }
+#endif
 
 TEST_F(FileFdTest, OpenFilenameWcsSuccess)
 {
@@ -214,12 +217,15 @@ TEST_F(FileFdTest, OpenFilenameWcsFailure)
     ASSERT_EQ(file.error(), std::errc::io_error);
 }
 
+#ifndef NDEBUG
 TEST_F(FileFdTest, OpenFilenameWcsInvalidMode)
 {
-    TestableFdFile file(&_funcs);
-    ASSERT_FALSE(file.open(L"x", static_cast<mb::FileOpenMode>(-1)));
-    ASSERT_EQ(file.error(), mb::FileError::InvalidMode);
+    ASSERT_DEATH({
+        TestableFdFile file(&_funcs);
+        ASSERT_FALSE(file.open(L"x", static_cast<mb::FileOpenMode>(-1)));
+    }, "Invalid mode");
 }
+#endif
 
 TEST_F(FileFdTest, OpenFstatFailed)
 {

--- a/libmbcommon/tests/file/test_posix.cpp
+++ b/libmbcommon/tests/file/test_posix.cpp
@@ -183,12 +183,15 @@ TEST_F(FilePosixTest, OpenFilenameMbsFailure)
     ASSERT_EQ(file.error(), std::errc::io_error);
 }
 
+#ifndef NDEBUG
 TEST_F(FilePosixTest, OpenFilenameMbsInvalidMode)
 {
-    TestablePosixFile file(&_funcs);
-    ASSERT_FALSE(file.open("x", static_cast<mb::FileOpenMode>(-1)));
-    ASSERT_EQ(file.error(), mb::FileError::InvalidMode);
+    ASSERT_DEATH({
+        TestablePosixFile file(&_funcs);
+        ASSERT_FALSE(file.open("x", static_cast<mb::FileOpenMode>(-1)));
+    }, "Invalid mode");
 }
+#endif
 
 TEST_F(FilePosixTest, OpenFilenameWcsSuccess)
 {
@@ -221,12 +224,15 @@ TEST_F(FilePosixTest, OpenFilenameWcsFailure)
     ASSERT_EQ(file.error(), std::errc::io_error);
 }
 
+#ifndef NDEBUG
 TEST_F(FilePosixTest, OpenFilenameWcsInvalidMode)
 {
-    TestablePosixFile file(&_funcs);
-    ASSERT_FALSE(file.open(L"x", static_cast<mb::FileOpenMode>(-1)));
-    ASSERT_EQ(file.error(), mb::FileError::InvalidMode);
+    ASSERT_DEATH({
+        TestablePosixFile file(&_funcs);
+        ASSERT_FALSE(file.open(L"x", static_cast<mb::FileOpenMode>(-1)));
+    }, "Invalid mode");
 }
+#endif
 
 TEST_F(FilePosixTest, OpenFstatFailed)
 {

--- a/libmbcommon/tests/file/test_win32.cpp
+++ b/libmbcommon/tests/file/test_win32.cpp
@@ -190,12 +190,15 @@ TEST_F(FileWin32Test, OpenFilenameMbsFailure)
     ASSERT_EQ(file.error().value(), ERROR_INVALID_HANDLE);
 }
 
+#ifndef NDEBUG
 TEST_F(FileWin32Test, OpenFilenameMbsInvalidMode)
 {
-    TestableWin32File file(&_funcs);
-    ASSERT_FALSE(file.open("x", static_cast<mb::FileOpenMode>(-1)));
-    ASSERT_EQ(file.error(), mb::FileError::InvalidMode);
+    ASSERT_DEATH({
+        TestableWin32File file(&_funcs);
+        ASSERT_FALSE(file.open("x", static_cast<mb::FileOpenMode>(-1)));
+    }, "Invalid mode");
 }
+#endif
 
 TEST_F(FileWin32Test, OpenFilenameWcsSuccess)
 {
@@ -221,12 +224,15 @@ TEST_F(FileWin32Test, OpenFilenameWcsFailure)
     ASSERT_EQ(file.error().value(), ERROR_INVALID_HANDLE);
 }
 
+#ifndef NDEBUG
 TEST_F(FileWin32Test, OpenFilenameWcsInvalidMode)
 {
-    TestableWin32File file(&_funcs);
-    ASSERT_FALSE(file.open(L"x", static_cast<mb::FileOpenMode>(-1)));
-    ASSERT_EQ(file.error(), mb::FileError::InvalidMode);
+    ASSERT_DEATH({
+        TestableWin32File file(&_funcs);
+        ASSERT_FALSE(file.open(L"x", static_cast<mb::FileOpenMode>(-1)));
+    }, "Invalid mode");
 }
+#endif
 
 TEST_F(FileWin32Test, CloseUnownedFile)
 {

--- a/libmbcommon/tests/test_file_error.cpp
+++ b/libmbcommon/tests/test_file_error.cpp
@@ -33,10 +33,6 @@ TEST(FileErrorTest, CheckErrorCodesComparableToErrorConditions)
                   mb::FileErrorC::InvalidArgument);
     TEST_EQUALITY(mb::make_error_code(mb::FileError::CannotConvertEncoding),
                   mb::FileErrorC::InvalidArgument);
-    TEST_EQUALITY(mb::make_error_code(mb::FileError::InvalidMode),
-                  mb::FileErrorC::InvalidArgument);
-    TEST_EQUALITY(mb::make_error_code(mb::FileError::InvalidWhence),
-                  mb::FileErrorC::InvalidArgument);
 
     TEST_EQUALITY(mb::make_error_code(mb::FileError::InvalidState),
                   mb::FileErrorC::InvalidState);

--- a/libmbsparse/src/sparse.cpp
+++ b/libmbsparse/src/sparse.cpp
@@ -1057,9 +1057,7 @@ bool SparseFile::on_seek(int64_t offset, int whence, uint64_t &new_offset_out)
         new_offset = priv->file_size + static_cast<uint64_t>(offset);
         break;
     default:
-        set_error(make_error_code(FileError::InvalidWhence),
-                  "Invalid seek whence: %d", whence);
-        return false;
+        MB_UNREACHABLE("Invalid seek whence: %d", whence);
     }
 
     if (!priv->move_to_chunk(new_offset)) {


### PR DESCRIPTION
Signed-off-by: Andrew Gunnerson <chenxiaolong@cxl.epac.to>