### PR TITLE
libmbpatcher: Fix warning about forward declaration not matching real declaration

### DIFF
--- a/libmbpatcher/include/mbpatcher/patchers/odinpatcher.h
+++ b/libmbpatcher/include/mbpatcher/patchers/odinpatcher.h
@@ -39,7 +39,7 @@ namespace mb
 namespace patcher
 {
 
-class ZipCtx;
+struct ZipCtx;
 
 class OdinPatcher : public Patcher
 {

--- a/libmbpatcher/include/mbpatcher/patchers/zippatcher.h
+++ b/libmbpatcher/include/mbpatcher/patchers/zippatcher.h
@@ -30,8 +30,8 @@ namespace mb
 namespace patcher
 {
 
-class UnzCtx;
-class ZipCtx;
+struct UnzCtx;
+struct ZipCtx;
 
 class ZipPatcher : public Patcher
 {


### PR DESCRIPTION
Signed-off-by: Andrew Gunnerson <chenxiaolong@cxl.epac.to>