### PR TITLE
mbtool: installer: Undo /init symlink patch before flashing

### DIFF
--- a/libmbutil/include/mbutil/hash.h
+++ b/libmbutil/include/mbutil/hash.h
@@ -19,6 +19,7 @@
 
 #pragma once
 
+#include <array>
 #include <string>
 
 #include <openssl/sha.h>
@@ -26,7 +27,8 @@
 namespace mb::util
 {
 
-bool sha512_hash(const std::string &path,
-                 unsigned char digest[SHA512_DIGEST_LENGTH]);
+using Sha512Digest = std::array<unsigned char, SHA512_DIGEST_LENGTH>;
+
+bool sha512_hash(const std::string &path, Sha512Digest &digest);
 
 }

--- a/mbtool/installer.cpp
+++ b/mbtool/installer.cpp
@@ -1545,15 +1545,6 @@ Installer::ProceedState Installer::install_stage_set_up_chroot()
 {
     LOGD("[Installer] Chroot set up stage");
 
-    // Calculate SHA512 hash of the boot partition
-    if (!util::sha512_hash(_boot_block_dev, _boot_hash)) {
-        display_msg("Failed to compute sha512sum of boot partition");
-        return ProceedState::Fail;
-    }
-
-    std::string digest = util::hex_string(_boot_hash, SHA512_DIGEST_LENGTH);
-    LOGD("Boot partition SHA512sum: %s", digest.c_str());
-
     // Save a copy of the boot image that we'll restore if the installation fails
     if (!util::copy_contents(_boot_block_dev, _temp + "/boot.orig")) {
         display_msg("Failed to backup boot partition");
@@ -1576,6 +1567,24 @@ Installer::ProceedState Installer::install_stage_set_up_chroot()
     } else {
         LOGV("Won't switch to non-existent target ROM");
     }
+
+    // Patch current boot image to undo the init symlink patch. This is
+    // necessary to flash something that also tries to touch /init.
+    LOGV("Patching ramdisk to undo init modifications");
+    std::vector<std::function<RamdiskPatcherFn>> rps{rp_restore_init()};
+    if (!InstallerUtil::patch_boot_image(_boot_block_dev, _boot_block_dev,
+                                         rps)) {
+        LOGW("Failed to patch boot image. Continuing anyway...");
+    }
+
+    // Calculate SHA512 hash of the boot partition
+    if (!util::sha512_hash(_boot_block_dev, _boot_hash)) {
+        display_msg("Failed to compute sha512sum of boot partition");
+        return ProceedState::Fail;
+    }
+
+    std::string digest = util::hex_string(_boot_hash.data(), _boot_hash.size());
+    LOGD("Boot partition SHA512sum: %s", digest.c_str());
 
     // Wrap busybox to disable some applets
     if (!set_up_busybox_wrapper()) {
@@ -1840,18 +1849,18 @@ Installer::ProceedState Installer::install_stage_finish()
     LOGD("[Installer] Finalization stage");
 
     // Calculate SHA512 hash of the boot partition after installation
-    unsigned char new_hash[SHA512_DIGEST_LENGTH];
+    util::Sha512Digest new_hash;
     if (!util::sha512_hash(_boot_block_dev, new_hash)) {
         display_msg("Failed to compute sha512sum of boot partition");
         return ProceedState::Fail;
     }
 
-    std::string old_digest = util::hex_string(_boot_hash, SHA512_DIGEST_LENGTH);
-    std::string new_digest = util::hex_string(new_hash, SHA512_DIGEST_LENGTH);
+    std::string old_digest = util::hex_string(_boot_hash.data(), _boot_hash.size());
+    std::string new_digest = util::hex_string(new_hash.data(), new_hash.size());
     LOGD("Old boot partition SHA512sum: %s", old_digest.c_str());
     LOGD("New boot partition SHA512sum: %s", new_digest.c_str());
 
-    bool changed = memcmp(_boot_hash, new_hash, SHA512_DIGEST_LENGTH) != 0;
+    bool changed = _boot_hash != new_hash;
     bool force_update = _prop["mbtool.installer.always-patch-ramdisk"] == "true";
 
     // Set kernel if it was changed
@@ -1904,14 +1913,14 @@ Installer::ProceedState Installer::install_stage_finish()
         }
 
         // Update checksums
-        unsigned char digest[SHA512_DIGEST_LENGTH];
+        util::Sha512Digest digest;
 
         if (!util::sha512_hash(temp_boot_img, digest)) {
             display_msg("Failed to compute sha512sum of new boot image");
             return ProceedState::Fail;
         }
 
-        std::string hash = util::hex_string(digest, SHA512_DIGEST_LENGTH);
+        std::string hash = util::hex_string(digest.data(), digest.size());
 
         std::unordered_map<std::string, std::string> props;
         checksums_read(&props);

--- a/mbtool/installer.cpp
+++ b/mbtool/installer.cpp
@@ -1001,13 +1001,6 @@ bool Installer::run_real_updater()
         }
     }
 
