### PR TITLE
libmbcommon: Fix naming of FileOpenMode variants

### DIFF
--- a/examples/bingrep.cpp
+++ b/examples/bingrep.cpp
@@ -143,7 +143,7 @@ static bool search_file(const char *path, int64_t start, int64_t end,
                         size_t bsize, const void *pattern,
                         size_t pattern_size, int64_t max_matches)
 {
-    mb::StandardFile file(path, mb::FileOpenMode::READ_ONLY);
+    mb::StandardFile file(path, mb::FileOpenMode::ReadOnly);
 
     if (!file.is_open()) {
         fprintf(stderr, "%s: Failed to open file: %s\n",

--- a/examples/desparse.cpp
+++ b/examples/desparse.cpp
@@ -40,7 +40,7 @@ int main(int argc, char *argv[])
     mb::StandardFile output_file;
     mb::sparse::SparseFile sparse_file;
 
-    if (!input_file.open(input_path, mb::FileOpenMode::READ_ONLY)) {
+    if (!input_file.open(input_path, mb::FileOpenMode::ReadOnly)) {
         fprintf(stderr, "%s: Failed to open for reading: %s\n",
                 input_path, input_file.error_string().c_str());
         return EXIT_FAILURE;
@@ -52,7 +52,7 @@ int main(int argc, char *argv[])
         return EXIT_FAILURE;
     }
 
-    if (!output_file.open(output_path, mb::FileOpenMode::WRITE_ONLY)) {
+    if (!output_file.open(output_path, mb::FileOpenMode::WriteOnly)) {
         fprintf(stderr, "%s: Failed to open for writing: %s\n",
                 output_path, output_file.error_string().c_str());
         return EXIT_FAILURE;

--- a/libmbbootimg/src/reader.cpp
+++ b/libmbbootimg/src/reader.cpp
@@ -340,7 +340,7 @@ int Reader::open_filename(const std::string &filename)
     ENSURE_STATE_OR_RETURN(ReaderState::New, RET_FATAL);
 
     std::unique_ptr<File> file(
-            new StandardFile(filename, FileOpenMode::READ_ONLY));
+            new StandardFile(filename, FileOpenMode::ReadOnly));
     if (!file->is_open()) {
         set_error(file->error(),
                   "Failed to open for reading: %s",
@@ -366,7 +366,7 @@ int Reader::open_filename_w(const std::wstring &filename)
     ENSURE_STATE_OR_RETURN(ReaderState::New, RET_FATAL);
 
     std::unique_ptr<File> file(
-            new StandardFile(filename, FileOpenMode::READ_ONLY));
+            new StandardFile(filename, FileOpenMode::ReadOnly));
     if (!file->is_open()) {
         set_error(file->error(),
                   "Failed to open for reading: %s",

--- a/libmbbootimg/src/writer.cpp
+++ b/libmbbootimg/src/writer.cpp
@@ -361,7 +361,7 @@ int Writer::open_filename(const std::string &filename)
     ENSURE_STATE_OR_RETURN(WriterState::New, RET_FATAL);
 
     std::unique_ptr<File> file(
-            new StandardFile(filename, FileOpenMode::READ_WRITE_TRUNC));
+            new StandardFile(filename, FileOpenMode::ReadWriteTrunc));
 
     // Open in read/write mode since some formats need to reread the file
     if (!file->is_open()) {
@@ -389,7 +389,7 @@ int Writer::open_filename_w(const std::wstring &filename)
     ENSURE_STATE_OR_RETURN(WriterState::New, RET_FATAL);
 
     std::unique_ptr<File> file(
-            new StandardFile(filename, FileOpenMode::READ_WRITE_TRUNC));
+            new StandardFile(filename, FileOpenMode::ReadWriteTrunc));
 
     // Open in read/write mode since some formats need to reread the file
     if (!file->is_open()) {

--- a/libmbcommon/include/mbcommon/file/open_mode.h
+++ b/libmbcommon/include/mbcommon/file/open_mode.h
@@ -24,12 +24,12 @@ namespace mb
 
 enum class FileOpenMode
 {
-    READ_ONLY,
-    READ_WRITE,
-    WRITE_ONLY,
-    READ_WRITE_TRUNC,
-    APPEND,
-    READ_APPEND,
+    ReadOnly,
+    ReadWrite,
+    WriteOnly,
+    ReadWriteTrunc,
+    Append,
+    ReadAppend,
 };
 
 }

--- a/libmbcommon/src/file.cpp
+++ b/libmbcommon/src/file.cpp
@@ -120,10 +120,10 @@ File::~File()
  * back to a useful state by assigning from a valid object. For example:
  *
  * \code{.cpp}
- * mb::StandardFile file1("foo.txt", mb::FileOpenMode::READ_ONLY);
- * mb::StandardFile file2("bar.txt", mb::FileOpenMode::READ_ONLY);
+ * mb::StandardFile file1("foo.txt", mb::FileOpenMode::ReadOnly);
+ * mb::StandardFile file2("bar.txt", mb::FileOpenMode::ReadOnly);
  * file1 = std::move(file2);
- * file2 = mb::StandardFile("baz.txt", mb::FileOpenMode::READ_ONLY);
+ * file2 = mb::StandardFile("baz.txt", mb::FileOpenMode::ReadOnly);
  * \endcode
  */
 File::File(File &&other) noexcept : _priv_ptr(std::move(other._priv_ptr))
@@ -140,10 +140,10 @@ File::File(File &&other) noexcept : _priv_ptr(std::move(other._priv_ptr))
  * back to a useful state by assigning from a valid object. For example:
  *
  * \code{.cpp}
- * mb::StandardFile file1("foo.txt", mb::FileOpenMode::READ_ONLY);
- * mb::StandardFile file2("bar.txt", mb::FileOpenMode::READ_ONLY);
+ * mb::StandardFile file1("foo.txt", mb::FileOpenMode::ReadOnly);
+ * mb::StandardFile file2("bar.txt", mb::FileOpenMode::ReadOnly);
  * file1 = std::move(file2);
- * file2 = mb::StandardFile("baz.txt", mb::FileOpenMode::READ_ONLY);
+ * file2 = mb::StandardFile("baz.txt", mb::FileOpenMode::ReadOnly);
  * \endcode
  */
 File & File::operator=(File &&rhs) noexcept

--- a/libmbcommon/src/file/fd.cpp
+++ b/libmbcommon/src/file/fd.cpp
@@ -128,22 +128,22 @@ int FdFilePrivate::convert_mode(FileOpenMode mode)
 #endif
 
     switch (mode) {
-    case FileOpenMode::READ_ONLY:
+    case FileOpenMode::ReadOnly:
         ret |= O_RDONLY;
         break;
-    case FileOpenMode::READ_WRITE:
+    case FileOpenMode::ReadWrite:
         ret |= O_RDWR;
         break;
-    case FileOpenMode::WRITE_ONLY:
+    case FileOpenMode::WriteOnly:
         ret |= O_WRONLY | O_CREAT | O_TRUNC;
         break;
-    case FileOpenMode::READ_WRITE_TRUNC:
+    case FileOpenMode::ReadWriteTrunc:
         ret |= O_RDWR | O_CREAT | O_TRUNC;
         break;
-    case FileOpenMode::APPEND:
+    case FileOpenMode::Append:
         ret |= O_WRONLY | O_CREAT | O_APPEND;
         break;
-    case FileOpenMode::READ_APPEND:
+    case FileOpenMode::ReadAppend:
         ret |= O_RDWR | O_CREAT | O_APPEND;
         break;
     default:

--- a/libmbcommon/src/file/open_mode.cpp
+++ b/libmbcommon/src/file/open_mode.cpp
@@ -34,7 +34,7 @@ namespace mb
  */
 
 /*!
- * \var FileOpenMode::READ_ONLY
+ * \var FileOpenMode::ReadOnly
  *
  * \brief Open file for reading.
  *
@@ -42,7 +42,7 @@ namespace mb
  */
 
 /*!
- * \var FileOpenMode::READ_WRITE
+ * \var FileOpenMode::ReadWrite
  *
  * \brief Open file for reading and writing.
  *
@@ -50,7 +50,7 @@ namespace mb
  */
 
 /*!
- * \var FileOpenMode::WRITE_ONLY
+ * \var FileOpenMode::WriteOnly
  *
  * \brief Truncate file and open for writing.
  *
@@ -58,7 +58,7 @@ namespace mb
  */
 
 /*!
- * \var FileOpenMode::READ_WRITE_TRUNC
+ * \var FileOpenMode::ReadWriteTrunc
  *
  * \brief Truncate file and open for reading and writing.
  *
@@ -66,7 +66,7 @@ namespace mb
  */
 
 /*!
- * \var FileOpenMode::APPEND
+ * \var FileOpenMode::Append
  *
  * \brief Open file for appending.
  *
@@ -74,7 +74,7 @@ namespace mb
  */
 
 /*!
- * \var FileOpenMode::READ_APPEND
+ * \var FileOpenMode::ReadAppend
  *
  * \brief Open file for reading and appending.
  *

--- a/libmbcommon/src/file/posix.cpp
+++ b/libmbcommon/src/file/posix.cpp
@@ -138,17 +138,17 @@ void PosixFilePrivate::clear()
 const wchar_t * PosixFilePrivate::convert_mode(FileOpenMode mode)
 {
     switch (mode) {
-    case FileOpenMode::READ_ONLY:
+    case FileOpenMode::ReadOnly:
         return L"rbN";
-    case FileOpenMode::READ_WRITE:
+    case FileOpenMode::ReadWrite:
         return L"r+bN";
-    case FileOpenMode::WRITE_ONLY:
+    case FileOpenMode::WriteOnly:
         return L"wbN";
-    case FileOpenMode::READ_WRITE_TRUNC:
+    case FileOpenMode::ReadWriteTrunc:
         return L"w+bN";
-    case FileOpenMode::APPEND:
+    case FileOpenMode::Append:
         return L"abN";
-    case FileOpenMode::READ_APPEND:
+    case FileOpenMode::ReadAppend:
         return L"a+bN";
     default:
         return nullptr;
@@ -158,17 +158,17 @@ const wchar_t * PosixFilePrivate::convert_mode(FileOpenMode mode)
 const char * PosixFilePrivate::convert_mode(FileOpenMode mode)
 {
     switch (mode) {
-    case FileOpenMode::READ_ONLY:
+    case FileOpenMode::ReadOnly:
         return "rbe";
-    case FileOpenMode::READ_WRITE:
+    case FileOpenMode::ReadWrite:
         return "r+be";
-    case FileOpenMode::WRITE_ONLY:
+    case FileOpenMode::WriteOnly:
         return "wbe";
-    case FileOpenMode::READ_WRITE_TRUNC:
+    case FileOpenMode::ReadWriteTrunc:
         return "w+be";
-    case FileOpenMode::APPEND:
+    case FileOpenMode::Append:
         return "abe";
-    case FileOpenMode::READ_APPEND:
+    case FileOpenMode::ReadAppend:
         return "a+be";
     default:
         return nullptr;

--- a/libmbcommon/src/file/win32.cpp
+++ b/libmbcommon/src/file/win32.cpp
@@ -152,28 +152,28 @@ bool Win32FilePrivate::convert_mode(FileOpenMode mode,
     bool append = false;
 
     switch (mode) {
-    case FileOpenMode::READ_ONLY:
+    case FileOpenMode::ReadOnly:
         access = GENERIC_READ;
         creation = OPEN_EXISTING;
         break;
-    case FileOpenMode::READ_WRITE:
+    case FileOpenMode::ReadWrite:
         access = GENERIC_READ | GENERIC_WRITE;
         creation = OPEN_EXISTING;
         break;
-    case FileOpenMode::WRITE_ONLY:
+    case FileOpenMode::WriteOnly:
         access = GENERIC_WRITE;
         creation = CREATE_ALWAYS;
         break;
-    case FileOpenMode::READ_WRITE_TRUNC:
+    case FileOpenMode::ReadWriteTrunc:
         access = GENERIC_READ | GENERIC_WRITE;
         creation = CREATE_ALWAYS;
         break;
-    case FileOpenMode::APPEND:
+    case FileOpenMode::Append:
         access = GENERIC_WRITE;
         creation = OPEN_ALWAYS;
         append = true;
         break;
-    case FileOpenMode::READ_APPEND:
+    case FileOpenMode::ReadAppend:
         access = GENERIC_READ | GENERIC_WRITE;
         creation = OPEN_ALWAYS;
         append = true;

--- a/libmbcommon/tests/file/test_fd.cpp
+++ b/libmbcommon/tests/file/test_fd.cpp
@@ -153,7 +153,7 @@ TEST_F(FileFdTest, OpenFilenameMbsSuccess)
 #endif
 
     TestableFdFile file(&_funcs);
-    ASSERT_TRUE(file.open("x", mb::FileOpenMode::READ_ONLY));
+    ASSERT_TRUE(file.open("x", mb::FileOpenMode::ReadOnly));
 }
 
 TEST_F(FileFdTest, OpenFilenameMbsFailure)
@@ -169,7 +169,7 @@ TEST_F(FileFdTest, OpenFilenameMbsFailure)
 #endif
 
     TestableFdFile file(&_funcs);
-    ASSERT_FALSE(file.open("x", mb::FileOpenMode::READ_ONLY));
+    ASSERT_FALSE(file.open("x", mb::FileOpenMode::ReadOnly));
     ASSERT_EQ(file.error(), std::errc::io_error);
 }
 
@@ -197,7 +197,7 @@ TEST_F(FileFdTest, OpenFilenameWcsSuccess)
 #endif
 
     TestableFdFile file(&_funcs);
-    ASSERT_TRUE(file.open(L"x", mb::FileOpenMode::READ_ONLY));
+    ASSERT_TRUE(file.open(L"x", mb::FileOpenMode::ReadOnly));
 }
 
 TEST_F(FileFdTest, OpenFilenameWcsFailure)
@@ -213,7 +213,7 @@ TEST_F(FileFdTest, OpenFilenameWcsFailure)
 #endif
 
     TestableFdFile file(&_funcs);
-    ASSERT_FALSE(file.open(L"x", mb::FileOpenMode::READ_ONLY));
+    ASSERT_FALSE(file.open(L"x", mb::FileOpenMode::ReadOnly));
     ASSERT_EQ(file.error(), std::errc::io_error);
 }
 

--- a/libmbcommon/tests/file/test_posix.cpp
+++ b/libmbcommon/tests/file/test_posix.cpp
@@ -165,7 +165,7 @@ TEST_F(FilePosixTest, OpenFilenameMbsSuccess)
 #endif
 
     TestablePosixFile file(&_funcs);
-    ASSERT_TRUE(file.open("x", mb::FileOpenMode::READ_ONLY));
+    ASSERT_TRUE(file.open("x", mb::FileOpenMode::ReadOnly));
 }
 
 TEST_F(FilePosixTest, OpenFilenameMbsFailure)
@@ -179,7 +179,7 @@ TEST_F(FilePosixTest, OpenFilenameMbsFailure)
 #endif
 
     TestablePosixFile file(&_funcs);
-    ASSERT_FALSE(file.open("x", mb::FileOpenMode::READ_ONLY));
+    ASSERT_FALSE(file.open("x", mb::FileOpenMode::ReadOnly));
     ASSERT_EQ(file.error(), std::errc::io_error);
 }
 
@@ -206,7 +206,7 @@ TEST_F(FilePosixTest, OpenFilenameWcsSuccess)
 #endif
 
     TestablePosixFile file(&_funcs);
-    ASSERT_TRUE(file.open(L"x", mb::FileOpenMode::READ_ONLY));
+    ASSERT_TRUE(file.open(L"x", mb::FileOpenMode::ReadOnly));
 }
 
 TEST_F(FilePosixTest, OpenFilenameWcsFailure)
@@ -220,7 +220,7 @@ TEST_F(FilePosixTest, OpenFilenameWcsFailure)
 #endif
 
     TestablePosixFile file(&_funcs);
-    ASSERT_FALSE(file.open(L"x", mb::FileOpenMode::READ_ONLY));
+    ASSERT_FALSE(file.open(L"x", mb::FileOpenMode::ReadOnly));
     ASSERT_EQ(file.error(), std::errc::io_error);
 }
 

--- a/libmbcommon/tests/file/test_win32.cpp
+++ b/libmbcommon/tests/file/test_win32.cpp
@@ -175,7 +175,7 @@ TEST_F(FileWin32Test, OpenFilenameMbsSuccess)
             .WillOnce(testing::Return(reinterpret_cast<HANDLE>(1)));
 
     TestableWin32File file(&_funcs);
-    ASSERT_TRUE(file.open("x", mb::FileOpenMode::READ_ONLY));
+    ASSERT_TRUE(file.open("x", mb::FileOpenMode::ReadOnly));
 }
 
 TEST_F(FileWin32Test, OpenFilenameMbsFailure)
@@ -186,7 +186,7 @@ TEST_F(FileWin32Test, OpenFilenameMbsFailure)
             .Times(1);
 
     TestableWin32File file(&_funcs);
-    ASSERT_FALSE(file.open("x", mb::FileOpenMode::READ_ONLY));
+    ASSERT_FALSE(file.open("x", mb::FileOpenMode::ReadOnly));
     ASSERT_EQ(file.error().value(), ERROR_INVALID_HANDLE);
 }
 
@@ -209,7 +209,7 @@ TEST_F(FileWin32Test, OpenFilenameWcsSuccess)
             .WillOnce(testing::Return(reinterpret_cast<HANDLE>(1)));
 
     TestableWin32File file(&_funcs);
-    ASSERT_TRUE(file.open(L"x", mb::FileOpenMode::READ_ONLY));
+    ASSERT_TRUE(file.open(L"x", mb::FileOpenMode::ReadOnly));
 }
 
 TEST_F(FileWin32Test, OpenFilenameWcsFailure)
@@ -220,7 +220,7 @@ TEST_F(FileWin32Test, OpenFilenameWcsFailure)
             .Times(1);
 
     TestableWin32File file(&_funcs);
-    ASSERT_FALSE(file.open(L"x", mb::FileOpenMode::READ_ONLY));
+    ASSERT_FALSE(file.open(L"x", mb::FileOpenMode::ReadOnly));
     ASSERT_EQ(file.error().value(), ERROR_INVALID_HANDLE);
 }
 

--- a/libmbpatcher/src/patchers/odinpatcher.cpp
+++ b/libmbpatcher/src/patchers/odinpatcher.cpp
@@ -745,14 +745,14 @@ int OdinPatcherPrivate::la_open_cb(archive *a, void *userdata)
         return -1;
     }
 
-    ret = priv->la_file.open(w_filename, FileOpenMode::READ_ONLY);
+    ret = priv->la_file.open(w_filename, FileOpenMode::ReadOnly);
 #else
 #  ifdef __ANDROID__
     if (priv->fd >= 0) {
         ret = priv->la_file.open(priv->fd, false);
     } else
 #  endif
-    ret = priv->la_file.open(priv->info->input_path(), FileOpenMode::READ_ONLY);
+    ret = priv->la_file.open(priv->info->input_path(), FileOpenMode::ReadOnly);
 #endif
 
     if (!ret) {

--- a/libmbpatcher/src/private/fileutils.cpp
+++ b/libmbpatcher/src/private/fileutils.cpp
@@ -77,7 +77,7 @@ ErrorCode FileUtils::read_to_memory(const std::string &path,
 {
     StandardFile file;
 
-    auto error = open_file(file, path, FileOpenMode::READ_ONLY);
+    auto error = open_file(file, path, FileOpenMode::ReadOnly);
     if (error != ErrorCode::NoError) {
         LOGE("%s: Failed to open for reading: %s",
              path.c_str(), file.error_string().c_str());
@@ -119,7 +119,7 @@ ErrorCode FileUtils::read_to_string(const std::string &path,
 {
     StandardFile file;
 
-    auto error = open_file(file, path, FileOpenMode::READ_ONLY);
+    auto error = open_file(file, path, FileOpenMode::ReadOnly);
     if (error != ErrorCode::NoError) {
         LOGE("%s: Failed to open for reading: %s",
              path.c_str(), file.error_string().c_str());
@@ -154,7 +154,7 @@ ErrorCode FileUtils::write_from_memory(const std::string &path,
 {
     StandardFile file;
 
-    auto error = open_file(file, path, FileOpenMode::WRITE_ONLY);
+    auto error = open_file(file, path, FileOpenMode::WriteOnly);
     if (error != ErrorCode::NoError) {
         LOGE("%s: Failed to open for writing: %s",
              path.c_str(), file.error_string().c_str());
@@ -177,7 +177,7 @@ ErrorCode FileUtils::write_from_string(const std::string &path,
 {
     StandardFile file;
 
-    auto error = open_file(file, path, FileOpenMode::WRITE_ONLY);
+    auto error = open_file(file, path, FileOpenMode::WriteOnly);
     if (error != ErrorCode::NoError) {
         LOGE("%s: Failed to open for writing: %s",
              path.c_str(), file.error_string().c_str());

--- a/libmbpatcher/src/private/miniziputils.cpp
+++ b/libmbpatcher/src/private/miniziputils.cpp
@@ -538,7 +538,7 @@ bool MinizipUtils::extract_file(unzFile uf, const std::string &directory)
     int ret;
 
     auto error = FileUtils::open_file(file, full_path,
-                                      FileOpenMode::WRITE_ONLY);
+                                      FileOpenMode::WriteOnly);
     if (error != ErrorCode::NoError) {
         LOGE("%s: Failed to open for writing: %s",
              full_path.c_str(), file.error_string().c_str());
@@ -700,7 +700,7 @@ ErrorCode MinizipUtils::add_file(zipFile zf,
     int ret;
 
     auto error = FileUtils::open_file(file, path,
-                                      FileOpenMode::READ_ONLY);
+                                      FileOpenMode::ReadOnly);
     if (error != ErrorCode::NoError) {
         LOGE("%s: Failed to open for reading: %s",
              path.c_str(), file.error_string().c_str());

--- a/mbtool/installer_util.cpp
+++ b/mbtool/installer_util.cpp
@@ -543,14 +543,14 @@ bool InstallerUtil::patch_kernel_rkp(const std::string &input_file,
     optional<uint64_t> offset;
 
     // Open input file
-    if (!fin.open(input_file, FileOpenMode::READ_ONLY)) {
+    if (!fin.open(input_file, FileOpenMode::ReadOnly)) {
         LOGE("%s: Failed to open for reading: %s",
              input_file.c_str(), fin.error_string().c_str());
         return false;
     }
 
     // Open output file
-    if (!fout.open(output_file, FileOpenMode::WRITE_ONLY)) {
+    if (!fout.open(output_file, FileOpenMode::WriteOnly)) {
         LOGE("%s: Failed to open for writing: %s",
              output_file.c_str(), fout.error_string().c_str());
         return false;

--- a/odinupdater/fuse-sparse.cpp
+++ b/odinupdater/fuse-sparse.cpp
@@ -94,7 +94,7 @@ static int fuse_open(const char *path, fuse_file_info *fi)
         return -ENOMEM;
     }
 
-    if (!ctx->source_file.open(source_fd_path, mb::FileOpenMode::READ_ONLY)) {
+    if (!ctx->source_file.open(source_fd_path, mb::FileOpenMode::ReadOnly)) {
         fprintf(stderr, "%s: Failed to open file: %s\n",
                 source_fd_path, ctx->source_file.error_string().c_str());
         auto error = ctx->source_file.error();
@@ -195,7 +195,7 @@ static int get_sparse_file_size()
     mb::StandardFile source_file;
     mb::sparse::SparseFile sparse_file;
 
-    if (!source_file.open(source_fd_path, mb::FileOpenMode::READ_ONLY)) {
+    if (!source_file.open(source_fd_path, mb::FileOpenMode::ReadOnly)) {
         fprintf(stderr, "%s: Failed to open file: %s\n",
                 source_fd_path, source_file.error_string().c_str());
         auto error = source_file.error();

--- a/odinupdater/odinupdater.cpp
+++ b/odinupdater/odinupdater.cpp
@@ -407,7 +407,7 @@ static ExtractResult extract_sparse_file(const char *zip_filename,
         return ExtractResult::ERROR;
     }
 
-    if (!out_file.open(out_filename, mb::FileOpenMode::WRITE_ONLY)) {
+    if (!out_file.open(out_filename, mb::FileOpenMode::WriteOnly)) {
         error("%s: Failed to open for writing: %s",
               out_filename, out_file.error_string().c_str());
         return ExtractResult::ERROR;


### PR DESCRIPTION
Signed-off-by: Andrew Gunnerson <chenxiaolong@cxl.epac.to>