### PR TITLE
Android GUI: Fix APK path when using the apk-install CMake target

### DIFF
--- a/Android_GUI/CMakeLists.txt
+++ b/Android_GUI/CMakeLists.txt
@@ -36,7 +36,7 @@ if(${MBP_BUILD_TARGET} STREQUAL android)
     )
 
     add_custom_target(
-        apk-install adb install -r build/outputs/apk/Android_GUI-${MBP_BUILD_TYPE}.apk
+        apk-install adb install -r build/outputs/apk/${MBP_BUILD_TYPE}/Android_GUI-${MBP_BUILD_TYPE}.apk
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
         VERBATIM
     )


### PR DESCRIPTION
This changed when the Android gradle plugin was updated to 3.0.

Signed-off-by: Andrew Gunnerson <chenxiaolong@cxl.epac.to>