-    char argv1[20];
-    char argv2[20];
-
-    snprintf(argv1, sizeof(argv1), "%d", _interface);
-    snprintf(argv2, sizeof(argv2), "%d",
-             _passthrough ? _output_fd : pipe_fds[1]);
-
     // Run updater in the chroot
     std::vector<std::string> argv{
 #if DEBUG_USE_UPDATER_WRAPPER
@@ -1017,8 +1010,8 @@ bool Installer::run_real_updater()
 #endif
 #endif
         "/mb/updater",
-        argv1,
-        argv2,
+        format("%d", _interface),
+        format("%d", _passthrough ? _output_fd : pipe_fds[1]),
         "/mb/install.zip"
     };
 

--- a/mbtool/installer.h
+++ b/mbtool/installer.h
@@ -92,7 +92,7 @@ protected:
     std::string _boot_block_dev;
     std::string _recovery_block_dev;
     std::string _system_block_dev;
-    unsigned char _boot_hash[SHA512_DIGEST_LENGTH];
+    util::Sha512Digest _boot_hash;
     std::shared_ptr<Rom> _rom;
     std::string _system_path;
     std::string _cache_path;

--- a/mbtool/installer_util.cpp
+++ b/mbtool/installer_util.cpp
@@ -311,6 +311,11 @@ bool InstallerUtil::patch_boot_image(const std::string &input_file,
     Entry in_entry;
     Entry out_entry;
 
+    // Debug
+    LOGD("Patching boot image");
+    LOGD("- Input: %s", input_file.c_str());
+    LOGD("- Output: %s", output_file.c_str());
+
     // Open input boot image
     auto ret = reader.enable_format_all();
     if (!ret) {
@@ -340,9 +345,6 @@ bool InstallerUtil::patch_boot_image(const std::string &input_file,
     }
 
     // Debug
-    LOGD("Patching boot image");
-    LOGD("- Input: %s", input_file.c_str());
-    LOGD("- Output: %s", output_file.c_str());
     LOGD("- Format: %s", reader.format_name().c_str());
 
     // Copy header

--- a/mbtool/ramdisk_patcher.cpp
+++ b/mbtool/ramdisk_patcher.cpp
@@ -263,14 +263,32 @@ rp_symlink_fuse_exfat()
     return _rp_symlink_fuse_exfat;
 }
 
-static bool _rp_symlink_init(const std::string &dir)
+static bool _is_linked_to_mbtool(const std::string &path)
+{
+    std::string link_target;
+
+    if (!util::read_link(path, link_target)) {
+        return false;
+    }
+
+    auto pieces = util::path_split(link_target);
+
+    if (std::find(pieces.begin(), pieces.end(), "mbtool") == pieces.end()) {
+        return false;
+    }
+
+    return true;
+}
+
+static std::string _get_init_target(const std::string &dir)
 {
     std::string target{dir};
     target += "/init";
-    std::string real_init{dir};
-    real_init += "/init.orig";
-
-    struct stat sb;
+    std::string sony_init_wrapper(dir);
+    sony_init_wrapper += "/sbin/init_sony";
+    std::string sony_real_init(dir);
+    sony_real_init += "/init.real";
+    std::string sony_symlink_target;
 
     // If this is a Sony device that doesn't use sbin/ramdisk.cpio for the
     // combined ramdisk, we'll have to explicitly allow their init executable to
@@ -280,40 +298,41 @@ static bool _rp_symlink_init(const std::string &dir)
     // See:
     // * https://github.com/chenxiaolong/DualBootPatcher/issues/533
     // * https://github.com/sonyxperiadev/device-sony-common-init
-    {
-        std::string sony_init_wrapper(dir);
-        sony_init_wrapper += "/sbin/init_sony";
-        std::string sony_real_init(dir);
-        sony_real_init += "/init.real";
-        std::string sony_symlink_target;
 
-        // Check that /init is a symlink and that /init.real exists
-        if (lstat(target.c_str(), &sb) == 0 && S_ISLNK(sb.st_mode)
-                && util::read_link(target, sony_symlink_target)
-                && lstat(sony_real_init.c_str(), &sb) == 0) {
-            std::vector<std::string> haystack{util::path_split(sony_symlink_target)};
-            std::vector<std::string> needle{util::path_split("sbin/init_sony")};
+    struct stat sb;
 
-            util::normalize_path(haystack);
+    // Check that /init is a symlink and that /init.real exists
+    if (lstat(target.c_str(), &sb) == 0 && S_ISLNK(sb.st_mode)
+            && util::read_link(target, sony_symlink_target)
+            && lstat(sony_real_init.c_str(), &sb) == 0) {
+        auto haystack = util::path_split(sony_symlink_target);
+        auto needle = util::path_split("sbin/init_sony");
 
-            // Check that init points to some path with "sbin/init_sony" in it
-            auto const it = std::search(haystack.cbegin(), haystack.cend(),
-                                        needle.cbegin(), needle.cend());
-            if (it != haystack.cend()) {
-                target.swap(sony_real_init);
-            }
+        util::normalize_path(haystack);
+
+        // Check that init points to some path with "sbin/init_sony" in it
+        auto const it = std::search(haystack.cbegin(), haystack.cend(),
+                                    needle.cbegin(), needle.cend());
+        if (it != haystack.cend()) {
+            target.swap(sony_real_init);
         }
     }
 
-    LOGD("[init] Target init path: %s", target.c_str());
-    LOGD("[init] Real init path: %s", real_init.c_str());
+    return target;
+}
 
-    if (lstat(real_init.c_str(), &sb) < 0) {
-        if (errno != ENOENT) {
-            LOGE("%s: Failed to access file: %s",
-                 real_init.c_str(), strerror(errno));
-            return false;
-        }
+static bool _rp_symlink_init(const std::string &dir)
+{
+    std::string real_init{dir};
+    real_init += "/init.orig";
+
+    auto target = _get_init_target(dir);
+    LOGD("[init] Target init path: %s", target.c_str());
+
+    // Move /init to /init.orig if it's not a symlink to mbtool
+
+    if (!_is_linked_to_mbtool(target)) {
+        LOGD("[init] Moving real init and symlinking init to mbtool");
 
         if (rename(target.c_str(), real_init.c_str()) < 0) {
             LOGE("%s: Failed to rename file: %s",
@@ -335,6 +354,35 @@ std::function<RamdiskPatcherFn>
 rp_symlink_init()
 {
     return _rp_symlink_init;
+}
+
+static bool _rp_restore_init(const std::string &dir)
+{
+    std::string real_init{dir};
+    real_init += "/init.orig";
+
+    auto target = _get_init_target(dir);
+    LOGD("[init] Target init path: %s", target.c_str());
+
+    // Move /init.orig to /init if /init is a symlink to mbtool
+
+    if (_is_linked_to_mbtool(target)) {
+        LOGD("[init] Restoring real init to init");
+
+        if (rename(real_init.c_str(), target.c_str()) < 0) {
+            LOGE("%s: Failed to rename file: %s",
+                 real_init.c_str(), strerror(errno));
+            return false;
+        }
+    }
+
+    return true;
+}
+
+std::function<RamdiskPatcherFn>
+rp_restore_init()
+{
+    return _rp_restore_init;
 }
 
 static bool _rp_add_device_json(const std::string &dir,

--- a/mbtool/ramdisk_patcher.h
+++ b/mbtool/ramdisk_patcher.h
@@ -44,6 +44,9 @@ std::function<RamdiskPatcherFn>
 rp_symlink_init();
 
 std::function<RamdiskPatcherFn>
+rp_restore_init();
+
+std::function<RamdiskPatcherFn>
 rp_add_device_json(const std::string &device_json_file);
 
 }

--- a/mbtool/switcher.cpp
+++ b/mbtool/switcher.cpp
@@ -19,6 +19,8 @@
 
 #include "switcher.h"
 
+#include <array>
+
 #include <cerrno>
 #include <cstdio>
 #include <cstdlib>
@@ -361,9 +363,9 @@ SwitchRomResult switch_rom(const std::string &id,
         }
 
         // Get actual sha512sum
-        unsigned char digest[SHA512_DIGEST_LENGTH];
-        SHA512(f.data.data(), f.data.size(), digest);
-        f.hash = util::hex_string(digest, SHA512_DIGEST_LENGTH);
+        std::array<unsigned char, SHA512_DIGEST_LENGTH> digest;
+        SHA512(f.data.data(), f.data.size(), digest.data());
+        f.hash = util::hex_string(digest.data(), digest.size());
 
         if (force_update_checksums) {
             checksums_update(&props, id, util::base_name(f.image), f.hash);
@@ -465,9 +467,9 @@ bool set_kernel(const std::string &id, const std::string &boot_blockdev)
     }
 
     // Get actual sha512sum
-    unsigned char digest[SHA512_DIGEST_LENGTH];
-    SHA512(data.data(), data.size(), digest);
-    std::string hash = util::hex_string(digest, SHA512_DIGEST_LENGTH);
+    std::array<unsigned char, SHA512_DIGEST_LENGTH> digest;
+    SHA512(data.data(), data.size(), digest.data());
+    std::string hash = util::hex_string(digest.data(), digest.size());
 
     // Add to checksums.prop
     std::unordered_map<std::string, std::string> props;


### PR DESCRIPTION
This commit updates the installer so that the /init -> /mbtool symlink
is removed and /init.orig is moved back to /init prior to flashing. This
ensures that flashing packages that touch /init won't adversely affect
multibooting. Magisk is an example of such a package.

Signed-off-by: Andrew Gunnerson <andrewgunnerson@gmail.com>