### PR TITLE
Update Galaxy S6 Edge Codenames

### DIFF
--- a/data/devices/samsung/00_galaxy_s.yml
+++ b/data/devices/samsung/00_galaxy_s.yml
@@ -695,6 +695,7 @@
     - zeroltebmc
     - zeroltetmo
     - zeroltexx
+    - zeroltexxx
   architecture: arm64-v8a
 
   block_devs:


### PR DESCRIPTION
Some custom roms change the code name to Zeroltexxx which makes the app unusable on these roms