### PR TITLE
libmbcommon: Replace file_*_fully() with file_*_retry() and file_*_exact()

### DIFF
--- a/libmbbootimg/include/mbbootimg/format/loki_error.h
+++ b/libmbbootimg/include/mbbootimg/format/loki_error.h
@@ -56,7 +56,6 @@ enum class LokiError
 
     // Miscellaneous
     UnexpectedFileTruncation            = 50,
-    UnexpectedEndOfFile                 = 51,
 };
 
 MB_EXPORT std::error_code make_error_code(LokiError e);

--- a/libmbbootimg/include/mbbootimg/format/segment_error_p.h
+++ b/libmbbootimg/include/mbbootimg/format/segment_error_p.h
@@ -34,8 +34,7 @@ enum class SegmentError
     EntryWouldOverflowOffset    = 11,
     ReadWouldOverflowInteger    = 12,
     WriteWouldOverflowInteger   = 13,
-    EntryIsTruncated            = 14,
-    InvalidEntrySize            = 15,
+    InvalidEntrySize            = 14,
 };
 
 MB_EXPORT std::error_code make_error_code(SegmentError e);

--- a/libmbbootimg/include/mbbootimg/format/sony_elf_error.h
+++ b/libmbbootimg/include/mbbootimg/format/sony_elf_error.h
@@ -36,9 +36,6 @@ enum class SonyElfError
     InvalidElfMagic         = 11,
     KernelCmdlineTooLong    = 12,
     InvalidTypeOrFlagsField = 13,
-
-    // Miscellaneous errors
-    UnexpectedEndOfFile     = 20,
 };
 
 MB_EXPORT std::error_code make_error_code(SonyElfError e);

--- a/libmbbootimg/src/format/android_reader.cpp
+++ b/libmbbootimg/src/format/android_reader.cpp
@@ -246,7 +246,7 @@ bool AndroidFormatReader::find_header(Reader &reader, File &file,
         return false;
     }
 
