### PR TITLE
mbtool: installer: Always patch boot image

### DIFF
--- a/libmbpatcher/include/mbpatcher/patchers/zippatcher.h
+++ b/libmbpatcher/include/mbpatcher/patchers/zippatcher.h
@@ -57,8 +57,7 @@ public:
 
     void cancel_patching() override;
 
-    static std::string create_info_prop(const std::string &rom_id,
-                                        bool always_patch_ramdisk);
+    static std::string create_info_prop(const std::string &rom_id);
 
 private:
     PatcherConfig &m_pc;

--- a/libmbpatcher/src/patchers/odinpatcher.cpp
+++ b/libmbpatcher/src/patchers/odinpatcher.cpp
@@ -277,7 +277,7 @@ bool OdinPatcher::patch_tar()
     update_details("multiboot/info.prop");
 
     const std::string info_prop =
-            ZipPatcher::create_info_prop(m_info->rom_id(), false);
+            ZipPatcher::create_info_prop(m_info->rom_id());
     result = MinizipUtils::add_file(
             handle, "multiboot/info.prop",
             std::vector<unsigned char>(info_prop.begin(), info_prop.end()));

--- a/libmbpatcher/src/patchers/ramdiskupdater.cpp
+++ b/libmbpatcher/src/patchers/ramdiskupdater.cpp
@@ -167,7 +167,7 @@ bool RamdiskUpdater::create_zip()
     if (m_cancelled) return false;
 
     const std::string info_prop =
-            ZipPatcher::create_info_prop(m_info->rom_id(), true);
+            ZipPatcher::create_info_prop(m_info->rom_id());
     result = MinizipUtils::add_file(
             handle, "multiboot/info.prop",
             std::vector<unsigned char>(info_prop.begin(), info_prop.end()));

--- a/libmbpatcher/src/patchers/zippatcher.cpp
+++ b/libmbpatcher/src/patchers/zippatcher.cpp
@@ -269,7 +269,7 @@ bool ZipPatcher::patch_zip()
     update_details("multiboot/info.prop");
 
     const std::string info_prop =
-            ZipPatcher::create_info_prop(m_info->rom_id(), false);
+            ZipPatcher::create_info_prop(m_info->rom_id());
     result = MinizipUtils::add_file(
             handle, "multiboot/info.prop",
             std::vector<unsigned char>(info_prop.begin(), info_prop.end()));
@@ -512,8 +512,7 @@ void ZipPatcher::la_progress_cb(uint64_t bytes, void *userdata)
     p->update_progress(p->m_bytes + bytes, p->m_max_bytes);
 }
 
-std::string ZipPatcher::create_info_prop(const std::string &rom_id,
-                                         bool always_patch_ramdisk)
+std::string ZipPatcher::create_info_prop(const std::string &rom_id)
 {
     std::string out;
 
@@ -548,20 +547,6 @@ std::string ZipPatcher::create_info_prop(const std::string &rom_id,
 
     out += "mbtool.installer.install-location=";
     out += rom_id;
-    out += "\n";
-
-    out +=
-"\n"
-"\n"
-"# mbtool.installer.always-patch-ramdisk\n"
-"# -------------------------------------\n"
-"# By default, the ramdisk is only patched if the boot partition is modified\n"
-"# during the installation process. If this property is enabled, it will always\n"
-"# be patched, regardless if the boot partition is modified.\n"
-"#\n";
-
-    out += "mbtool.installer.always-patch-ramdisk=";
-    out += always_patch_ramdisk ? "true" : "false";
     out += "\n";
 
     return out;

--- a/mbtool/installer.h
+++ b/mbtool/installer.h
@@ -26,7 +26,6 @@
 #include "mbcommon/common.h"
 #include "mbcommon/flags.h"
 #include "mbdevice/device.h"
-#include "mbutil/hash.h"
 
 #include "roms.h"
 
@@ -92,7 +91,6 @@ protected:
     std::string _boot_block_dev;
     std::string _recovery_block_dev;
     std::string _system_block_dev;
-    util::Sha512Digest _boot_hash;
     std::shared_ptr<Rom> _rom;
     std::string _system_path;
     std::string _cache_path;


### PR DESCRIPTION
This commit updates mbtool to always patch the boot image after an installation. Previously, it would compute the SHA512 checksum of the boot partition before and after flashing and only patch the boot image if they differed. This was fine until mbtool was updated to partially undo certain patches before installation (1c0a9079481921f95e74308f66d2329804949bbc). When flashing a zip that did not touch the boot partition, the partially unpatched boot image would remain, rendering the system unbootable.

The original behavior was introduced in commit a5a2c83128b97b6778a825020a00c85a89fdbd6f. At the time, it was unsafe to assume that the current boot partition contents belonged to the target ROM ID. However, this is no longer the case, since `/sdcard/MultiBoot/[ROM ID]/boot.img` is flashed to the boot partition prior to installation. Always patching the boot image shouldn't cause any major issues.