### PR TITLE
 Change device name from 'Redmi 5' Plus to 'Xiaomi Redmi 5 Plus'.

### DIFF
--- a/data/devices/xiaomi/03_redmi.yml
+++ b/data/devices/xiaomi/03_redmi.yml
@@ -522,7 +522,7 @@
     theme: portrait_hdpi
 
 
-- name: Redmi 5 Plus
+- name: Xiaomi Redmi 5 Plus
   id: vince
   codenames:
     - vince


### PR DESCRIPTION
It seems better to add a manufacturer name ‘Xiaomi’.
By the way,thanks for your effort.