-    auto n = file_read_fully(file, buf, static_cast<size_t>(max_header_offset)
+    auto n = file_read_retry(file, buf, static_cast<size_t>(max_header_offset)
                              + sizeof(AndroidHeader));
     if (!n) {
         reader.set_error(n.error(),
@@ -336,7 +336,7 @@ bool AndroidFormatReader::find_samsung_seandroid_magic(Reader &reader,
         return false;
     }
 
-    auto n = file_read_fully(file, buf, sizeof(buf));
+    auto n = file_read_retry(file, buf, sizeof(buf));
     if (!n) {
         reader.set_error(n.error(),
                          "Failed to read SEAndroid magic: %s",
@@ -411,7 +411,7 @@ bool AndroidFormatReader::find_bump_magic(Reader &reader, File &file,
         return false;
     }
 
-    auto n = file_read_fully(file, buf, sizeof(buf));
+    auto n = file_read_retry(file, buf, sizeof(buf));
     if (!n) {
         reader.set_error(n.error(),
                          "Failed to read SEAndroid magic: %s",

--- a/libmbbootimg/src/format/android_writer.cpp
+++ b/libmbbootimg/src/format/android_writer.cpp
@@ -281,22 +281,22 @@ bool AndroidFormatWriter::close(File &file)
         // Write bump magic if we're outputting a bump'd image. Otherwise, write
         // the Samsung SEAndroid magic.
         if (_is_bump) {
-            auto n = file_write_fully(file, bump::BUMP_MAGIC,
-                                      bump::BUMP_MAGIC_SIZE);
-            if (!n || n.value() != bump::BUMP_MAGIC_SIZE) {
-                _writer.set_error(n.error(),
+            auto ret = file_write_exact(file, bump::BUMP_MAGIC,
+                                        bump::BUMP_MAGIC_SIZE);
+            if (!ret) {
+                _writer.set_error(ret.error(),
                                   "Failed to write Bump magic: %s",
-                                  n.error().message().c_str());
+                                  ret.error().message().c_str());
                 if (file.is_fatal()) { _writer.set_fatal(); }
                 return false;
             }
         } else {
-            auto n = file_write_fully(file, SAMSUNG_SEANDROID_MAGIC,
-                                      SAMSUNG_SEANDROID_MAGIC_SIZE);
-            if (!n || n.value() != SAMSUNG_SEANDROID_MAGIC_SIZE) {
-                _writer.set_error(n.error(),
+            auto ret = file_write_exact(file, SAMSUNG_SEANDROID_MAGIC,
+                                        SAMSUNG_SEANDROID_MAGIC_SIZE);
+            if (!ret) {
+                _writer.set_error(ret.error(),
                                   "Failed to write SEAndroid magic: %s",
-                                  n.error().message().c_str());
+                                  ret.error().message().c_str());
                 if (file.is_fatal()) { _writer.set_fatal(); }
                 return false;
             }
@@ -326,11 +326,11 @@ bool AndroidFormatWriter::close(File &file)
         }
 
         // Write header
-        auto n = file_write_fully(file, &hdr, sizeof(hdr));
-        if (!n || n.value() != sizeof(hdr)) {
-            _writer.set_error(n.error(),
+        auto ret = file_write_exact(file, &hdr, sizeof(hdr));
+        if (!ret) {
+            _writer.set_error(ret.error(),
                               "Failed to write header: %s",
-                              n.error().message().c_str());
+                              ret.error().message().c_str());
             if (file.is_fatal()) { _writer.set_fatal(); }
             return false;
         }

--- a/libmbbootimg/src/format/loki.cpp
+++ b/libmbbootimg/src/format/loki.cpp
@@ -157,16 +157,12 @@ static bool _loki_read_android_header(Writer &writer, File &file,
         return false;
     }
 
-    auto n = file_read_fully(file, &ahdr, sizeof(ahdr));
-    if (!n) {
-        writer.set_error(n.error(),
+    auto ret = file_read_exact(file, &ahdr, sizeof(ahdr));
+    if (!ret) {
+        writer.set_error(ret.error(),
                          "Failed to read Android header: %s",
-                         n.error().message().c_str());
+                         ret.error().message().c_str());
         if (file.is_fatal()) { writer.set_fatal(); }
-        return false;
-    } else if (n.value() != sizeof(ahdr)) {
-        writer.set_error(LokiError::UnexpectedEndOfFile,
-                         "Unexpected EOF when reading Android header");
         return false;
     }
 
@@ -191,16 +187,12 @@ static bool _loki_write_android_header(Writer &writer, File &file,
         return false;
     }
 
-    auto n = file_write_fully(file, &dup, sizeof(dup));
-    if (!n) {
-        writer.set_error(n.error(),
+    auto ret = file_write_exact(file, &dup, sizeof(dup));
+    if (!ret) {
+        writer.set_error(ret.error(),
                          "Failed to write Android header: %s",
-                         n.error().message().c_str());
+                         ret.error().message().c_str());
         if (file.is_fatal()) { writer.set_fatal(); }
-        return false;
-    } else if (n.value() != sizeof(dup)) {
-        writer.set_error(LokiError::UnexpectedEndOfFile,
-                         "Unexpected EOF when writing Android header");
         return false;
     }
 
@@ -223,16 +215,12 @@ static bool _loki_write_loki_header(Writer &writer, File &file,
         return false;
     }
 
-    auto n = file_write_fully(file, &dup, sizeof(dup));
-    if (!n) {
-        writer.set_error(n.error(),
+    auto ret = file_write_exact(file, &dup, sizeof(dup));
+    if (!ret) {
+        writer.set_error(ret.error(),
                          "Failed to write Loki header: %s",
-                         n.error().message().c_str());
+                         ret.error().message().c_str());
         if (file.is_fatal()) { writer.set_fatal(); }
-        return false;
-    } else if (n.value() != sizeof(dup)) {
-        writer.set_error(LokiError::UnexpectedEndOfFile,
-                         "Unexpected EOF when writing Loki header");
         return false;
     }
 
@@ -283,16 +271,11 @@ static bool _loki_write_aboot(Writer &writer, File &file,
         return false;
     }
 
-    auto n = file_write_fully(file, aboot + aboot_func_offset, fake_size);
-    if (!n) {
-        writer.set_error(n.error(),
+    auto ret = file_write_exact(file, aboot + aboot_func_offset, fake_size);
+    if (!ret) {
+        writer.set_error(ret.error(),
                          "Failed to write aboot segment: %s",
-                         n.error().message().c_str());
-        writer.set_fatal();
-        return false;
-    } else if (n.value() != fake_size) {
-        writer.set_error(LokiError::UnexpectedEndOfFile,
-                         "Unexpected EOF when writing aboot segment");
+                         ret.error().message().c_str());
         writer.set_fatal();
         return false;
     }
@@ -314,16 +297,11 @@ static bool _loki_write_shellcode(Writer &writer, File &file,
         return false;
     }
 
-    auto n = file_write_fully(file, patch, LOKI_SHELLCODE_SIZE);
-    if (!n) {
-        writer.set_error(n.error(),
+    auto ret = file_write_exact(file, patch, LOKI_SHELLCODE_SIZE);
+    if (!ret) {
+        writer.set_error(ret.error(),
                          "Failed to write shellcode: %s",
-                         n.error().message().c_str());
-        if (file.is_fatal()) { writer.set_fatal(); }
-        return false;
-    } else if (n.value() != LOKI_SHELLCODE_SIZE) {
-        writer.set_error(LokiError::UnexpectedEndOfFile,
-                         "Unexpected EOF when writing shellcode");
+                         ret.error().message().c_str());
         writer.set_fatal();
         return false;
     }

--- a/libmbbootimg/src/format/loki_error.cpp
+++ b/libmbbootimg/src/format/loki_error.cpp
@@ -84,8 +84,6 @@ std::string LokiErrorCategory::message(int ev) const
         return "aboot function out of range";
     case LokiError::UnexpectedFileTruncation:
         return "unexpected file truncation";
-    case LokiError::UnexpectedEndOfFile:
-        return "unexpected end of file";
     default:
         return "(unknown Loki format error)";
     }

--- a/libmbbootimg/src/format/loki_writer.cpp
+++ b/libmbbootimg/src/format/loki_writer.cpp
@@ -329,11 +329,11 @@ bool LokiFormatWriter::close(File &file)
         }
 
         // Write header
-        auto n = file_write_fully(file, &hdr, sizeof(hdr));
-        if (!n || n.value() != sizeof(hdr)) {
-            _writer.set_error(n.error(),
+        auto ret = file_write_exact(file, &hdr, sizeof(hdr));
+        if (!ret) {
+            _writer.set_error(ret.error(),
                               "Failed to write header: %s",
-                              n.error().message().c_str());
+                              ret.error().message().c_str());
             if (file.is_fatal()) { _writer.set_fatal(); }
             return false;
         }

--- a/libmbbootimg/src/format/segment_error.cpp
+++ b/libmbbootimg/src/format/segment_error.cpp
@@ -60,8 +60,6 @@ std::string SegmentErrorCategory::message(int ev) const
         return "read would overflow integer";
     case SegmentError::WriteWouldOverflowInteger:
         return "write would overflow integer";
-    case SegmentError::EntryIsTruncated:
-        return "entry is truncated";
     case SegmentError::InvalidEntrySize:
         return "invalid entry size";
     default:

--- a/libmbbootimg/src/format/segment_writer.cpp
+++ b/libmbbootimg/src/format/segment_writer.cpp
@@ -152,21 +152,17 @@ bool SegmentWriter::write_data(File &file, const void *buf, size_t buf_size,
         return false;
     }
 
-    auto n = file_write_fully(file, buf, buf_size);
-    if (!n) {
-        writer.set_error(n.error(),
+    auto ret = file_write_exact(file, buf, buf_size);
+    if (!ret) {
+        writer.set_error(ret.error(),
                          "Failed to write data: %s",
-                         n.error().message().c_str());
-        if (file.is_fatal()) { writer.set_fatal(); }
-        return false;
-    } else if (n.value() != buf_size) {
-        writer.set_error(n.error(), "Write was truncated");
+                         ret.error().message().c_str());
         // This is a fatal error. We must guarantee that buf_size bytes will be
         // written.
         writer.set_fatal();
         return false;
     }
-    bytes_written = n.value();
+    bytes_written = buf_size;
 
     m_entry_size += static_cast<uint32_t>(buf_size);
     *m_pos += buf_size;

--- a/libmbbootimg/src/format/sony_elf_error.cpp
+++ b/libmbbootimg/src/format/sony_elf_error.cpp
@@ -62,8 +62,6 @@ std::string SonyElfErrorCategory::message(int ev) const
         return "kernel cmdline too long";
     case SonyElfError::InvalidTypeOrFlagsField:
         return "invalid type or flags field";
-    case SonyElfError::UnexpectedEndOfFile:
-        return "unexpected end of file";
     default:
         return "(unknown Sony ELF format error)";
     }

--- a/libmbbootimg/src/format/sony_elf_writer.cpp
+++ b/libmbbootimg/src/format/sony_elf_writer.cpp
@@ -349,11 +349,11 @@ bool SonyElfFormatWriter::close(File &file)
 
         // Write headers
         for (auto it = headers; it->ptr && it->can_write; ++it) {
-            auto n = file_write_fully(file, it->ptr, it->size);
-            if (!n || n.value() != it->size) {
-                _writer.set_error(n.error(),
+            auto ret = file_write_exact(file, it->ptr, it->size);
+            if (!ret) {
+                _writer.set_error(ret.error(),
                                   "Failed to write header: %s",
-                                  n.error().message().c_str());
+                                  ret.error().message().c_str());
                 if (file.is_fatal()) { _writer.set_fatal(); }
                 return false;
             }

--- a/libmbcommon/include/mbcommon/file_error.h
+++ b/libmbcommon/include/mbcommon/file_error.h
@@ -38,7 +38,9 @@ enum class FileError
     UnsupportedSeek         = 32,
     UnsupportedTruncate     = 33,
 
-    IntegerOverflow         = 40,
+    UnexpectedEof           = 40,
+
+    IntegerOverflow         = 50,
 };
 
 enum class FileErrorC
@@ -46,7 +48,8 @@ enum class FileErrorC
     InvalidArgument         = 10,
     InvalidState            = 20,
     Unsupported             = 30,
-    InternalError           = 40,
+    UnexpectedEof           = 40,
+    InternalError           = 50,
 };
 
 MB_EXPORT std::error_code make_error_code(FileError e);

--- a/libmbcommon/include/mbcommon/file_util.h
+++ b/libmbcommon/include/mbcommon/file_util.h
@@ -34,10 +34,15 @@ using FileSearchResultCallback =
         oc::result<FileSearchAction> (*)(File &file, void *userdata,
                                          uint64_t offset);
 
-MB_EXPORT oc::result<size_t> file_read_fully(File &file,
+MB_EXPORT oc::result<size_t> file_read_retry(File &file,
                                              void *buf, size_t size);
-MB_EXPORT oc::result<size_t> file_write_fully(File &file,
+MB_EXPORT oc::result<size_t> file_write_retry(File &file,
                                               const void *buf, size_t size);
+
+MB_EXPORT oc::result<void> file_read_exact(File &file,
+                                           void *buf, size_t size);
+MB_EXPORT oc::result<void> file_write_exact(File &file,
+                                            const void *buf, size_t size);
 
 MB_EXPORT oc::result<uint64_t> file_read_discard(File &file, uint64_t size);
 

--- a/libmbcommon/src/file_error.cpp
+++ b/libmbcommon/src/file_error.cpp
@@ -64,6 +64,8 @@ std::string FileErrorCategory::message(int ev) const
         return "seek not supported";
     case FileError::UnsupportedTruncate:
         return "truncate not supported";
+    case FileError::UnexpectedEof:
+        return "unexpected end of file";
     case FileError::IntegerOverflow:
         return "integer overflowed";
     default:
@@ -105,6 +107,8 @@ std::string FileErrorCCategory::message(int ev) const
         return "invalid state";
     case FileErrorC::Unsupported:
         return "unsupported operation";
+    case FileErrorC::UnexpectedEof:
+        return "unexpected end of file";
     case FileErrorC::InternalError:
         return "internal error";
     default:

--- a/libmbsparse/include/mbsparse/sparse_error.h
+++ b/libmbsparse/include/mbsparse/sparse_error.h
@@ -30,8 +30,6 @@ namespace sparse
 
 enum class SparseFileError
 {
-    UnexpectedEndOfFile         = 10,
-
     // Sparse header errors
     InvalidSparseMagic          = 20,
     InvalidSparseMajorVersion   = 21,

--- a/libmbsparse/src/sparse_error.cpp
+++ b/libmbsparse/src/sparse_error.cpp
@@ -41,8 +41,6 @@ const char * SparseFileErrorCategory::name() const noexcept
 std::string SparseFileErrorCategory::message(int ev) const
 {
     switch (static_cast<SparseFileError>(ev)) {
-    case SparseFileError::UnexpectedEndOfFile:
-        return "unexpected end of file";
     case SparseFileError::InvalidSparseMagic:
         return "invalid sparse header magic";
     case SparseFileError::InvalidSparseMajorVersion:

--- a/libmbsparse/tests/test_sparse.cpp
+++ b/libmbsparse/tests/test_sparse.cpp
@@ -530,7 +530,7 @@ TEST_F(SparseTest, CheckReadTruncatedChunkHeaderFatal)
     ASSERT_TRUE(_file.open(&_source_file));
     auto n = _file.read(buf, sizeof(buf));
     ASSERT_FALSE(n);
-    ASSERT_EQ(n.error(), SparseFileError::UnexpectedEndOfFile);
+    ASSERT_EQ(n.error(), FileError::UnexpectedEof);
     ASSERT_TRUE(_file.is_fatal());
 }
 


### PR DESCRIPTION
Signed-off-by: Andrew Gunnerson <chenxiaolong@cxl.epac.to>