### PR TITLE
Add TrustZone block device to OnePlus 3T

### DIFF
--- a/data/devices/oneplus.yml
+++ b/data/devices/oneplus.yml
@@ -175,6 +175,11 @@
       - /dev/block/bootdevice/by-name/recovery
       - /dev/block/platform/soc/624000.ufshc/by-name/recovery
       - /dev/block/sde21
+     #Trust Zone
+    extra:
+      - /dev/block/bootdevice/by-name/tz
+      - /dev/block/platform/soc/624000.ufshc/by-name/tz
+      - /dev/block/sde3
 
   boot_ui:
     supported: true


### PR DESCRIPTION
This is to prevent errors that TrustZone could not be verified.