### PR TITLE
mbtool: Cache version and build properties during installation

### DIFF
--- a/mbtool/installer.h
+++ b/mbtool/installer.h
@@ -98,6 +98,7 @@ protected:
 
     std::unordered_map<std::string, std::string> _prop;
     std::unordered_map<std::string, std::string> _chroot_prop;
+    std::unordered_map<std::string, std::string> _cached_prop;
 
     std::string _temp_image_path;
     bool _has_block_image;

--- a/mbtool/romconfig.cpp
+++ b/mbtool/romconfig.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015  Andrew Gunnerson <andrewgunnerson@gmail.com>
+ * Copyright (C) 2015-2018  Andrew Gunnerson <andrewgunnerson@gmail.com>
  *
  * This file is part of DualBootPatcher
  *
@@ -24,29 +24,40 @@
 #include <rapidjson/document.h>
 #include <rapidjson/error/en.h>
 #include <rapidjson/filereadstream.h>
+#include <rapidjson/filewritestream.h>
 #include <rapidjson/reader.h>
+#include <rapidjson/writer.h>
 
 #include "mblog/logging.h"
 
 #define LOG_TAG "mbtool/romconfig"
 
-#define CONFIG_KEY_ID                      "id"
-#define CONFIG_KEY_NAME                    "name"
-#define CONFIG_KEY_APP_SHARING             "app_sharing"
-#define CONFIG_KEY_INDIVIDUAL_APP_SHARING  "individual"
-#define CONFIG_KEY_PACKAGES                "packages"
-#define CONFIG_KEY_PACKAGE_ID              "pkg_id"
-#define CONFIG_KEY_SHARE_DATA              "share_data"
+#define KEY_ID                     "id"
+#define KEY_NAME                   "name"
+#define KEY_CACHED_PROPERTIES      "cached_properties"
+#define KEY_APP_SHARING            "app_sharing"
+#define KEY_INDIVIDUAL_APP_SHARING "individual"
+#define KEY_PACKAGES               "packages"
+#define KEY_PACKAGE_ID             "pkg_id"
+#define KEY_SHARE_DATA             "share_data"
+
+using namespace rapidjson;
 
 namespace mb
 {
+
+using ScopedFILE = std::unique_ptr<FILE, decltype(fclose) *>;
 
 /*
  * Example JSON structure:
  *
  * {
  *     "id": "primary",
- *     "name": "TouchWiz 5.0",
+ *     "name": "TouchWiz 7.0",
+ *     "cached_properties": {
+ *         "ro.build.version.release": "7.0",
+ *         "ro.build.display.id": "NRD90M.G955FXXU1AQL5"
+ *     },
  *     "app_sharing": {
  *         "individual": true
  *         "packages": [
@@ -55,17 +66,161 @@ namespace mb
  *                 "share_data": true
  *             },{
  *                 "pkg_id": "com.android.vending",
- *                 "share_data":true
+ *                 "share_data": true
  *             }
  *         ]
  *     }
  * }
  */
+
+static inline std::string get_string(const Value &node)
+{
+    return {node.GetString(), node.GetStringLength()};
+}
+
+static bool load_app_sharing_packages(RomConfig &config, const Value &node)
+{
+    static constexpr char context[] = "." KEY_APP_SHARING "." KEY_PACKAGES;
+
+    if (!node.IsArray()) {
+        LOGE("%s: Not an array", context);
+        return false;
+    }
+
+    size_t i = 0;
+    for (auto const &item : node.GetArray()) {
+        if (!item.IsObject()) {
+            LOGE("%s[%zu]: Not an object", context, i);
+            return false;
+        }
+
+        SharedPackage shared_pkg = {};
+
+        for (auto const &pkg_item : item.GetObject()) {
+            auto const &key = get_string(pkg_item.name);
+
+            if (key == KEY_PACKAGE_ID) {
+                if (!pkg_item.value.IsString()) {
+                    LOGE("%s[%zu].%s: Not a string", context, i, key.c_str());
+                    return false;
+                }
+                shared_pkg.pkg_id = get_string(pkg_item.value);
+            } else if (key == KEY_SHARE_DATA) {
+                if (!pkg_item.value.IsBool()) {
+                    LOGE("%s[%zu].%s: Not a boolean", context, i, key.c_str());
+                    return false;
+                }
+                shared_pkg.share_data = pkg_item.value.GetBool();
+            } else {
+                LOGW("%s[%zu].%s: Skipping unknown key", context, i, key.c_str());
+            }
+        }
+
+        if (!shared_pkg.pkg_id.empty()) {
+            config.shared_pkgs.push_back(std::move(shared_pkg));
+        }
+
+        ++i;
+    }
+
+    return true;
+}
+
+static bool load_app_sharing(RomConfig &config, const Value &node)
+{
+    static constexpr char context[] = "." KEY_APP_SHARING;
+
+    if (!node.IsObject()) {
+        LOGE("%s: Not an object", context);
+        return false;
+    }
+
+    for (auto const &item : node.GetObject()) {
+        auto const &key = get_string(item.name);
+
+        if (key == KEY_INDIVIDUAL_APP_SHARING) {
+            if (!item.value.IsBool()) {
+                LOGE("%s.%s: Not a boolean", context, key.c_str());
+                return false;
+            }
+            config.indiv_app_sharing = item.value.GetBool();
+        } else if (key == KEY_PACKAGES) {
+            if (!load_app_sharing_packages(config, node)) {
+                return false;
+            }
+        } else {
+            LOGW("%s.%s: Skipping unknown key", context, key.c_str());
+        }
+    }
+
+    return true;
+}
+
+static bool load_cached_props(RomConfig &config, const Value &node)
+{
+    static constexpr char context[] = "." KEY_CACHED_PROPERTIES;
+
+    if (!node.IsObject()) {
+        LOGE("%s: Not an object", context);
+        return false;
+    }
+
+    for (auto const &item : node.GetObject()) {
+        auto const &key = get_string(item.name);
+
+        if (!item.value.IsString()) {
+            LOGE("%s.%s: Not a string", context, key.c_str());
+            return false;
+        }
+
+        config.cached_props[key] = get_string(item.value);
+    }
+
+    return true;
+}
+
+static bool load_root(RomConfig &config, const Value &node)
+{
+    static constexpr char context[] = ".";
+
+    if (!node.IsObject()) {
+        LOGE("%s: Not an object", context);
+        return false;
+    }
+
+    for (auto const &item : node.GetObject()) {
+        auto const &key = get_string(item.name);
+
+        if (key == KEY_ID) {
+            if (!item.value.IsString()) {
+                LOGE("%s.%s: Not a string", context, key.c_str());
+                return false;
+            }
+            config.id = get_string(item.value);
+        } else if (key == KEY_NAME) {
+            if (!item.value.IsString()) {
+                LOGE("%s.%s: Not a string", context, key.c_str());
+                return false;
+            }
+            config.name = get_string(item.value);
+        } else if (key == KEY_CACHED_PROPERTIES) {
+            if (!load_cached_props(config, item.value)) {
+                return false;
+            }
+        } else if (key == KEY_APP_SHARING) {
+            if (!load_app_sharing(config, item.value)) {
+                return false;
+            }
+        } else {
+            LOGW("%s.%s: Skipping unknown key", context, key.c_str());
+        }
+    }
+
+    return true;
+}
+
 bool RomConfig::load_file(const std::string &path)
 {
-    using ScopedFILE = std::unique_ptr<FILE, decltype(fclose) *>;
-    using namespace rapidjson;
-
     ScopedFILE fp(fopen(path.c_str(), "r"), &fclose);
     if (!fp) {
         LOGE("%s: Failed to open for reading: %s",
@@ -85,96 +240,78 @@ bool RomConfig::load_file(const std::string &path)
         return false;
     }
 
-    if (!d.IsObject()) {
-        LOGE("[root]: Not an object");
+    return load_root(*this, d);
+}
+
+bool RomConfig::save_file(const std::string &path)
+{
+    Document d;
+    d.SetObject();
+
+    auto &alloc = d.GetAllocator();
+
+    if (!id.empty()) {
+        d.AddMember(KEY_ID, id, alloc);
+    }
+
+    if (!name.empty()) {
+        d.AddMember(KEY_NAME, name, alloc);
+    }
+
+    Value v_cached_props(kObjectType);
+
+    for (auto const &cp : cached_props) {
+        v_cached_props.AddMember(StringRef(cp.first), StringRef(cp.second),
+                                 alloc);
+    }
+
+    if (!v_cached_props.ObjectEmpty()) {
+        d.AddMember(KEY_CACHED_PROPERTIES, v_cached_props, alloc);
+    }
+
+    if (indiv_app_sharing || !shared_pkgs.empty()) {
+        Value v_app_sharing(kObjectType);
+
+        v_app_sharing.AddMember(KEY_INDIVIDUAL_APP_SHARING,
+                                indiv_app_sharing, alloc);
+
+        Value v_shared_pkgs(kArrayType);
+
+        for (auto const &sp : shared_pkgs) {
+            Value v_shared_pkg(kObjectType);
+
+            v_shared_pkg.AddMember(KEY_PACKAGE_ID, sp.pkg_id, alloc);
+            v_shared_pkg.AddMember(KEY_SHARE_DATA, sp.share_data, alloc);
+
+            v_shared_pkgs.PushBack(v_shared_pkg, alloc);
+        }
+
+        if (!v_shared_pkgs.Empty()) {
+            v_app_sharing.AddMember(KEY_PACKAGES, v_shared_pkgs, alloc);
+        }
+
+        d.AddMember(KEY_APP_SHARING, v_app_sharing, alloc);
+    }
+
+    ScopedFILE fp(fopen(path.c_str(), "w"), &fclose);
+    if (!fp) {
+        LOGE("%s: Failed to open for writing: %s",
+             path.c_str(), strerror(errno));
         return false;
     }
 
-    // ROM ID
-    auto const j_id = d.FindMember(CONFIG_KEY_ID);
-    if (j_id != d.MemberEnd()) {
-        if (!j_id->value.IsString()) {
-            LOGE("[root]->id: Not a string");
-            return false;
-        }
-        id = j_id->value.GetString();
+    char buf[65536];
+    FileWriteStream os(fp.get(), buf, sizeof(buf));
+    Writer<FileWriteStream> writer(os);
+
+    if (!d.Accept(writer)) {
+        return false;
     }
 
-    // ROM name
-    auto const j_name = d.FindMember(CONFIG_KEY_NAME);
-    if (j_name != d.MemberEnd()) {
-        if (!j_name->value.IsString()) {
-            LOGE("[root]->name: Not a string");
-            return false;
-        }
-        name = j_name->value.GetString();
-    }
-
-    // App sharing
-    auto const j_app_sharing = d.FindMember(CONFIG_KEY_APP_SHARING);
-    if (j_app_sharing != d.MemberEnd()) {
-        if (!j_app_sharing->value.IsObject()) {
-            LOGE("[root]->app_sharing: Not an object");
-            return false;
-        }
-
-        // Individual app sharing
-        auto const j_individual = j_app_sharing->value.FindMember(
-                CONFIG_KEY_INDIVIDUAL_APP_SHARING);
-        if (j_individual != j_app_sharing->value.MemberEnd()) {
-            if (!j_individual->value.IsBool()) {
-                LOGE("[root]->app_sharing->individual: Not a boolean");
-                return false;
-            }
-            indiv_app_sharing = j_individual->value.GetBool();
-        }
-
-        // Shared packages
-        auto const j_pkgs = j_app_sharing->value.FindMember(
-                CONFIG_KEY_PACKAGES);
-        if (j_pkgs != j_app_sharing->value.MemberEnd()) {
-            if (!j_pkgs->value.IsArray()) {
-                LOGE("[root]->app_sharing->packages: Not an array");
-                return false;
-            }
-
-            size_t i = 0;
-            for (auto const &j_data : j_pkgs->value.GetArray()) {
-                if (!j_data.IsObject()) {
-                    LOGE("[root]->app_sharing->packages[%zu]: Not an object", i);
-                    return false;
-                }
-
-                SharedPackage shared_pkg;
-
-                // Package ID
-                auto const j_pkg_id = j_data.FindMember(CONFIG_KEY_PACKAGE_ID);
-                if (j_pkg_id != j_data.MemberEnd()) {
-                    if (!j_pkg_id->value.IsString()) {
-                        LOGE("[root]->app_sharing->packages[%zu]->pkg_id: Not a string", i);
-                        return false;
-                    }
-                    shared_pkg.pkg_id = j_pkg_id->value.GetString();
-                } else {
-                    // Skip empty package names
-                    continue;
-                }
-
-                // Shared data
-                auto const j_share_data = j_data.FindMember(CONFIG_KEY_SHARE_DATA);
-                if (j_share_data != j_data.MemberEnd()) {
-                    if (!j_share_data->value.IsBool()) {
-                        LOGE("[root]->app_sharing->packages[%zu]->share_data: Not a boolean", i);
-                        return false;
-                    }
-                    shared_pkg.share_data = j_share_data->value.GetBool();
-                }
-
-                shared_pkgs.push_back(std::move(shared_pkg));
-
-                ++i;
-            }
-        }
+    if (fclose(fp.release()) != 0) {
+        LOGE("%s: Failed to close file: %s",
+             path.c_str(), strerror(errno));
+        return false;
     }
 
     return true;

--- a/mbtool/romconfig.h
+++ b/mbtool/romconfig.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015  Andrew Gunnerson <andrewgunnerson@gmail.com>
+ * Copyright (C) 2015-2018  Andrew Gunnerson <andrewgunnerson@gmail.com>
  *
  * This file is part of DualBootPatcher
  *
@@ -20,6 +20,7 @@
 #pragma once
 
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 namespace mb
@@ -35,10 +36,12 @@ struct RomConfig
 {
     std::string id;
     std::string name;
+    std::unordered_map<std::string, std::string> cached_props;
     bool indiv_app_sharing = false;
     std::vector<SharedPackage> shared_pkgs;
 
     bool load_file(const std::string &path);
+    bool save_file(const std::string &path);
 };
 
 }


### PR DESCRIPTION
This allows showing the build and version numbers on the ROMs page of
the Android app for ROMs that don't get mounted by default.

(Fixes #1013)