### PR TITLE
devices: lenovo: Add  new codename for P1a41

### DIFF
--- a/data/devices/lenovo.yml
+++ b/data/devices/lenovo.yml
@@ -321,6 +321,7 @@
   codenames:
     - P1a41
     - passion_row
+    - passion
     - p1a41
   architecture: arm64-v8a
 


### PR DESCRIPTION
New ROMs now use the passion assert.