### PR TITLE
libmbcommon: file: Remove ability to clear fatal status

### DIFF
--- a/libmbcommon/include/mbcommon/file.h
+++ b/libmbcommon/include/mbcommon/file.h
@@ -59,7 +59,7 @@ public:
     // File state
     bool is_open();
     bool is_fatal();
-    bool set_fatal(bool fatal);
+    void set_fatal();
 
     // Error handling functions
     std::error_code error();

--- a/libmbcommon/src/file.cpp
+++ b/libmbcommon/src/file.cpp
@@ -346,20 +346,18 @@ bool File::is_fatal()
 /*!
  * \brief Set whether file is fatal state
  *
- * This function can only be called if the file is opened.
+ * This function only has an effect if the file is opened.
  *
  * If the file is in the fatal state, the only valid operation is to call
  * close().
- *
- * \return Whether the fatal state was successfully set
  */
-bool File::set_fatal(bool fatal)
+void File::set_fatal()
 {
-    GET_PIMPL_OR_RETURN(false);
-    ENSURE_STATE_OR_RETURN(FileState::OPENED | FileState::FATAL, false);
+    GET_PIMPL_OR_RETURN();
 
-    priv->state = fatal ? FileState::FATAL : FileState::OPENED;
-    return true;
+    if (priv->state == FileState::OPENED) {
+        priv->state = FileState::FATAL;
+    }
 }
 
 /*!

--- a/libmbcommon/src/file/posix.cpp
+++ b/libmbcommon/src/file/posix.cpp
@@ -519,7 +519,7 @@ bool PosixFile::on_seek(int64_t offset, int whence, uint64_t &new_offset)
         // Try to restore old position
         set_error(ec_from_errno(), "Failed to get file position");
         if (priv->funcs->fn_fseeko(priv->fp, old_pos, SEEK_SET) != 0) {
-            set_fatal(true);
+            set_fatal();
         }
         return false;
     }

--- a/libmbcommon/src/file/win32.cpp
+++ b/libmbcommon/src/file/win32.cpp
@@ -576,7 +576,7 @@ bool Win32File::on_truncate(uint64_t size)
     if (!on_seek(static_cast<int64_t>(current_pos), SEEK_SET, temp)) {
         // We can't guarantee the file position so the handle shouldn't be used
         // anymore
-        set_fatal(true);
+        set_fatal();
         ret = false;
     }
 

--- a/libmbcommon/src/file_util.cpp
+++ b/libmbcommon/src/file_util.cpp
@@ -295,7 +295,7 @@ bool file_search(File &file, int64_t start, int64_t end,
             } else if (discarded != offset) {
                 file.set_error(make_error_code(FileError::ArgumentOutOfRange),
                                "Reached EOF before starting offset");
-                file.set_fatal(true);
+                file.set_fatal();
                 return false;
             }
         } else {

--- a/libmbsparse/src/sparse.cpp
+++ b/libmbsparse/src/sparse.cpp
@@ -173,7 +173,7 @@ bool SparseFilePrivate::wread(void *buf, size_t size)
         pub->set_error(file->error(), "Requested %" MB_PRIzu
                        " bytes, but only read %" MB_PRIzu " bytes",
                        size, bytes_read);
-        pub->set_fatal(true);
+        pub->set_fatal();
         return false;
     }
 
@@ -224,14 +224,14 @@ bool SparseFilePrivate::skip_bytes(uint64_t bytes)
         } else if (discarded != bytes) {
             pub->set_error(file->error(), "Reached EOF when skipping bytes: %s",
                            file->error_string().c_str());
-            pub->set_fatal(true);
+            pub->set_fatal();
             return false;
         }
         return true;
     }
 
     // Unreached
-    pub->set_fatal(true);
+    pub->set_fatal();
     return false;
 }
 
@@ -600,7 +600,7 @@ bool SparseFilePrivate::move_to_chunk(uint64_t offset)
                            "Internal error: src_begin (%" PRIu64 ")"
                            " < cur_src_offset (%" PRIu64 ")",
                            src_begin, cur_src_offset);
-            pub->set_fatal(true);
+            pub->set_fatal();
             return false;
         }
 
@@ -608,7 +608,7 @@ bool SparseFilePrivate::move_to_chunk(uint64_t offset)
             pub->set_error(pub->error(),
                            "Failed to skip to chunk #%" MB_PRIzu ": %s",
                            chunk_num, pub->error_string().c_str());
-            pub->set_fatal(true);
+            pub->set_fatal();
             return false;
         }
 
@@ -618,7 +618,7 @@ bool SparseFilePrivate::move_to_chunk(uint64_t offset)
             pub->set_error(pub->error(),
                            "Failed to read chunk header for chunk %" MB_PRIzu
                            ": %s", chunk_num, pub->error_string().c_str());
-            pub->set_fatal(true);
+            pub->set_fatal();
             return false;
         }
 
@@ -635,14 +635,14 @@ bool SparseFilePrivate::move_to_chunk(uint64_t offset)
                            "Failed to skip extra bytes in chunk #%" MB_PRIzu
                            "'s header: %s", chunk_num,
                            pub->error_string().c_str());
-            pub->set_fatal(true);
+            pub->set_fatal();
             return false;
         }
 
         ChunkInfo chunk_info{};
 
         if (!process_chunk(chdr, tgt_begin, chunk_info)) {
-            pub->set_fatal(true);
+            pub->set_fatal();
             return false;
         }
 
@@ -657,7 +657,7 @@ bool SparseFilePrivate::move_to_chunk(uint64_t offset)
                            "Chunk #%" MB_PRIzu " ends (%" PRIu64 ") after the "
                            "file size specified in the sparse header (%"
                            PRIu64 ")", chunk_num, chunk_info.end, file_size);
-            pub->set_fatal(true);
+            pub->set_fatal();
             return false;
         }
 
@@ -671,7 +671,7 @@ bool SparseFilePrivate::move_to_chunk(uint64_t offset)
                            "Last chunk does not end (%" PRIu64 ") at position"
                            " specified by sparse header (%" PRIu64 ")",
                            chunks.back().end, file_size);
-            pub->set_fatal(true);
+            pub->set_fatal();
             return false;
         }
 

--- a/libmbsparse/tests/test_sparse.cpp
+++ b/libmbsparse/tests/test_sparse.cpp
@@ -49,7 +49,7 @@ protected:
         case mb::sparse::Seekability::CAN_READ:
             break;
         default:
-            set_fatal(true);
+            set_fatal();
             return false;
         }
 


### PR DESCRIPTION
There's no need to ever revert from the FATAL state to the OPENED state.

Signed-off-by: Andrew Gunnerson <chenxiaolong@cxl.epac.to>