### PR TITLE
OnePlus 5T codenames revision

### DIFF
--- a/data/devices/oneplus.yml
+++ b/data/devices/oneplus.yml
@@ -273,6 +273,9 @@
   codenames:
     - OnePlus5T
     - OnePlus5t
+    - dumpling
+    - A5010
+    - op5t
   architecture: arm64-v8a
 
   block_devs:


### PR DESCRIPTION
Most used codename for OnePlus 5T is "dumpling", so is recommended to be added due to TWRP restrictions, if not, dual patched zips are not supported to be directly flashed.