### PR TITLE
libmbutil: Use outcome for error handling where possible

### DIFF
--- a/examples/libmbpatcher_test.cpp
+++ b/examples/libmbpatcher_test.cpp
@@ -50,9 +50,16 @@ static bool file_read_all(const std::string &path,
         return false;
     }
 
-    fseek(fp, 0, SEEK_END);
+    if (fseeko64(fp, 0, SEEK_END) < 0) {
+        return false;
+    }
     auto size = ftello64(fp);
-    rewind(fp);
+    if (size < 0 || std::make_unsigned_t<decltype(size)>(size) > SIZE_MAX) {
+        return false;
+    }
+    if (fseeko64(fp, 0, SEEK_SET) < 0) {
+        return false;
+    }
 
     std::vector<unsigned char> data(static_cast<size_t>(size));
     if (fread(data.data(), data.size(), 1, fp) != 1) {

--- a/libmbutil/CMakeLists.txt
+++ b/libmbutil/CMakeLists.txt
@@ -54,6 +54,7 @@ foreach(variant ${variants})
         src/vibrate.cpp
         src/external/system_properties.cpp
         src/external/system_properties_compat.c
+        src/result/file_op_result.cpp
         external/android_reboot.c
     )
 

--- a/libmbutil/include/mbutil/blkid.h
+++ b/libmbutil/include/mbutil/blkid.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2017  Andrew Gunnerson <andrewgunnerson@gmail.com>
+ * Copyright (C) 2016-2018  Andrew Gunnerson <andrewgunnerson@gmail.com>
  *
  * This file is part of DualBootPatcher
  *
@@ -19,13 +19,13 @@
 
 #pragma once
 
-#include <optional>
 #include <string>
+
+#include "mbcommon/outcome.h"
 
 namespace mb::util
 {
 
-bool blkid_get_fs_type(const std::string &path,
-                       std::optional<std::string> &type);
+oc::result<std::string> blkid_get_fs_type(const std::string &path);
 
 }

--- a/libmbutil/include/mbutil/chmod.h
+++ b/libmbutil/include/mbutil/chmod.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2017  Andrew Gunnerson <andrewgunnerson@gmail.com>
+ * Copyright (C) 2014-2018  Andrew Gunnerson <andrewgunnerson@gmail.com>
  *
  * This file is part of DualBootPatcher
  *
@@ -20,9 +20,11 @@
 #pragma once
 
 #include <string>
+
 #include <sys/types.h>
 
 #include "mbcommon/flags.h"
+#include "mbcommon/outcome.h"
 
 namespace mb::util
 {
@@ -34,6 +36,6 @@ enum class ChmodFlag : uint8_t
 MB_DECLARE_FLAGS(ChmodFlags, ChmodFlag)
 MB_DECLARE_OPERATORS_FOR_FLAGS(ChmodFlags)
 
-bool chmod(const std::string &path, mode_t perms, ChmodFlags flags);
+oc::result<void> chmod(const std::string &path, mode_t perms, ChmodFlags flags);
 
 }

--- a/libmbutil/include/mbutil/chown.h
+++ b/libmbutil/include/mbutil/chown.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2017  Andrew Gunnerson <andrewgunnerson@gmail.com>
+ * Copyright (C) 2014-2018  Andrew Gunnerson <andrewgunnerson@gmail.com>
  *
  * This file is part of DualBootPatcher
  *
@@ -24,6 +24,7 @@
 #include <sys/types.h>
 
 #include "mbcommon/flags.h"
+#include "mbcommon/outcome.h"
 
 namespace mb::util
 {
@@ -36,13 +37,13 @@ enum class ChownFlag : uint8_t
 MB_DECLARE_FLAGS(ChownFlags, ChownFlag)
 MB_DECLARE_OPERATORS_FOR_FLAGS(ChownFlags)
 
-bool chown(const std::string &path,
-           const std::string &user,
-           const std::string &group,
-           ChownFlags flags);
-bool chown(const std::string &path,
-           uid_t user,
-           gid_t group,
-           ChownFlags flags);
+oc::result<void> chown(const std::string &path,
+                       const std::string &user,
+                       const std::string &group,
+                       ChownFlags flags);
+oc::result<void> chown(const std::string &path,
+                       uid_t user,
+                       gid_t group,
+                       ChownFlags flags);
 
 }

--- a/libmbutil/include/mbutil/cmdline.h
+++ b/libmbutil/include/mbutil/cmdline.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2017  Andrew Gunnerson <andrewgunnerson@gmail.com>
+ * Copyright (C) 2014-2018  Andrew Gunnerson <andrewgunnerson@gmail.com>
  *
  * This file is part of DualBootPatcher
  *
@@ -21,24 +21,17 @@
 
 #include <optional>
 #include <string>
+#include <unordered_map>
+
+#include "mbcommon/outcome.h"
+
 
 namespace mb::util
 {
 
-enum class CmdlineIterAction
-{
-    Continue,
-    Stop,
-    Error
-};
+using KernelCmdlineArgs =
+    std::unordered_map<std::string, std::optional<std::string>>;
 
-typedef CmdlineIterAction (*CmdlineIterFn)(const std::string &name,
-                                           const std::optional<std::string> &value,
-                                           void *userdata);
-
-bool kernel_cmdline_iter(CmdlineIterFn fn, void *userdata);
-
-bool kernel_cmdline_get_option(const std::string &option,
-                               std::optional<std::string> &value);
+oc::result<KernelCmdlineArgs> kernel_cmdline();
 
 }

--- a/libmbutil/include/mbutil/copy.h
+++ b/libmbutil/include/mbutil/copy.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2017  Andrew Gunnerson <andrewgunnerson@gmail.com>
+ * Copyright (C) 2014-2018  Andrew Gunnerson <andrewgunnerson@gmail.com>
  *
  * This file is part of DualBootPatcher
  *
@@ -22,6 +22,9 @@
 #include <string>
 
 #include "mbcommon/flags.h"
+#include "mbcommon/outcome.h"
+
+#include "mbutil/result/file_op_result.h"
 
 namespace mb::util
 {
@@ -36,11 +39,16 @@ enum class CopyFlag : uint8_t
 MB_DECLARE_FLAGS(CopyFlags, CopyFlag)
 MB_DECLARE_OPERATORS_FOR_FLAGS(CopyFlags)
 
-bool copy_data_fd(int fd_source, int fd_target);
-bool copy_xattrs(const std::string &source, const std::string &target);
-bool copy_stat(const std::string &source, const std::string &target);
-bool copy_contents(const std::string &source, const std::string &target);
-bool copy_file(const std::string &source, const std::string &target, CopyFlags flags);
-bool copy_dir(const std::string &source, const std::string &target, CopyFlags flags);
+oc::result<void> copy_data_fd(int fd_source, int fd_target);
+FileOpResult<void> copy_xattrs(const std::string &source,
+                               const std::string &target);
+FileOpResult<void> copy_stat(const std::string &source,
+                             const std::string &target);
+FileOpResult<void> copy_contents(const std::string &source,
+                                 const std::string &target);
+FileOpResult<void> copy_file(const std::string &source,
+                             const std::string &target, CopyFlags flags);
+FileOpResult<void> copy_dir(const std::string &source,
+                            const std::string &target, CopyFlags flags);
 
 }

--- a/libmbutil/include/mbutil/directory.h
+++ b/libmbutil/include/mbutil/directory.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014  Andrew Gunnerson <andrewgunnerson@gmail.com>
+ * Copyright (C) 2014-2018  Andrew Gunnerson <andrewgunnerson@gmail.com>
  *
  * This file is part of DualBootPatcher
  *
@@ -21,10 +21,12 @@
 
 #include <string>
 
+#include "mbcommon/outcome.h"
+
 namespace mb::util
 {
 
-bool mkdir_recursive(const std::string &dir, mode_t mode);
-bool mkdir_parent(const std::string &path, mode_t perms);
+oc::result<void> mkdir_recursive(std::string dir, mode_t perms);
+oc::result<void> mkdir_parent(const std::string &path, mode_t perms);
 
 }

--- a/libmbutil/include/mbutil/file.h
+++ b/libmbutil/include/mbutil/file.h
@@ -33,9 +33,7 @@ oc::result<void> file_write_data(const std::string &path,
                                  const void *data, size_t size);
 oc::result<bool> file_find_one_of(const std::string &path,
                                   const std::vector<std::string> &items);
-oc::result<std::vector<unsigned char>> file_read_all_v(const std::string &path);
-oc::result<std::pair<void *, std::size_t>>
-file_read_all(const std::string &path);
+oc::result<std::vector<unsigned char>> file_read_all(const std::string &path);
 
 oc::result<uint64_t> get_blockdev_size(const std::string &path);
 

--- a/libmbutil/include/mbutil/file.h
+++ b/libmbutil/include/mbutil/file.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2017  Andrew Gunnerson <andrewgunnerson@gmail.com>
+ * Copyright (C) 2014-2018  Andrew Gunnerson <andrewgunnerson@gmail.com>
  *
  * This file is part of DualBootPatcher
  *
@@ -22,19 +22,21 @@
 #include <string>
 #include <vector>
 
+#include "mbcommon/outcome.h"
+
 namespace mb::util
 {
 
-bool create_empty_file(const std::string &path);
-bool file_first_line(const std::string &path, std::string &line_out);
-bool file_write_data(const std::string &path,
-                     const void *data, size_t size);
-bool file_find_one_of(const std::string &path, std::vector<std::string> items);
-bool file_read_all(const std::string &path,
-                   std::vector<unsigned char> &data_out);
-bool file_read_all(const std::string &path,
-                   unsigned char *&data_out, std::size_t &size_out);
+oc::result<void> create_empty_file(const std::string &path);
+oc::result<std::string> file_first_line(const std::string &path);
+oc::result<void> file_write_data(const std::string &path,
+                                 const void *data, size_t size);
+oc::result<bool> file_find_one_of(const std::string &path,
+                                  const std::vector<std::string> &items);
+oc::result<std::vector<unsigned char>> file_read_all_v(const std::string &path);
+oc::result<std::pair<void *, std::size_t>>
+file_read_all(const std::string &path);
 
-bool get_blockdev_size(const std::string &path, uint64_t &size_out);
+oc::result<uint64_t> get_blockdev_size(const std::string &path);
 
 }

--- a/libmbutil/include/mbutil/hash.h
+++ b/libmbutil/include/mbutil/hash.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2015  Andrew Gunnerson <andrewgunnerson@gmail.com>
+ * Copyright (C) 2014-2018  Andrew Gunnerson <andrewgunnerson@gmail.com>
  *
  * This file is part of DualBootPatcher
  *
@@ -24,11 +24,13 @@
 
 #include <openssl/sha.h>
 
+#include "mbcommon/outcome.h"
+
 namespace mb::util
 {
 
 using Sha512Digest = std::array<unsigned char, SHA512_DIGEST_LENGTH>;
 
-bool sha512_hash(const std::string &path, Sha512Digest &digest);
+oc::result<Sha512Digest> sha512_hash(const std::string &path);
 
 }

--- a/libmbutil/include/mbutil/loopdev.h
+++ b/libmbutil/include/mbutil/loopdev.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2017  Andrew Gunnerson <andrewgunnerson@gmail.com>
+ * Copyright (C) 2014-2018  Andrew Gunnerson <andrewgunnerson@gmail.com>
  *
  * This file is part of DualBootPatcher
  *
@@ -21,12 +21,15 @@
 
 #include <string>
 
+#include "mbcommon/outcome.h"
+
 namespace mb::util
 {
 
-std::string loopdev_find_unused();
-bool loopdev_set_up_device(const std::string &loopdev, const std::string &file,
-                           uint64_t offset, bool ro);
-bool loopdev_remove_device(const std::string &loopdev);
+oc::result<std::string> loopdev_find_unused();
+oc::result<void> loopdev_set_up_device(const std::string &loopdev,
+                                       const std::string &file,
+                                       uint64_t offset, bool ro);
+oc::result<void> loopdev_remove_device(const std::string &loopdev);
 
 }

--- a/libmbutil/include/mbutil/mount.h
+++ b/libmbutil/include/mbutil/mount.h
@@ -23,8 +23,20 @@
 
 #include <cstdio>
 
+#include "mbcommon/outcome.h"
+
 namespace mb::util
 {
+
+enum class MountError
+{
+    EndOfFile = 1,
+    PathNotMounted,
+};
+
+std::error_code make_error_code(MountError e);
+
+const std::error_category & mount_error_category();
 
 constexpr char PROC_MOUNTS[] = "/proc/mounts";
 
@@ -38,16 +50,24 @@ struct MountEntry
     int passno;
 };
 
-bool get_mount_entry(std::FILE *fp, MountEntry &entry_out);
+oc::result<MountEntry> get_mount_entry(std::FILE *fp);
 
-bool is_mounted(const std::string &mountpoint);
-bool unmount_all(const std::string &dir);
-bool mount(const std::string &source, const std::string &target,
-           const std::string &fstype, unsigned long mount_flags,
-           const std::string &data);
-bool umount(const std::string &target);
+oc::result<void> is_mounted(const std::string &mountpoint);
+oc::result<void> unmount_all(const std::string &dir);
+oc::result<void> mount(const std::string &source, const std::string &target,
+                       const std::string &fstype, unsigned long mount_flags,
+                       const std::string &data);
+oc::result<void> umount(const std::string &target);
 
-bool mount_get_total_size(const std::string &path, uint64_t &size);
-bool mount_get_avail_size(const std::string &path, uint64_t &size);
+oc::result<uint64_t> mount_get_total_size(const std::string &path);
+oc::result<uint64_t> mount_get_avail_size(const std::string &path);
 
+}
+
+namespace std
+{
+    template<>
+    struct is_error_code_enum<mb::util::MountError> : true_type
+    {
+    };
 }

--- a/libmbutil/include/mbutil/path.h
+++ b/libmbutil/include/mbutil/path.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2017  Andrew Gunnerson <andrewgunnerson@gmail.com>
+ * Copyright (C) 2014-2018  Andrew Gunnerson <andrewgunnerson@gmail.com>
  *
  * This file is part of DualBootPatcher
  *
@@ -23,20 +23,20 @@
 #include <string>
 #include <vector>
 
+#include "mbcommon/outcome.h"
+
 namespace mb::util
 {
 
-std::string get_cwd();
-std::string dir_name(const std::string &path);
-std::string base_name(const std::string &path);
-std::string real_path(const std::string &path);
-bool read_link(const std::string &path, std::string &out);
-bool inodes_equal(const std::string &path1, const std::string &path2);
-std::vector<std::string> path_split(const std::string &path);
+oc::result<std::string> get_cwd();
+std::string dir_name(std::string path);
+std::string base_name(std::string path);
+oc::result<std::string> read_link(const std::string &path);
+std::vector<std::string> path_split(std::string path);
 std::string path_join(const std::vector<std::string> &components);
 void normalize_path(std::vector<std::string> &components);
-bool relative_path(const std::string &path, const std::string &start,
-                   std::string &out);
+oc::result<std::string> relative_path(const std::string &path,
+                                      const std::string &start);
 int path_compare(const std::string &path1, const std::string &path2);
 bool wait_for_path(const std::string &path, std::chrono::milliseconds timeout);
 bool path_exists(const std::string &path, bool follow_symlinks);

--- a/libmbutil/include/mbutil/process.h
+++ b/libmbutil/include/mbutil/process.h
@@ -24,11 +24,12 @@
 #include <sys/types.h>
 
 #include "mbcommon/common.h"
+#include "mbcommon/outcome.h"
 
 namespace mb::util
 {
 
-bool set_process_title_init(int argc, char *argv[]);
-bool set_process_title(const std::string &title, size_t *size_out);
+oc::result<void> set_process_title_init(int argc, char *argv[]);
+oc::result<size_t> set_process_title(std::string_view title);
 
 }

--- a/libmbutil/include/mbutil/result/file_op_result.h
+++ b/libmbutil/include/mbutil/result/file_op_result.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2018  Andrew Gunnerson <andrewgunnerson@gmail.com>
+ * Copyright (C) 2018  Andrew Gunnerson <andrewgunnerson@gmail.com>
  *
  * This file is part of DualBootPatcher
  *
@@ -19,15 +19,32 @@
 
 #pragma once
 
-#include <string>
-
 #include "mbcommon/outcome.h"
-
-#include "mbutil/result/file_op_result.h"
 
 namespace mb::util
 {
 
-FileOpResult<void> delete_recursive(const std::string &path);
+struct FileOpErrorInfo
+{
+    std::string path;
+    std::error_code ec;
+
+    std::string message() const;
+};
+
+inline const std::error_code & make_error_code(const FileOpErrorInfo &ei)
+{
+    return ei.ec;
+}
+
+[[noreturn]]
+inline void throw_as_system_error_with_payload(const FileOpErrorInfo &ei)
+{
+    (void) ei;
+    OUTCOME_THROW_EXCEPTION(std::system_error(make_error_code(ei)));
+}
+
+template <typename T>
+using FileOpResult = oc::result<T, FileOpErrorInfo>;
 
 }

--- a/libmbutil/include/mbutil/selinux.h
+++ b/libmbutil/include/mbutil/selinux.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2017  Andrew Gunnerson <andrewgunnerson@gmail.com>
+ * Copyright (C) 2014-2018  Andrew Gunnerson <andrewgunnerson@gmail.com>
  *
  * This file is part of DualBootPatcher
  *
@@ -22,6 +22,8 @@
 #include <string>
 
 #include <sepol/policydb/policydb.h>
+
+#include "mbcommon/outcome.h"
 
 namespace mb::util
 {
@@ -46,21 +48,22 @@ enum class SELinuxAttr
 
 bool selinux_read_policy(const std::string &path, policydb_t *pdb);
 bool selinux_write_policy(const std::string &path, policydb_t *pdb);
-bool selinux_get_context(const std::string &path, std::string &context);
-bool selinux_lget_context(const std::string &path, std::string &context);
-bool selinux_fget_context(int fd, std::string &context);
-bool selinux_set_context(const std::string &path, const std::string &context);
-bool selinux_lset_context(const std::string &path, const std::string &context);
-bool selinux_fset_context(int fd, const std::string &context);
-bool selinux_set_context_recursive(const std::string &path,
-                                   const std::string &context);
-bool selinux_lset_context_recursive(const std::string &path,
-                                    const std::string &context);
-bool selinux_get_enforcing(int &value);
-bool selinux_set_enforcing(int value);
-bool selinux_get_process_attr(pid_t pid, SELinuxAttr attr,
-                              std::string &context_out);
-bool selinux_set_process_attr(pid_t pid, SELinuxAttr attr,
-                              const std::string &context);
+oc::result<std::string> selinux_get_context(const std::string &path);
+oc::result<std::string> selinux_lget_context(const std::string &path);
+oc::result<std::string> selinux_fget_context(int fd);
+oc::result<void> selinux_set_context(const std::string &path,
+                                     const std::string &context);
+oc::result<void> selinux_lset_context(const std::string &path,
+                                      const std::string &context);
+oc::result<void> selinux_fset_context(int fd, const std::string &context);
+oc::result<void> selinux_set_context_recursive(const std::string &path,
+                                               const std::string &context);
+oc::result<void> selinux_lset_context_recursive(const std::string &path,
+                                                const std::string &context);
+oc::result<bool> selinux_get_enforcing();
+oc::result<void> selinux_set_enforcing(bool value);
+oc::result<std::string> selinux_get_process_attr(pid_t pid, SELinuxAttr attr);
+oc::result<void> selinux_set_process_attr(pid_t pid, SELinuxAttr attr,
+                                          const std::string &context);
 
 }

--- a/libmbutil/include/mbutil/socket.h
+++ b/libmbutil/include/mbutil/socket.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2017  Andrew Gunnerson <andrewgunnerson@gmail.com>
+ * Copyright (C) 2014-2018  Andrew Gunnerson <andrewgunnerson@gmail.com>
  *
  * This file is part of DualBootPatcher
  *
@@ -22,32 +22,34 @@
 #include <string>
 #include <vector>
 
-#include <inttypes.h>
+#include <cinttypes>
+
+#include "mbcommon/outcome.h"
 
 namespace mb::util
 {
 
-ssize_t socket_read(int fd, void *buf, size_t size);
-ssize_t socket_write(int fd, const void *buf, size_t size);
-bool socket_read_bytes(int fd, std::vector<uint8_t> &result);
-bool socket_write_bytes(int fd, const uint8_t *data, size_t len);
-bool socket_read_uint16(int fd, uint16_t &result);
-bool socket_write_uint16(int fd, uint16_t n);
-bool socket_read_uint32(int fd, uint32_t &result);
-bool socket_write_uint32(int fd, uint32_t n);
-bool socket_read_uint64(int fd, uint64_t &result);
-bool socket_write_uint64(int fd, uint64_t n);
-bool socket_read_int16(int fd, int16_t &result);
-bool socket_write_int16(int fd, int16_t n);
-bool socket_read_int32(int fd, int32_t &result);
-bool socket_write_int32(int fd, int32_t n);
-bool socket_read_int64(int fd, int64_t &result);
-bool socket_write_int64(int fd, int64_t n);
-bool socket_read_string(int fd, std::string &result);
-bool socket_write_string(int fd, const std::string &str);
-bool socket_read_string_array(int fd, std::vector<std::string> &result);
-bool socket_write_string_array(int fd, const std::vector<std::string> &list);
-bool socket_receive_fds(int fd, std::vector<int> &fds);
-bool socket_send_fds(int fd, const std::vector<int> &fds);
+oc::result<size_t> socket_read(int fd, void *buf, size_t size);
+oc::result<size_t> socket_write(int fd, const void *buf, size_t size);
+oc::result<std::vector<unsigned char>> socket_read_bytes(int fd);
+oc::result<void> socket_write_bytes(int fd, const void *data, size_t len);
+oc::result<uint16_t> socket_read_uint16(int fd);
+oc::result<void> socket_write_uint16(int fd, uint16_t n);
+oc::result<uint32_t> socket_read_uint32(int fd);
+oc::result<void> socket_write_uint32(int fd, uint32_t n);
+oc::result<uint64_t> socket_read_uint64(int fd);
+oc::result<void> socket_write_uint64(int fd, uint64_t n);
+oc::result<int16_t> socket_read_int16(int fd);
+oc::result<void> socket_write_int16(int fd, int16_t n);
+oc::result<int32_t> socket_read_int32(int fd);
+oc::result<void> socket_write_int32(int fd, int32_t n);
+oc::result<int64_t> socket_read_int64(int fd);
+oc::result<void> socket_write_int64(int fd, int64_t n);
+oc::result<std::string> socket_read_string(int fd);
+oc::result<void> socket_write_string(int fd, const std::string &str);
+oc::result<std::vector<std::string>> socket_read_string_array(int fd);
+oc::result<void> socket_write_string_array(int fd, const std::vector<std::string> &list);
+oc::result<void> socket_receive_fds(int fd, std::vector<int> &fds);
+oc::result<void> socket_send_fds(int fd, const std::vector<int> &fds);
 
 }

--- a/libmbutil/include/mbutil/string.h
+++ b/libmbutil/include/mbutil/string.h
@@ -32,8 +32,7 @@ void replace(std::string &source,
 void replace_all(std::string &source,
                  const std::string &from, const std::string &to);
 
-std::vector<std::string> tokenize(const std::string &str,
-                                  const std::string &delims);
+std::vector<std::string> tokenize(std::string str, const std::string &delims);
 
 std::string hex_string(const unsigned char *data, size_t size);
 

--- a/libmbutil/include/mbutil/vibrate.h
+++ b/libmbutil/include/mbutil/vibrate.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015  Andrew Gunnerson <andrewgunnerson@gmail.com>
+ * Copyright (C) 2015-2018  Andrew Gunnerson <andrewgunnerson@gmail.com>
  *
  * This file is part of DualBootPatcher
  *
@@ -19,9 +19,14 @@
 
 #pragma once
 
+#include <chrono>
+
+#include "mbcommon/outcome.h"
+
 namespace mb::util
 {
 
-bool vibrate(unsigned int timeout_ms, unsigned int additional_wait_ms);
+oc::result<void> vibrate(std::chrono::milliseconds timeout,
+                         std::chrono::milliseconds wait);
 
 }

--- a/libmbutil/src/archive.cpp
+++ b/libmbutil/src/archive.cpp
@@ -469,20 +469,21 @@ bool libarchive_tar_create(const std::string &filename,
             // the archive path to the relative path starting at base_dir
             const char *curpath = archive_entry_pathname(entry);
             if (curpath && path[0] != '/' && !base_dir.empty()) {
-                std::string relpath;
-                if (!relative_path(curpath, base_dir, relpath)) {
+                auto relpath = relative_path(curpath, base_dir);
+                if (!relpath) {
                     LOGE("Failed to compute relative path of %s starting at %s: %s",
-                         curpath, base_dir.c_str(), strerror(errno));
+                         curpath, base_dir.c_str(),
+                         relpath.error().message().c_str());
                     archive_entry_free(entry);
                     return false;
                 }
-                if (relpath.empty()) {
+                if (relpath.value().empty()) {
                     // If the relative path is empty, then the current path is
                     // the root of the directory tree. We don't need that, so
                     // skip it.
                     continue;
                 }
-                archive_entry_set_pathname(entry, relpath.c_str());
+                archive_entry_set_pathname(entry, relpath.value().c_str());
             }
 
             switch (archive_entry_filetype(entry)) {
@@ -610,9 +611,11 @@ bool extract_archive(const std::string &filename, const std::string &target)
 
     archive_entry *entry;
     int ret;
-    std::string cwd = get_cwd();
 
-    if (cwd.empty()) {
+    auto cwd = get_cwd();
+    if (!cwd) {
+        LOGE("Failed to get working directory: %s",
+             cwd.error().message().c_str());
         return false;
     }
 
@@ -635,7 +638,7 @@ bool extract_archive(const std::string &filename, const std::string &target)
     }
 
     auto chdir_back = finally([&] {
-        chdir(cwd.c_str());
+        chdir(cwd.value().c_str());
     });
 
     while ((ret = archive_read_next_header(in.get(), &entry)) == ARCHIVE_OK) {
@@ -670,10 +673,12 @@ bool extract_files(const std::string &filename, const std::string &target,
 
     archive_entry *entry;
     int ret;
-    std::string cwd = get_cwd();
     unsigned int count = 0;
 
-    if (cwd.empty()) {
+    auto cwd = get_cwd();
+    if (!cwd) {
+        LOGE("Failed to get working directory: %s",
+             cwd.error().message().c_str());
         return false;
     }
 
@@ -696,7 +701,7 @@ bool extract_files(const std::string &filename, const std::string &target,
     }
 
     auto chdir_back = finally([&] {
-        chdir(cwd.c_str());
+        chdir(cwd.value().c_str());
     });
 
     while ((ret = archive_read_next_header(in.get(), &entry)) == ARCHIVE_OK) {

--- a/libmbutil/src/archive.cpp
+++ b/libmbutil/src/archive.cpp
@@ -625,9 +625,9 @@ bool extract_archive(const std::string &filename, const std::string &target)
 
     set_up_output(out.get());
 
-    if (!mkdir_recursive(target, S_IRWXU | S_IRWXG | S_IRWXO)) {
+    if (auto r = mkdir_recursive(target, S_IRWXU | S_IRWXG | S_IRWXO); !r) {
         LOGE("%s: Failed to create directory: %s",
-             target.c_str(), strerror(errno));
+             target.c_str(), r.error().message().c_str());
         return false;
     }
 
@@ -688,9 +688,9 @@ bool extract_files(const std::string &filename, const std::string &target,
 
     set_up_output(out.get());
 
-    if (!mkdir_recursive(target, S_IRWXU | S_IRWXG | S_IRWXO)) {
+    if (auto r = mkdir_recursive(target, S_IRWXU | S_IRWXG | S_IRWXO); !r) {
         LOGE("%s: Failed to create directory: %s",
-             target.c_str(), strerror(errno));
+             target.c_str(), r.error().message().c_str());
         return false;
     }
 

--- a/libmbutil/src/copy.cpp
+++ b/libmbutil/src/copy.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2017  Andrew Gunnerson <andrewgunnerson@gmail.com>
+ * Copyright (C) 2014-2018  Andrew Gunnerson <andrewgunnerson@gmail.com>
  *
  * This file is part of DualBootPatcher
  *
@@ -28,6 +28,7 @@
 #include <sys/xattr.h>
 #include <unistd.h>
 
+#include "mbcommon/error_code.h"
 #include "mbcommon/finally.h"
 #include "mbcommon/string.h"
 #include "mblog/logging.h"
@@ -43,19 +44,19 @@
 namespace mb::util
 {
 
-bool copy_data_fd(int fd_source, int fd_target)
+oc::result<void> copy_data_fd(int fd_source, int fd_target)
 {
     char buf[10240];
     ssize_t nread;
 
-    while ((nread = read(fd_source, buf, sizeof buf)) > 0) {
+    while ((nread = read(fd_source, buf, sizeof(buf))) > 0) {
         char *out_ptr = buf;
         ssize_t nwritten;
 
         do {
             if ((nwritten = write(fd_target, out_ptr,
                                   static_cast<size_t>(nread))) < 0) {
-                return false;
+                return ec_from_errno();
             }
 
             nread -= nwritten;
@@ -63,159 +64,154 @@ bool copy_data_fd(int fd_source, int fd_target)
         } while (nread > 0);
     }
 
-    return nread == 0;
+    if (nread < 0) {
+        return ec_from_errno();
+    }
+
+    return oc::success();
 }
 
-static bool copy_data(const std::string &source, const std::string &target)
+static FileOpResult<void> copy_data(const std::string &source,
+                                    const std::string &target)
 {
-    int fd_source = -1;
-    int fd_target = -1;
-
-    fd_source = open(source.c_str(), O_RDONLY);
+    int fd_source = open(source.c_str(), O_RDONLY);
     if (fd_source < 0) {
-        return false;
+        return FileOpErrorInfo{source, ec_from_errno()};
     }
 
     auto close_source_fd = finally([&] {
         close(fd_source);
     });
 
-    fd_target = open(target.c_str(), O_WRONLY | O_CREAT | O_EXCL, 0666);
+    int fd_target = open(target.c_str(), O_WRONLY | O_CREAT | O_EXCL, 0666);
     if (fd_target < 0) {
-        return false;
+        return FileOpErrorInfo{target, ec_from_errno()};
     }
 
     auto close_target_fd = finally([&] {
         close(fd_target);
     });
 
-    return copy_data_fd(fd_source, fd_target);
+    if (auto r = copy_data_fd(fd_source, fd_target); !r) {
+        // TODO: OR SOURCE?
+        return FileOpErrorInfo{target, r.error()};
+    }
+
+    close_target_fd.dismiss();
+
+    if (close(fd_target) < 0) {
+        return FileOpErrorInfo{target, ec_from_errno()};
+    }
+
+    return oc::success();
 }
 
-bool copy_xattrs(const std::string &source, const std::string &target)
+FileOpResult<void> copy_xattrs(const std::string &source,
+                               const std::string &target)
 {
-    ssize_t size;
-    std::vector<char> names;
-    char *end_names;
-    char *name;
-    std::vector<char> value;
-
     // xattr names are in a NULL-separated list
-    size = llistxattr(source.c_str(), nullptr, 0);
+    ssize_t size = llistxattr(source.c_str(), nullptr, 0);
     if (size < 0) {
         if (errno == ENOTSUP) {
             LOGV("%s: xattrs not supported on source filesystem",
                  source.c_str());
-            return true;
+            return oc::success();
         } else {
-            LOGE("%s: Failed to list xattrs: %s",
-                 source.c_str(), strerror(errno));
-            return false;
+            return FileOpErrorInfo{source, ec_from_errno()};
         }
     }
 
-    names.resize(static_cast<size_t>(size + 1));
+    std::string names;
+    names.resize(static_cast<size_t>(size));
 
-    size = llistxattr(source.c_str(), names.data(), static_cast<size_t>(size));
+    size = llistxattr(source.c_str(), names.data(), names.size());
     if (size < 0) {
-        LOGE("%s: Failed to list xattrs on second try: %s",
-             source.c_str(), strerror(errno));
-        return false;
-    } else {
-        names[static_cast<size_t>(size)] = '\0';
-        end_names = names.data() + size;
+        return FileOpErrorInfo{source, ec_from_errno()};
     }
 
-    for (name = names.data(); name != end_names; name = strchr(name, '\0') + 1) {
-        if (!*name) {
-            continue;
-        }
+    std::string value;
 
+    for (char *name = names.data(); *name; name = strchr(name, '\0') + 1) {
         size = lgetxattr(source.c_str(), name, nullptr, 0);
         if (size < 0) {
-            LOGW("%s: Failed to get attribute '%s': %s",
-                 source.c_str(), name, strerror(errno));
-            continue;
+            return FileOpErrorInfo{source, ec_from_errno()};
         }
 
         value.resize(static_cast<size_t>(size));
 
-        size = lgetxattr(source.c_str(), name, value.data(),
-                         static_cast<size_t>(size));
+        size = lgetxattr(source.c_str(), name, value.data(), value.size());
         if (size < 0) {
-            LOGW("%s: Failed to get attribute '%s' on second try: %s",
-                 source.c_str(), name, strerror(errno));
-            continue;
+            return FileOpErrorInfo{source, ec_from_errno()};
         }
 
-        if (lsetxattr(target.c_str(), name, value.data(),
-                      static_cast<size_t>(size), 0) < 0) {
+        if (lsetxattr(target.c_str(), name, value.data(), value.size(), 0) < 0) {
             if (errno == ENOTSUP) {
                 LOGV("%s: xattrs not supported on target filesystem",
                      target.c_str());
                 break;
             } else {
-                LOGE("%s: Failed to set xattrs: %s",
-                     target.c_str(), strerror(errno));
-                return false;
+                return FileOpErrorInfo{target, ec_from_errno()};
             }
         }
     }
 
-    return true;
+    return oc::success();
 }
 
-bool copy_stat(const std::string &source, const std::string &target)
+FileOpResult<void> copy_stat(const std::string &source,
+                             const std::string &target)
 {
     struct stat sb;
 
     if (lstat(source.c_str(), &sb) < 0) {
-        LOGE("%s: Failed to stat: %s", source.c_str(), strerror(errno));
-        return false;
+        return FileOpErrorInfo{source, ec_from_errno()};
     }
 
     if (lchown(target.c_str(), sb.st_uid, sb.st_gid) < 0) {
-        LOGE("%s: Failed to chown: %s", target.c_str(), strerror(errno));
-        return false;
+        return FileOpErrorInfo{target, ec_from_errno()};
     }
 
     if (!S_ISLNK(sb.st_mode)) {
-        if (chmod(target.c_str(), sb.st_mode & (S_ISUID | S_ISGID | S_ISVTX
-                                              | S_IRWXU | S_IRWXG | S_IRWXO)) < 0) {
-            LOGE("%s: Failed to chmod: %s", target.c_str(), strerror(errno));
-            return false;
+        if (chmod(target.c_str(),
+                  sb.st_mode & static_cast<mode_t>(~S_IFMT)) < 0) {
+            return FileOpErrorInfo{target, ec_from_errno()};
         }
     }
 
-    return true;
+    return oc::success();
 }
 
-bool copy_contents(const std::string &source, const std::string &target)
+FileOpResult<void> copy_contents(const std::string &source,
+                                 const std::string &target)
 {
-    int fd_source = -1;
-    int fd_target = -1;
-
-    if ((fd_source = open(source.c_str(), O_RDONLY)) < 0) {
-        return false;
+    int fd_source = open(source.c_str(), O_RDONLY);
+    if (fd_source < 0) {
+        return FileOpErrorInfo{source, ec_from_errno()};
     }
 
     auto close_source_fd = finally([&] {
         close(fd_source);
     });
 
-    if ((fd_target = open(target.c_str(), O_WRONLY | O_CREAT | O_TRUNC, 0666)) < 0) {
-        return false;
+    int fd_target = open(target.c_str(), O_WRONLY | O_CREAT | O_TRUNC, 0666);
+    if (fd_target < 0) {
+        return FileOpErrorInfo{target, ec_from_errno()};
     }
 
     auto close_target_fd = finally([&] {
         close(fd_target);
     });
 
-    return copy_data_fd(fd_source, fd_target);
+    if (auto r = copy_data_fd(fd_source, fd_target)) {
+        // TODO: OR SOURCE?
+        return FileOpErrorInfo{target, ec_from_errno()};
+    }
+
+    return oc::success();
 }
 
-bool copy_file(const std::string &source, const std::string &target,
-               CopyFlags flags)
+FileOpResult<void> copy_file(const std::string &source,
+                             const std::string &target, CopyFlags flags)
 {
     mode_t old_umask = umask(0);
 
@@ -224,43 +220,33 @@ bool copy_file(const std::string &source, const std::string &target,
     });
 
     if (unlink(target.c_str()) < 0 && errno != ENOENT) {
-        LOGE("%s: Failed to remove old file: %s",
-             target.c_str(), strerror(errno));
-        return false;
+        return FileOpErrorInfo{target, ec_from_errno()};
     }
 
     struct stat sb;
     if (((flags & CopyFlag::FollowSymlinks)
             ? stat : lstat)(source.c_str(), &sb) < 0) {
-        LOGE("%s: Failed to stat: %s",
-             source.c_str(), strerror(errno));
-        return false;
+        return FileOpErrorInfo{source, ec_from_errno()};
     }
 
     switch (sb.st_mode & S_IFMT) {
     case S_IFBLK:
         if (mknod(target.c_str(), S_IFBLK | S_IRWXU,
                   static_cast<dev_t>(sb.st_rdev)) < 0) {
-            LOGW("%s: Failed to create block device: %s",
-                 target.c_str(), strerror(errno));
-            return false;
+            return FileOpErrorInfo{target, ec_from_errno()};
         }
         break;
 
     case S_IFCHR:
         if (mknod(target.c_str(), S_IFCHR | S_IRWXU,
                   static_cast<dev_t>(sb.st_rdev)) < 0) {
-            LOGW("%s: Failed to create character device: %s",
-                 target.c_str(), strerror(errno));
-            return false;
+            return FileOpErrorInfo{target, ec_from_errno()};
         }
         break;
 
     case S_IFIFO:
         if (mkfifo(target.c_str(), S_IRWXU) < 0) {
-            LOGW("%s: Failed to create FIFO pipe: %s",
-                 target.c_str(), strerror(errno));
-            return false;
+            return FileOpErrorInfo{target, ec_from_errno()};
         }
         break;
 
@@ -268,15 +254,11 @@ bool copy_file(const std::string &source, const std::string &target,
         if (!(flags & CopyFlag::FollowSymlinks)) {
             auto symlink_path = read_link(source);
             if (!symlink_path) {
-                LOGW("%s: Failed to read symlink path: %s",
-                     source.c_str(), symlink_path.error().message().c_str());
-                return false;
+                return FileOpErrorInfo{source, symlink_path.error()};
             }
 
             if (symlink(symlink_path.value().c_str(), target.c_str()) < 0) {
-                LOGW("%s: Failed to create symlink: %s",
-                     target.c_str(), strerror(errno));
-                return false;
+                return FileOpErrorInfo{target, ec_from_errno()};
             }
 
             break;
@@ -286,44 +268,33 @@ bool copy_file(const std::string &source, const std::string &target,
         [[fallthrough]];
 
     case S_IFREG:
-        if (!copy_data(source, target)) {
-            LOGE("%s: Failed to copy data: %s",
-                 target.c_str(), strerror(errno));
-            return false;
+        if (auto r = copy_data(source, target); !r) {
+            return r.as_failure();
         }
         break;
 
     case S_IFSOCK:
-        LOGE("%s: Cannot copy socket", target.c_str());
-        errno = EINVAL;
-        return false;
-
     case S_IFDIR:
-        LOGE("%s: Cannot copy directory", target.c_str());
-        errno = EINVAL;
-        return false;
+        return FileOpErrorInfo{
+                target, std::make_error_code(std::errc::invalid_argument)};
     }
 
-    if ((flags & CopyFlag::CopyAttributes)
-            && !copy_stat(source, target)) {
-        LOGE("%s: Failed to copy attributes: %s",
-             target.c_str(), strerror(errno));
-        return false;
+    if (flags & CopyFlag::CopyAttributes) {
+        OUTCOME_TRYV(copy_stat(source, target));
     }
-    if ((flags & CopyFlag::CopyXattrs)
-            && !copy_xattrs(source, target)) {
-        LOGE("%s: Failed to copy xattrs: %s",
-             target.c_str(), strerror(errno));
-        return false;
+    if (flags & CopyFlag::CopyXattrs) {
+        OUTCOME_TRYV(copy_xattrs(source, target));
     }
 
-    return true;
+    return oc::success();
 }
 
 
 class RecursiveCopier : public FtsWrapper
 {
 public:
+    FileOpErrorInfo error;
+
     RecursiveCopier(std::string path, std::string target, CopyFlags copyflags)
         : FtsWrapper(path, 0)
         , _copyflags(copyflags)
@@ -335,33 +306,26 @@ public:
     {
         // This is almost *never* useful, so we won't allow it
         if (_copyflags & CopyFlag::FollowSymlinks) {
-            _error_msg = "CopyFlag::FollowSymlinks not allowed for recursive copies";
-            LOGE("%s", _error_msg.c_str());
+            error = {{}, std::make_error_code(std::errc::invalid_argument)};
             return false;
         }
 
         // Create the target directory if it doesn't exist
         if (mkdir(_target.c_str(), S_IRWXU | S_IRWXG | S_IRWXO) < 0
                 && errno != EEXIST) {
-            _error_msg = format("%s: Failed to create directory: %s",
-                                _target.c_str(), strerror(errno));
-            LOGE("%s", _error_msg.c_str());
+            error = {_target, ec_from_errno()};
             return false;
         }
 
         // Ensure target is a directory
 
         if (stat(_target.c_str(), &sb_target) < 0) {
-            _error_msg = format("%s: Failed to stat: %s",
-                                _target.c_str(), strerror(errno));
-            LOGE("%s", _error_msg.c_str());
+            error = {_target, ec_from_errno()};
             return false;
         }
 
         if (!S_ISDIR(sb_target.st_mode)) {
-            _error_msg = format("%s: Target exists but is not a directory",
-                                _target.c_str());
-            LOGE("%s", _error_msg.c_str());
+            error = {_target, std::make_error_code(std::errc::not_a_directory)};
             return false;
         }
 
@@ -373,9 +337,8 @@ public:
         // Make sure we aren't copying the target on top of itself
         if (sb_target.st_dev == _curr->fts_statp->st_dev
                 && sb_target.st_ino == _curr->fts_statp->st_ino) {
-            _error_msg = format("%s: Cannot copy on top of itself",
-                                _curr->fts_path);
-            LOGE("%s", _error_msg.c_str());
+            error = {_curr->fts_path,
+                     std::make_error_code(std::errc::invalid_argument)};
             return Action::Fail | Action::Stop;
         }
 
@@ -413,9 +376,7 @@ public:
         // Create target directory if it doesn't exist
         if (mkdir(_curtgtpath.c_str(), S_IRWXU | S_IRWXG | S_IRWXO) < 0
                 && errno != EEXIST) {
-            _error_msg = format("%s: Failed to create directory: %s",
-                                _curtgtpath.c_str(), strerror(errno));
-            LOGW("%s", _error_msg.c_str());
+            error = {_curtgtpath, ec_from_errno()};
             success = false;
             skip = true;
         }
@@ -423,9 +384,8 @@ public:
         // Ensure target path is a directory
         if (!skip && stat(_curtgtpath.c_str(), &sb) == 0
                 && !S_ISDIR(sb.st_mode)) {
-            _error_msg = format("%s: Exists but is not a directory",
-                                _curtgtpath.c_str());
-            LOGW("%s", _error_msg.c_str());
+            error = {_curtgtpath,
+                     std::make_error_code(std::errc::not_a_directory)};
             success = false;
             skip = true;
         }
@@ -466,10 +426,8 @@ public:
         }
 
         // Copy file contents
-        if (!copy_data(_curr->fts_accpath, _curtgtpath)) {
-            _error_msg = format("%s: Failed to copy data: %s",
-                                _curtgtpath.c_str(), strerror(errno));
-            LOGW("%s", _error_msg.c_str());
+        if (auto r = copy_data(_curr->fts_accpath, _curtgtpath); !r) {
+            error = r.error();
             return Action::Fail;
         }
 
@@ -493,18 +451,13 @@ public:
         // Find current symlink target
         auto symlink_path = read_link(_curr->fts_accpath);
         if (!symlink_path) {
-            _error_msg = format("%s: Failed to read symlink path: %s",
-                                _curr->fts_accpath,
-                                symlink_path.error().message().c_str());
-            LOGW("%s", _error_msg.c_str());
+            error = {_curr->fts_accpath, symlink_path.error()};
             return Action::Fail;
         }
 
         // Create new symlink
         if (symlink(symlink_path.value().c_str(), _curtgtpath.c_str()) < 0) {
-            _error_msg = format("%s: Failed to create symlink: %s",
-                                _curtgtpath.c_str(), strerror(errno));
-            LOGW("%s", _error_msg.c_str());
+            error = {_curtgtpath, ec_from_errno()};
             return Action::Fail;
         }
 
@@ -527,9 +480,7 @@ public:
 
         if (mknod(_curtgtpath.c_str(), S_IFBLK | S_IRWXU,
                   static_cast<dev_t>(_curr->fts_statp->st_rdev)) < 0) {
-            _error_msg = format("%s: Failed to create block device: %s",
-                                _curtgtpath.c_str(), strerror(errno));
-            LOGW("%s", _error_msg.c_str());
+            error = {_curtgtpath, ec_from_errno()};
             return Action::Fail;
         }
 
@@ -552,9 +503,7 @@ public:
 
         if (mknod(_curtgtpath.c_str(), S_IFCHR | S_IRWXU,
                   static_cast<dev_t>(_curr->fts_statp->st_rdev)) < 0) {
-            _error_msg = format("%s: Failed to create character device: %s",
-                                _curtgtpath.c_str(), strerror(errno));
-            LOGW("%s", _error_msg.c_str());
+            error = {_curtgtpath, ec_from_errno()};
             return Action::Fail;
         }
 
@@ -576,9 +525,7 @@ public:
         }
 
         if (mkfifo(_curtgtpath.c_str(), S_IRWXU) < 0) {
-            _error_msg = format("%s: Failed to create FIFO pipe: %s",
-                                _curtgtpath.c_str(), strerror(errno));
-            LOGW("%s", _error_msg.c_str());
+            error = {_curtgtpath, ec_from_errno()};
             return Action::Fail;
         }
 
@@ -609,9 +556,7 @@ private:
     {
         // Remove existing file
         if (unlink(_curtgtpath.c_str()) < 0 && errno != ENOENT) {
-            _error_msg = format("%s: Failed to remove old path: %s",
-                                _curtgtpath.c_str(), strerror(errno));
-            LOGW("%s", _error_msg.c_str());
+            error = {_curtgtpath, ec_from_errno()};
             return false;
         }
         return true;
@@ -619,24 +564,22 @@ private:
 
     bool cp_attrs()
     {
-        if ((_copyflags & CopyFlag::CopyAttributes)
-                && !copy_stat(_curr->fts_accpath, _curtgtpath)) {
-            _error_msg = format("%s: Failed to copy attributes: %s",
-                                _curtgtpath.c_str(), strerror(errno));
-            LOGW("%s", _error_msg.c_str());
-            return false;
+        if (_copyflags & CopyFlag::CopyAttributes) {
+            if (auto r = copy_stat(_curr->fts_accpath, _curtgtpath); !r) {
+                error = r.error();
+                return false;
+            }
         }
         return true;
     }
 
     bool cp_xattrs()
     {
-        if ((_copyflags & CopyFlag::CopyXattrs)
-                && !copy_xattrs(_curr->fts_accpath, _curtgtpath)) {
-            _error_msg = format("%s: Failed to copy xattrs: %s",
-                                _curtgtpath.c_str(), strerror(errno));
-            LOGW("%s", _error_msg.c_str());
-            return false;
+        if (_copyflags & CopyFlag::CopyXattrs) {
+            if (auto r = copy_xattrs(_curr->fts_accpath, _curtgtpath); !r) {
+                error = r.error();
+                return false;
+            }
         }
         return true;
     }
@@ -644,17 +587,22 @@ private:
 
 
 // Copy as much as possible
-bool copy_dir(const std::string &source, const std::string &target,
-              CopyFlags flags)
+FileOpResult<void> copy_dir(const std::string &source,
+                            const std::string &target, CopyFlags flags)
 {
     mode_t old_umask = umask(0);
 
+    auto restore_umask = finally([&] {
+        umask(old_umask);
+    });
+
     RecursiveCopier copier(source, target, flags);
-    bool ret = copier.run();
 
-    umask(old_umask);
+    if (!copier.run()) {
+        return std::move(copier.error);
+    }
 
-    return ret;
+    return oc::success();
 }
 
 }

--- a/libmbutil/src/copy.cpp
+++ b/libmbutil/src/copy.cpp
@@ -202,7 +202,7 @@ FileOpResult<void> copy_contents(const std::string &source,
         close(fd_target);
     });
 
-    if (auto r = copy_data_fd(fd_source, fd_target)) {
+    if (auto r = copy_data_fd(fd_source, fd_target); !r) {
         // TODO: OR SOURCE?
         return FileOpErrorInfo{target, ec_from_errno()};
     }

--- a/libmbutil/src/file.cpp
+++ b/libmbutil/src/file.cpp
@@ -178,7 +178,7 @@ oc::result<bool> file_find_one_of(const std::string &path,
     return false;
 }
 
-oc::result<std::vector<unsigned char>> file_read_all_v(const std::string &path)
+oc::result<std::vector<unsigned char>> file_read_all(const std::string &path)
 {
     ScopedFILE fp(fopen(path.c_str(), "rb"), fclose);
     if (!fp) {
@@ -209,47 +209,6 @@ oc::result<std::vector<unsigned char>> file_read_all_v(const std::string &path)
     }
 
     return std::move(data);
-}
-
-oc::result<std::pair<void *, std::size_t>>
-file_read_all(const std::string &path)
-{
-    ScopedFILE fp(fopen(path.c_str(), "rb"), fclose);
-    if (!fp) {
-        return ec_from_errno();
-    }
-
-    if (fseeko(fp.get(), 0, SEEK_END) < 0) {
-        return ec_from_errno();
-    }
-    auto size = ftello(fp.get());
-    if (size < 0) {
-        return ec_from_errno();
-    } else if (std::make_unsigned_t<decltype(size)>(size) > SIZE_MAX) {
-        return std::errc::result_out_of_range;
-    }
-    if (fseeko(fp.get(), 0, SEEK_SET) < 0) {
-        return ec_from_errno();
-    }
-
-    auto data_size = static_cast<size_t>(size);
-
-    auto data = std::malloc(data_size);
-    if (!data) {
-        return ec_from_errno();
-    }
-
-    if (fread(data, data_size, 1, fp.get()) != 1) {
-        free(data);
-
-        if (ferror(fp.get())) {
-            return ec_from_errno();
-        } else {
-            return FileError::UnexpectedEof;
-        }
-    }
-
-    return {data, data_size};
 }
 
 oc::result<uint64_t> get_blockdev_size(const std::string &path)

--- a/libmbutil/src/file.cpp
+++ b/libmbutil/src/file.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2017  Andrew Gunnerson <andrewgunnerson@gmail.com>
+ * Copyright (C) 2014-2018  Andrew Gunnerson <andrewgunnerson@gmail.com>
  *
  * This file is part of DualBootPatcher
  *
@@ -32,6 +32,8 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
+#include "mbcommon/error_code.h"
+#include "mbcommon/file_error.h"
 #include "mbcommon/finally.h"
 
 namespace mb::util
@@ -45,39 +47,37 @@ using ScopedFILE = std::unique_ptr<FILE, decltype(fclose) *>;
  * \note Returns 0 if file already exists
  *
  * \param path File to create
- * \return true on success, false on failure with errno set appropriately
+ *
+ * \return Nothing on success or the error code on failure
  */
-bool create_empty_file(const std::string &path)
+oc::result<void> create_empty_file(const std::string &path)
 {
     int fd;
     if ((fd = open(path.c_str(), O_RDWR | O_CREAT, S_IRUSR | S_IWUSR |
                                                    S_IRGRP | S_IWGRP |
                                                    S_IROTH | S_IWOTH)) < 0) {
-        return false;
+        return ec_from_errno();
     }
 
     close(fd);
-    return true;
+    return oc::success();
 }
 
 /*!
  * \brief Get first line from file
  *
+ * The trailing newline (if exists) will be stripped from the result.
+ *
  * \param path File to read
- * \param line_out Pointer to char * which will contain the first line
  *
- * \note line_out will point to a dynamically allocated buffer that should be
- *       free()'d when it is no longer needed
- *
- * \note line_out is not modified if this function fails
- *
- * \return true on success, false on failure and errno set appropriately
+ * \return Nothing on success or the error code on failure. Returns
+ *         FileError::UnexpectedEof if the file is empty.
  */
-bool file_first_line(const std::string &path, std::string &line_out)
+oc::result<std::string> file_first_line(const std::string &path)
 {
     ScopedFILE fp(fopen(path.c_str(), "rb"), fclose);
     if (!fp) {
-        return false;
+        return ec_from_errno();
     }
 
     char *line = nullptr;
@@ -89,7 +89,11 @@ bool file_first_line(const std::string &path, std::string &line_out)
     });
 
     if ((read = getline(&line, &len, fp.get())) < 0) {
-        return false;
+        if (ferror(fp.get())) {
+            return ec_from_errno();
+        } else {
+            return FileError::UnexpectedEof;
+        }
     }
 
     if (read > 0 && line[read - 1] == '\n') {
@@ -97,9 +101,7 @@ bool file_first_line(const std::string &path, std::string &line_out)
         --read;
     }
 
-    line_out = line;
-
-    return true;
+    return line;
 }
 
 /*!
@@ -109,44 +111,43 @@ bool file_first_line(const std::string &path, std::string &line_out)
  * \param data Pointer to data to write
  * \param size Size of \a data
  *
- * \return true on success, false on failure and errno set appropriately
+ * \return Nothing on success or the error code on failure. Returns
+ *         FileError::UnexpectedEof if EOF is reached before the write
+ *         completes.
  */
-bool file_write_data(const std::string &path,
-                     const void *data, size_t size)
+oc::result<void> file_write_data(const std::string &path,
+                                 const void *data, size_t size)
 {
-    FILE *fp = fopen(path.c_str(), "wb");
+    ScopedFILE fp(fopen(path.c_str(), "wb"), fclose);
     if (!fp) {
-        return false;
+        return ec_from_errno();
     }
 
-    size_t nwritten;
-
-    do {
-        if ((nwritten = std::fwrite(data, 1, size, fp)) == 0) {
-            break;
+    size_t n = std::fwrite(data, 1, size, fp.get());
+    if (n != size) {
+        if (ferror(fp.get())) {
+            return ec_from_errno();
+        } else {
+            return FileError::UnexpectedEof;
         }
-
-        size -= nwritten;
-        data = static_cast<const char *>(data) + nwritten;
-    } while (size > 0);
-
-    bool ret = size == 0 || !ferror(fp);
-
-    if (fclose(fp) < 0) {
-        return false;
     }
 
-    return ret;
+    if (fclose(fp.release()) != 0) {
+        return ec_from_errno();
+    }
+
+    return oc::success();
 }
 
-bool file_find_one_of(const std::string &path, std::vector<std::string> items)
+oc::result<bool> file_find_one_of(const std::string &path,
+                                  const std::vector<std::string> &items)
 {
     struct stat sb;
     void *map = MAP_FAILED;
     int fd = -1;
 
     if ((fd = open(path.c_str(), O_RDONLY)) < 0) {
-        return false;
+        return ec_from_errno();
     }
 
     auto close_fd = finally([&] {
@@ -154,13 +155,13 @@ bool file_find_one_of(const std::string &path, std::vector<std::string> items)
     });
 
     if (fstat(fd, &sb) < 0) {
-        return false;
+        return ec_from_errno();
     }
 
     map = mmap(nullptr, static_cast<size_t>(sb.st_size), PROT_READ, MAP_PRIVATE,
                fd, 0);
     if (map == MAP_FAILED) {
-        return false;
+        return ec_from_errno();
     }
 
     auto unmap_map = finally([&] {
@@ -177,63 +178,85 @@ bool file_find_one_of(const std::string &path, std::vector<std::string> items)
     return false;
 }
 
-bool file_read_all(const std::string &path,
-                   std::vector<unsigned char> &data_out)
+oc::result<std::vector<unsigned char>> file_read_all_v(const std::string &path)
 {
     ScopedFILE fp(fopen(path.c_str(), "rb"), fclose);
     if (!fp) {
-        return false;
+        return ec_from_errno();
     }
 
-    fseek(fp.get(), 0, SEEK_END);
+    if (fseeko(fp.get(), 0, SEEK_END) < 0) {
+        return ec_from_errno();
+    }
     auto size = ftello(fp.get());
-    rewind(fp.get());
+    if (size < 0) {
+        return ec_from_errno();
+    } else if (std::make_unsigned_t<decltype(size)>(size) > SIZE_MAX) {
+        return std::errc::result_out_of_range;
+    }
+    if (fseeko(fp.get(), 0, SEEK_SET) < 0) {
+        return ec_from_errno();
+    }
 
     std::vector<unsigned char> data(static_cast<size_t>(size));
-    if (fread(data.data(), static_cast<size_t>(size), 1, fp.get()) != 1) {
-        return false;
+
+    if (fread(data.data(), data.size(), 1, fp.get()) != 1) {
+        if (ferror(fp.get())) {
+            return ec_from_errno();
+        } else {
+            return FileError::UnexpectedEof;
+        }
     }
 
-    data_out.swap(data);
-
-    return true;
+    return std::move(data);
 }
 
-bool file_read_all(const std::string &path,
-                   unsigned char *&data_out,
-                   std::size_t &size_out)
+oc::result<std::pair<void *, std::size_t>>
+file_read_all(const std::string &path)
 {
     ScopedFILE fp(fopen(path.c_str(), "rb"), fclose);
     if (!fp) {
-        return false;
+        return ec_from_errno();
     }
 
-    fseek(fp.get(), 0, SEEK_END);
+    if (fseeko(fp.get(), 0, SEEK_END) < 0) {
+        return ec_from_errno();
+    }
     auto size = ftello(fp.get());
-    rewind(fp.get());
+    if (size < 0) {
+        return ec_from_errno();
+    } else if (std::make_unsigned_t<decltype(size)>(size) > SIZE_MAX) {
+        return std::errc::result_out_of_range;
+    }
+    if (fseeko(fp.get(), 0, SEEK_SET) < 0) {
+        return ec_from_errno();
+    }
 
-    auto data = static_cast<unsigned char *>(
-            std::malloc(static_cast<size_t>(size)));
+    auto data_size = static_cast<size_t>(size);
+
+    auto data = std::malloc(data_size);
     if (!data) {
-        return false;
+        return ec_from_errno();
     }
 
-    if (fread(data, static_cast<size_t>(size), 1, fp.get()) != 1) {
+    if (fread(data, data_size, 1, fp.get()) != 1) {
         free(data);
-        return false;
+
+        if (ferror(fp.get())) {
+            return ec_from_errno();
+        } else {
+            return FileError::UnexpectedEof;
+        }
     }
 
-    data_out = data;
-    size_out = static_cast<size_t>(size);
-
-    return true;
+    return {data, data_size};
 }
 
-bool get_blockdev_size(const std::string &path, uint64_t &size_out)
+oc::result<uint64_t> get_blockdev_size(const std::string &path)
 {
     int fd = open(path.c_str(), O_RDONLY);
     if (fd < 0) {
-        return false;
+        return ec_from_errno();
     }
 
     auto close_fd = finally([&]{
@@ -245,14 +268,12 @@ bool get_blockdev_size(const std::string &path, uint64_t &size_out)
 
     uint64_t size;
     if (ioctl(fd, BLKGETSIZE64, &size) < 0) {
-        return false;
+        return ec_from_errno();
     }
 
 #pragma GCC diagnostic pop
 
-    size_out = size;
-
-    return true;
+    return size;
 }
 
 }

--- a/libmbutil/src/mount.cpp
+++ b/libmbutil/src/mount.cpp
@@ -33,7 +33,7 @@
 #include <sys/vfs.h>
 #include <unistd.h>
 
-#include "mbcommon/error.h"
+#include "mbcommon/error_code.h"
 #include "mbcommon/finally.h"
 #include "mbcommon/string.h"
 #include "mblog/logging.h"
@@ -53,7 +53,42 @@ namespace mb::util
 
 using ScopedFILE = std::unique_ptr<FILE, decltype(fclose) *>;
 
-static std::string unescape_octals(const std::string &in)
+struct MountErrorCategory : std::error_category
+{
+    const char * name() const noexcept override;
+
+    std::string message(int ev) const override;
+};
+
+const std::error_category & mount_error_category()
+{
+    static MountErrorCategory c;
+    return c;
+}
+
+std::error_code make_error_code(MountError e)
+{
+    return {static_cast<int>(e), mount_error_category()};
+}
+
+const char * MountErrorCategory::name() const noexcept
+{
+    return "mount";
+}
+
+std::string MountErrorCategory::message(int ev) const
+{
+    switch (static_cast<MountError>(ev)) {
+    case MountError::EndOfFile:
+        return "end of file";
+    case MountError::PathNotMounted:
+        return "path not mounted";
+    default:
+        return "(unknown mount error)";
+    }
+}
+
+static std::string unescape_octals(std::string_view in)
 {
     std::string result;
 
@@ -76,8 +111,9 @@ static std::string unescape_octals(const std::string &in)
     return result;
 }
 
-bool get_mount_entry(std::FILE *fp, MountEntry &entry_out)
+oc::result<MountEntry> get_mount_entry(std::FILE *fp)
 {
+    MountEntry entry;
     char *line = nullptr;
     size_t size = 0;
 
@@ -85,8 +121,11 @@ bool get_mount_entry(std::FILE *fp, MountEntry &entry_out)
         free(line);
     });
 
-    if (getline(&line, &size, fp) < 0) {
-        return false;
+    ssize_t n = getline(&line, &size, fp);
+    if (n < 0) {
+        return ec_from_errno();
+    } else if (n == 0) {
+        return MountError::EndOfFile;
     }
 
     int pos[8];
@@ -95,11 +134,11 @@ bool get_mount_entry(std::FILE *fp, MountEntry &entry_out)
             pos + 2, pos + 3,   // dir
             pos + 4, pos + 5,   // type
             pos + 6, pos + 7,   // opts
-            &entry_out.freq,    // freq
-            &entry_out.passno); // passno
+            &entry.freq,        // freq
+            &entry.passno);     // passno
 
     if (count != 2) {
-        return false;
+        return std::errc::invalid_argument;
     }
 
     // NULL terminate entries
@@ -108,56 +147,63 @@ bool get_mount_entry(std::FILE *fp, MountEntry &entry_out)
     line[pos[5]] = '\0';
     line[pos[7]] = '\0';
 
-    entry_out.fsname = unescape_octals(line + pos[0]);
-    entry_out.dir = unescape_octals(line + pos[2]);
-    entry_out.type = unescape_octals(line + pos[4]);
-    entry_out.opts = unescape_octals(line + pos[6]);
+    entry.fsname = unescape_octals(line + pos[0]);
+    entry.dir = unescape_octals(line + pos[2]);
+    entry.type = unescape_octals(line + pos[4]);
+    entry.opts = unescape_octals(line + pos[6]);
 
     struct stat sb;
-    if (lstat(entry_out.dir.c_str(), &sb) < 0 && errno == ENOENT
-            && ends_with(entry_out.dir, DELETED_SUFFIX)) {
-        entry_out.dir.erase(entry_out.dir.size() - strlen(DELETED_SUFFIX));
+    if (lstat(entry.dir.c_str(), &sb) < 0 && errno == ENOENT
+            && ends_with(entry.dir, DELETED_SUFFIX)) {
+        entry.dir.erase(entry.dir.size() - strlen(DELETED_SUFFIX));
     }
 
-    return true;
+    return std::move(entry);
 }
 
-bool is_mounted(const std::string &mountpoint)
+oc::result<void> is_mounted(const std::string &mountpoint)
 {
     ScopedFILE fp(std::fopen(PROC_MOUNTS, "r"), std::fclose);
     if (!fp) {
-        LOGE("%s: Failed to read file: %s", PROC_MOUNTS, strerror(errno));
-        return false;
+        return ec_from_errno();
     }
 
-    for (MountEntry entry; get_mount_entry(fp.get(), entry);) {
-        if (mountpoint == entry.dir) {
-            return true;
+    while (true) {
+        auto entry = get_mount_entry(fp.get());
+        if (!entry) {
+            if (entry.error() == MountError::EndOfFile) {
+                break;
+            } else {
+                return entry.as_failure();
+            }
+        } else if (entry.value().dir == mountpoint) {
+            return oc::success();
         }
     }
 
-    return false;
+    return MountError::PathNotMounted;
 }
 
-bool unmount_all(const std::string &dir)
+oc::result<void> unmount_all(const std::string &dir)
 {
     std::vector<std::string> to_unmount;
     int failed = 0;
+    std::error_code ec;
 
     for (int tries = 0; tries < MAX_UNMOUNT_TRIES; ++tries) {
         failed = 0;
         to_unmount.clear();
+        ec.clear();
 
         ScopedFILE fp(std::fopen(PROC_MOUNTS, "r"), std::fclose);
         if (!fp) {
-            LOGE("%s: Failed to read file: %s", PROC_MOUNTS, strerror(errno));
-            return false;
+            return ec_from_errno();
         }
 
-        for (MountEntry entry; get_mount_entry(fp.get(), entry);) {
+        while (auto entry = get_mount_entry(fp.get())) {
             // TODO: Use path_compare() instead of dumb string prefix matching
-            if (starts_with(entry.dir, dir)) {
-                to_unmount.push_back(std::move(entry.dir));
+            if (starts_with(entry.value().dir, dir)) {
+                to_unmount.push_back(std::move(entry.value().dir));
             }
         }
 
@@ -165,30 +211,31 @@ bool unmount_all(const std::string &dir)
         for (auto it = to_unmount.rbegin(); it != to_unmount.rend(); ++it) {
             LOGD("Attempting to unmount %s", it->c_str());
 
-            if (!umount(*it)) {
-                LOGE("%s: Failed to unmount: %s",
-                     it->c_str(), strerror(errno));
+            if (auto ret = umount(*it); !ret) {
+                LOGW("%s: Failed to unmount: %s",
+                     it->c_str(), ret.error().message().c_str());
                 ++failed;
+                ec = ret.error();
             }
         }
 
         // No more matching mount points
         if (failed == 0) {
-            return true;
+            return oc::success();
         }
 
         // Retry
     }
 
-    LOGE("Failed to unmount %d mount points", failed);
-    return false;
+    LOGW("Failed to unmount %d mount points", failed);
+    return ec;
 }
 
 /*!
  * \brief Mount filesystem
  *
- * This function takes the same arguments as mount(2), but returns true on
- * success and false on failure.
+ * This function takes the same arguments as mount(2), but returns nothing on
+ * success and the error on failure.
  *
  * If MS_BIND is not specified in \a mount_flags and \a source is not a block
  * device, then the file will be attached to a loop device and the the loop
@@ -200,12 +247,13 @@ bool unmount_all(const std::string &dir)
  * \param mount_flags See man mount(2)
  * \param data See man mount(2)
  *
- * \return True if mount(2) is successful. False if mount(2) is unsuccessful
- *         or loopdev could not be created or associated with the source path.
+ * \return Nothing if mount(2) is successful. The error code if mount(2) is
+ *         unsuccessful or the loopdev could not be created or be associated
+ *         with the source path.
  */
-bool mount(const std::string &source, const std::string &target,
-           const std::string &fstype, unsigned long mount_flags,
-           const std::string &data)
+oc::result<void> mount(const std::string &source, const std::string &target,
+                       const std::string &fstype, unsigned long mount_flags,
+                       const std::string &data)
 {
     bool need_loopdev = false;
     struct stat sb;
@@ -218,84 +266,77 @@ bool mount(const std::string &source, const std::string &target,
             }
             if (fstype == "auto"
                     && (S_ISREG(sb.st_mode) || S_ISBLK(sb.st_mode))) {
-                std::optional<std::string> detected;
-                if (!blkid_get_fs_type(source, detected) || !detected) {
-                    return false;
-                } else if (*detected == "ext") {
+                OUTCOME_TRY(detected, blkid_get_fs_type(source));
+                if (detected.empty()) {
+                    return std::errc::invalid_argument;
+                } else if (detected == "ext") {
                     // Always assume ext4 instead of ext2, ext3, ext4dev, or jbd
                     fstype_real = "ext4";
                 } else {
-                    fstype_real.swap(*detected);
+                    fstype_real.swap(detected);
                 }
             }
         }
     }
 
     if (need_loopdev) {
-        std::string loopdev = loopdev_find_unused();
-        if (loopdev.empty()) {
-            LOGE("Failed to find unused loop device: %s", strerror(errno));
-            return false;
-        }
-
-        LOGD("Assigning %s to loop device %s", source.c_str(), loopdev.c_str());
-
-        if (!loopdev_set_up_device(
-                loopdev, source, 0, mount_flags & MS_RDONLY)) {
-            LOGE("Failed to set up loop device %s: %s",
-                 loopdev.c_str(), strerror(errno));
-            return false;
-        }
+        OUTCOME_TRY(loopdev, loopdev_find_unused());
+        OUTCOME_TRYV(loopdev_set_up_device(loopdev, source, 0,
+                                           mount_flags & MS_RDONLY));
 
         if (::mount(loopdev.c_str(), target.c_str(), fstype_real.c_str(),
                     mount_flags, data.c_str()) < 0) {
-            loopdev_remove_device(loopdev);
-            return false;
+            int saved_errno = errno;
+            (void) loopdev_remove_device(loopdev);
+            return ec_from_errno(saved_errno);
         }
-
-        return true;
     } else {
-        return ::mount(source.c_str(), target.c_str(), fstype_real.c_str(),
-                       mount_flags, data.c_str()) == 0;
+        if (::mount(source.c_str(), target.c_str(), fstype_real.c_str(),
+                    mount_flags, data.c_str()) < 0) {
+            return ec_from_errno();
+        }
     }
+
+    return oc::success();
 }
 
 /*!
  * \brief Unmount filesystem
  *
- * This function takes the same arguments as umount(2), but returns true on
- * success and false on failure.
+ * This function takes the same arguments as umount(2), but returns nothing on
+ * success and the error on failure.
  *
- * This function will /proc/mounts for the mountpoint (using an exact string
- * compare). If the source path of the mountpoint is a block device and the
- * block device is a loop device, then it will be disassociated from the
+ * This function will search /proc/mounts for the mountpoint (using an exact
+ * string compare). If the source path of the mountpoint is a block device and
+ * the block device is a loop device, then it will be disassociated from the
  * previously attached file. Note that the return value of
- * loopdev_remove_device() is ignored and this function will always return true
- * if umount(2) is successful.
+ * loopdev_remove_device() is ignored and this function will always return a
+ * success result if umount(2) is successful.
  *
- * \param target See man umount(2)
+ * \param target See `man umount(2)`
  *
- * \return True if umount(2) is successful. False if umount(2) is unsuccessful.
+ * \return Nothing if umount(2) is successful. Otherwise, the error code.
  */
-bool umount(const std::string &target)
+oc::result<void> umount(const std::string &target)
 {
     std::string source;
     std::string mnt_dir;
 
     ScopedFILE fp(std::fopen(PROC_MOUNTS, "r"), std::fclose);
     if (fp) {
-        for (MountEntry entry; get_mount_entry(fp.get(), entry);) {
-            if (entry.dir == target) {
-                source = entry.fsname;
+        while (auto entry = get_mount_entry(fp.get())) {
+            if (entry.value().dir == target) {
+                source = entry.value().fsname;
             }
         }
     } else {
         LOGW("%s: Failed to read file: %s", PROC_MOUNTS, strerror(errno));
     }
 
-    int ret = ::umount(target.c_str());
-
-    ErrorRestorer restorer;
+    oc::result<void> ret = oc::success();
+    if (::umount(target.c_str()) < 0) {
+        ret = ec_from_errno();
+    }
 
     if (!source.empty()) {
         struct stat sb;
@@ -305,37 +346,36 @@ bool umount(const std::string &target)
             // If the source path is a loop block device, then disassociate it
             // from the image
             LOGD("Clearing loop device %s", source.c_str());
-            if (!loopdev_remove_device(source)) {
-                LOGW("Failed to clear loop device: %s", strerror(errno));
+            if (auto r = loopdev_remove_device(source); !r) {
+                LOGW("Failed to clear loop device: %s",
+                     ret.error().message().c_str());
             }
         }
     }
 
-    return ret == 0;
+    return ret;
 }
 
-bool mount_get_total_size(const std::string &path, uint64_t &size)
+oc::result<uint64_t> mount_get_total_size(const std::string &path)
 {
     struct statfs sfs;
 
     if (statfs(path.c_str(), &sfs) < 0) {
-        return false;
+        return ec_from_errno();
     }
 
-    size = sfs.f_bsize * sfs.f_blocks;
-    return true;
+    return sfs.f_bsize * sfs.f_blocks;
 }
 
-bool mount_get_avail_size(const std::string &path, uint64_t &size)
+oc::result<uint64_t> mount_get_avail_size(const std::string &path)
 {
     struct statfs sfs;
 
     if (statfs(path.c_str(), &sfs) < 0) {
-        return false;
+        return ec_from_errno();
     }
 
-    size = sfs.f_bsize * sfs.f_bavail;
-    return true;
+    return sfs.f_bsize * sfs.f_bavail;
 }
 
 }

--- a/libmbutil/src/mount.cpp
+++ b/libmbutil/src/mount.cpp
@@ -123,9 +123,11 @@ oc::result<MountEntry> get_mount_entry(std::FILE *fp)
 
     ssize_t n = getline(&line, &size, fp);
     if (n < 0) {
-        return ec_from_errno();
-    } else if (n == 0) {
-        return MountError::EndOfFile;
+        if (ferror(fp)) {
+            return ec_from_errno();
+        } else {
+            return MountError::EndOfFile;
+        }
     }
 
     int pos[8];

--- a/libmbutil/src/path.cpp
+++ b/libmbutil/src/path.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2017  Andrew Gunnerson <andrewgunnerson@gmail.com>
+ * Copyright (C) 2014-2018  Andrew Gunnerson <andrewgunnerson@gmail.com>
  *
  * This file is part of DualBootPatcher
  *
@@ -30,55 +30,33 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
-#include "mblog/logging.h"
+#include "mbcommon/error_code.h"
 
-#define LOG_TAG "mbutil/path"
 
 namespace mb::util
 {
 
-std::string get_cwd()
+oc::result<std::string> get_cwd()
 {
-    char *cwd = nullptr;
-
-    if (!(cwd = getcwd(nullptr, 0))) {
-        LOGE("Failed to get cwd: %s", strerror(errno));
-        return std::string();
+    std::unique_ptr<char, decltype(free) *> cwd(getcwd(nullptr, 0), &free);
+    if (!cwd) {
+        return ec_from_errno();
     }
 
-    std::string ret(cwd);
-    free(cwd);
-    return ret;
+    return cwd.get();
 }
 
-std::string dir_name(const std::string &path)
+std::string dir_name(std::string path)
 {
-    std::vector<char> buf(path.begin(), path.end());
-    buf.push_back('\0');
-
-    char *ptr = dirname(buf.data());
-    return std::string(ptr);
+    return dirname(path.data());
 }
 
-std::string base_name(const std::string &path)
+std::string base_name(std::string path)
 {
-    std::vector<char> buf(path.begin(), path.end());
-    buf.push_back('\0');
-
-    char *ptr = basename(buf.data());
-    return std::string(ptr);
+    return basename(path.data());
 }
 
-std::string real_path(const std::string &path)
-{
-    char actual_path[PATH_MAX + 1];
-    if (!realpath(path.c_str(), actual_path)) {
-        return std::string();
-    }
-    return std::string(actual_path);
-}
-
-bool read_link(const std::string &path, std::string &out)
+oc::result<std::string> read_link(const std::string &path)
 {
     std::vector<char> buf;
     ssize_t len;
@@ -88,7 +66,7 @@ bool read_link(const std::string &path, std::string &out)
     for (;;) {
         len = readlink(path.c_str(), buf.data(), buf.size() - 1);
         if (len < 0) {
-            return false;
+            return ec_from_errno();
         } else if (static_cast<size_t>(len) == buf.size() - 1) {
             buf.resize(buf.size() << 1);
         } else {
@@ -97,26 +75,7 @@ bool read_link(const std::string &path, std::string &out)
     }
 
     buf[static_cast<size_t>(len)] = '\0';
-    out.assign(buf.data());
-    return true;
-}
-
-bool inodes_equal(const std::string &path1, const std::string &path2)
-{
-    struct stat sb1;
-    struct stat sb2;
-
-    if (lstat(path1.c_str(), &sb1) < 0) {
-        LOGE("%s: Failed to stat: %s", path1.c_str(), strerror(errno));
-        return false;
-    }
-
-    if (lstat(path2.c_str(), &sb2) < 0) {
-        LOGE("%s: Failed to stat: %s", path2.c_str(), strerror(errno));
-        return false;
-    }
-
-    return sb1.st_dev == sb2.st_dev && sb1.st_ino == sb2.st_ino;
+    return buf.data();
 }
 
 /*!
@@ -133,12 +92,10 @@ bool inodes_equal(const std::string &path1, const std::string &path2)
  *
  * \return Split pieces of the path
  */
-std::vector<std::string> path_split(const std::string &path)
+std::vector<std::string> path_split(std::string path)
 {
     char *p;
     char *save_ptr;
-    std::vector<char> copy(path.begin(), path.end());
-    copy.push_back('\0');
 
     std::vector<std::string> split;
 
@@ -147,7 +104,7 @@ std::vector<std::string> path_split(const std::string &path)
         split.push_back(std::string());
     }
 
-    p = strtok_r(copy.data(), "/", &save_ptr);
+    p = strtok_r(path.data(), "/", &save_ptr);
     while (p != nullptr) {
         // Ignore useless references to '.' in the path
         if (strcmp(p, ".") != 0) {
@@ -253,20 +210,19 @@ void normalize_path(std::vector<std::string> &components)
  * \note This function does not traverse the filesystem at all. It works purely
  *       on the given path strings.
  *
- * \return True if the relative path was successfully computed. False and errno
- *         set to \a EINVAL if:
+ * \return The relative path if it was successfully computed.
+ *         std::errc::invalid_argument if:
  *         - \a path is absolute and \a start is relative or vice versa
  *         - \a path or \a start is empty
  *         - an intermediate path could not be computed
  */
-bool relative_path(const std::string &path, const std::string &start,
-                   std::string &out)
+oc::result<std::string> relative_path(const std::string &path,
+                                      const std::string &start)
 {
     if (path.empty() || start.empty()
             || (path[0] == '/' && start[0] != '/')
             || (path[0] != '/' && start[0] == '/')) {
-        errno = EINVAL;
-        return false;
+        return std::errc::invalid_argument;
     }
 
     std::vector<std::string> path_pieces(path_split(path));
@@ -286,8 +242,7 @@ bool relative_path(const std::string &path, const std::string &start,
     // Add '..' for the remaining path segments in 'start'
     for (size_t i = common; i < start_pieces.size(); ++i) {
         if (start_pieces[i] == "..") {
-            errno = EINVAL;
-            return false;
+            return std::errc::invalid_argument;
         }
         result_pieces.push_back("..");
     }
@@ -297,9 +252,7 @@ bool relative_path(const std::string &path, const std::string &start,
         result_pieces.push_back(path_pieces[i]);
     }
 
-    out = path_join(result_pieces);
-
-    return true;
+    return path_join(result_pieces);
 }
 
 /*!

--- a/libmbutil/src/result/file_op_result.cpp
+++ b/libmbutil/src/result/file_op_result.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2018  Andrew Gunnerson <andrewgunnerson@gmail.com>
+ * Copyright (C) 2018  Andrew Gunnerson <andrewgunnerson@gmail.com>
  *
  * This file is part of DualBootPatcher
  *
@@ -17,17 +17,25 @@
  * along with DualBootPatcher.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#pragma once
+#include "mbutil/result/file_op_result.h"
 
 #include <string>
-
-#include "mbcommon/outcome.h"
-
-#include "mbutil/result/file_op_result.h"
 
 namespace mb::util
 {
 
-FileOpResult<void> delete_recursive(const std::string &path);
+std::string FileOpErrorInfo::message() const
+{
+    std::string buf;
+
+    if (!path.empty()) {
+        buf += path;
+        buf += ": ";
+    }
+
+    buf += ec.message();
+
+    return buf;
+}
 
 }

--- a/libmbutil/src/socket.cpp
+++ b/libmbutil/src/socket.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2017  Andrew Gunnerson <andrewgunnerson@gmail.com>
+ * Copyright (C) 2014-2018  Andrew Gunnerson <andrewgunnerson@gmail.com>
  *
  * This file is part of DualBootPatcher
  *
@@ -27,248 +27,248 @@
 #include <sys/socket.h>
 #include <unistd.h>
 
+#include "mbcommon/error_code.h"
+
 namespace mb::util
 {
 
-ssize_t socket_read(int fd, void *buf, size_t size)
+oc::result<size_t> socket_read(int fd, void *buf, size_t size)
 {
     // read()'s behavior is undefined when size is greater than SSIZE_MAX
     if (size > SSIZE_MAX) {
-        errno = EINVAL;
-        return -1;
+        return std::errc::invalid_argument;
     }
 
-    ssize_t bytes_read = 0;
-    ssize_t n;
+    size_t bytes_read = 0;
 
-    while (bytes_read < static_cast<ssize_t>(size)) {
-        n = read(fd, static_cast<char *>(buf) + bytes_read,
-                 size - static_cast<size_t>(bytes_read));
+    while (bytes_read < size) {
+        auto n = read(fd, static_cast<char *>(buf) + bytes_read,
+                 size - bytes_read);
         if (n < 0) {
-            return n;
+            if (errno == EINTR) {
+                continue;
+            } else {
+                return ec_from_errno();
+            }
         } else if (n == 0) {
             break;
         }
 
-        bytes_read += n;
+        bytes_read += static_cast<size_t>(n);
     }
 
     return bytes_read;
 }
 
-ssize_t socket_write(int fd, const void *buf, size_t size)
+oc::result<size_t> socket_write(int fd, const void *buf, size_t size)
 {
     // write()'s behavior is implementation-defined when size is greater than
     // SSIZE_MAX
     if (size > SSIZE_MAX) {
-        errno = EINVAL;
-        return -1;
+        return std::errc::invalid_argument;
     }
 
-    ssize_t bytes_written = 0;
-    ssize_t n;
+    size_t bytes_written = 0;
 
-    while (bytes_written < static_cast<ssize_t>(size)) {
-        n = write(fd, static_cast<const char *>(buf) + bytes_written,
-                  size - static_cast<size_t>(bytes_written));
+    while (bytes_written < size) {
+        auto n = write(fd, static_cast<const char *>(buf) + bytes_written,
+                  size - bytes_written);
         if (n < 0) {
-            return n;
+            if (errno == EINTR) {
+                continue;
+            } else {
+                return ec_from_errno();
+            }
         } else if (n == 0) {
             break;
         }
 
-        bytes_written += n;
+        bytes_written += static_cast<size_t>(n);
     }
 
     return bytes_written;
 }
 
-bool socket_read_bytes(int fd, std::vector<uint8_t> &result)
+oc::result<std::vector<unsigned char>> socket_read_bytes(int fd)
 {
-    int32_t len;
-    if (!socket_read_int32(fd, len)) {
-        return false;
-    }
-
+    OUTCOME_TRY(len, socket_read_int32(fd));
     if (len < 0) {
-        return false;
+        return std::errc::bad_message;
     }
 
-    std::vector<uint8_t> buf(static_cast<size_t>(len));
+    std::vector<unsigned char> buf(static_cast<size_t>(len));
 
-    if (socket_read(fd, buf.data(), static_cast<size_t>(len))
-            != static_cast<ssize_t>(len)) {
-        return false;
+    OUTCOME_TRY(n, socket_read(fd, buf.data(), static_cast<size_t>(len)));
+    if (n != static_cast<size_t>(len)) {
+        return std::errc::io_error;
     }
 
-    result.swap(buf);
-    return true;
+    return std::move(buf);
 }
 
-bool socket_write_bytes(int fd, const uint8_t *data, size_t len)
+oc::result<void> socket_write_bytes(int fd, const void *data, size_t len)
 {
-    if (!socket_write_int32(fd, static_cast<int32_t>(len))) {
-        return false;
+    if (len > INT32_MAX) {
+        return std::errc::invalid_argument;
     }
 
-    if (socket_write(fd, data, len) != static_cast<ssize_t>(len)) {
-        return false;
+    OUTCOME_TRYV(socket_write_int32(fd, static_cast<int32_t>(len)));
+    OUTCOME_TRY(n, socket_write(fd, data, len));
+    if (n != len) {
+        return std::errc::io_error;
     }
 
-    return true;
+    return oc::success();
 }
 
 template<typename T>
-static inline bool read_copyable_type(int fd, T &result)
+static inline oc::result<T> read_copyable_type(int fd)
 {
     T buf;
-    if (socket_read(fd, &buf, sizeof(T)) != sizeof(T)) {
-        return false;
+    OUTCOME_TRY(size, socket_read(fd, &buf, sizeof(T)));
+    if (size != sizeof(T)) {
+        return std::errc::io_error;
     }
-    result = buf;
-    return true;
+    return oc::success(buf);
 }
 
 template<typename T>
-static inline bool write_copyable_type(int fd, T value)
+static inline oc::result<void> write_copyable_type(int fd, T value)
 {
-    return socket_write(fd, &value, sizeof(T)) == sizeof(T);
-}
-
-bool socket_read_uint16(int fd, uint16_t &result)
-{
-    return read_copyable_type(fd, result);
-}
-
-bool socket_write_uint16(int fd, uint16_t n)
-{
-    return write_copyable_type(fd, n);
-}
-
-bool socket_read_uint32(int fd, uint32_t &result)
-{
-    return read_copyable_type(fd, result);
-}
-
-bool socket_write_uint32(int fd, uint32_t n)
-{
-    return write_copyable_type(fd, n);
-}
-
-bool socket_read_uint64(int fd, uint64_t &result)
-{
-    return read_copyable_type(fd, result);
-}
-
-bool socket_write_uint64(int fd, uint64_t n)
-{
-    return write_copyable_type(fd, n);
-}
-
-bool socket_read_int16(int fd, int16_t &result)
-{
-    return read_copyable_type(fd, result);
-}
-
-bool socket_write_int16(int fd, int16_t n)
-{
-    return write_copyable_type(fd, n);
-}
-
-bool socket_read_int32(int fd, int32_t &result)
-{
-    return read_copyable_type(fd, result);
-}
-
-bool socket_write_int32(int fd, int32_t n)
-{
-    return write_copyable_type(fd, n);
-}
-
-bool socket_read_int64(int fd, int64_t &result)
-{
-    return read_copyable_type(fd, result);
-}
-
-bool socket_write_int64(int fd, int64_t n)
-{
-    return write_copyable_type(fd, n);
-}
-
-bool socket_read_string(int fd, std::string &result)
-{
-    int32_t len;
-    if (!socket_read_int32(fd, len)) {
-        return false;
+    OUTCOME_TRY(size, socket_write(fd, &value, sizeof(T)));
+    if (size != sizeof(T)) {
+        return std::errc::io_error;
     }
+    return oc::success();
+}
 
+oc::result<uint16_t> socket_read_uint16(int fd)
+{
+    return read_copyable_type<uint16_t>(fd);
+}
+
+oc::result<void> socket_write_uint16(int fd, uint16_t n)
+{
+    return write_copyable_type(fd, n);
+}
+
+oc::result<uint32_t> socket_read_uint32(int fd)
+{
+    return read_copyable_type<uint32_t>(fd);
+}
+
+oc::result<void> socket_write_uint32(int fd, uint32_t n)
+{
+    return write_copyable_type(fd, n);
+}
+
+oc::result<uint64_t> socket_read_uint64(int fd)
+{
+    return read_copyable_type<uint64_t>(fd);
+}
+
+oc::result<void> socket_write_uint64(int fd, uint64_t n)
+{
+    return write_copyable_type(fd, n);
+}
+
+oc::result<int16_t> socket_read_int16(int fd)
+{
+    return read_copyable_type<int16_t>(fd);
+}
+
+oc::result<void> socket_write_int16(int fd, int16_t n)
+{
+    return write_copyable_type(fd, n);
+}
+
+oc::result<int32_t> socket_read_int32(int fd)
+{
+    return read_copyable_type<int32_t>(fd);
+}
+
+oc::result<void> socket_write_int32(int fd, int32_t n)
+{
+    return write_copyable_type(fd, n);
+}
+
+oc::result<int64_t> socket_read_int64(int fd)
+{
+    return read_copyable_type<int64_t>(fd);
+}
+
+oc::result<void> socket_write_int64(int fd, int64_t n)
+{
+    return write_copyable_type(fd, n);
+}
+
+oc::result<std::string> socket_read_string(int fd)
+{
+    OUTCOME_TRY(len, socket_read_int32(fd));
     if (len < 0) {
-        return false;
+        return std::errc::bad_message;
     }
 
-    std::vector<char> buf(static_cast<size_t>(len));
+    std::string buf;
+    buf.resize(static_cast<size_t>(len));
 
-    if (socket_read(fd, buf.data(), static_cast<size_t>(len))
-            != static_cast<ssize_t>(len)) {
-        return false;
+    OUTCOME_TRY(n, socket_read(fd, buf.data(), static_cast<size_t>(len)));
+    if (n != static_cast<size_t>(len)) {
+        return std::errc::io_error;
     }
 
-    result.assign(buf.begin(), buf.end());
-    return true;
+    return std::move(buf);
 }
 
-bool socket_write_string(int fd, const std::string &str)
+oc::result<void> socket_write_string(int fd, const std::string &str)
 {
-    if (!socket_write_int32(fd, static_cast<int32_t>(str.size()))) {
-        return false;
+    if (str.size() > INT32_MAX) {
+        return std::errc::invalid_argument;
     }
 
-    if (socket_write(fd, str.data(), str.size())
-            != static_cast<ssize_t>(str.size())) {
-        return false;
+    OUTCOME_TRYV(socket_write_int32(fd, static_cast<int32_t>(str.size())));
+    OUTCOME_TRY(n, socket_write(fd, str.data(), str.size()));
+    if (n != str.size()) {
+        return std::errc::io_error;
     }
 
-    return true;
+    return oc::success();
 }
 
-bool socket_read_string_array(int fd, std::vector<std::string> &result)
+oc::result<std::vector<std::string>> socket_read_string_array(int fd)
 {
-    int32_t len;
-    if (!socket_read_int32(fd, len)) {
-        return false;
-    }
-
+    OUTCOME_TRY(len, socket_read_int32(fd));
     if (len < 0) {
-        return false;
+        return std::errc::bad_message;
     }
 
-    std::vector<std::string> buf(static_cast<size_t>(len));
+    std::vector<std::string> buf;
+    buf.reserve(static_cast<size_t>(len));
+
     for (int32_t i = 0; i < len; ++i) {
-        if (!socket_read_string(fd, buf[static_cast<size_t>(i)])) {
-            return false;
-        }
+        OUTCOME_TRY(str, socket_read_string(fd));
+        buf.push_back(std::move(str));
     }
 
-    result.swap(buf);
-    return true;
+    return std::move(buf);
 }
 
-bool socket_write_string_array(int fd, const std::vector<std::string> &list)
+oc::result<void> socket_write_string_array(int fd, const std::vector<std::string> &list)
 {
-    if (!socket_write_int32(fd, static_cast<int32_t>(list.size()))) {
-        return false;
+    if (list.size() > INT32_MAX) {
+        return std::errc::invalid_argument;
     }
+
+    OUTCOME_TRYV(socket_write_int32(fd, static_cast<int32_t>(list.size())));
 
     for (const std::string &str : list) {
-        if (!socket_write_string(fd, str)) {
-            return false;
-        }
+        OUTCOME_TRYV(socket_write_string(fd, str));
     }
 
-    return true;
+    return oc::success();
 }
 
-bool socket_receive_fds(int fd, std::vector<int> &fds)
+oc::result<void> socket_receive_fds(int fd, std::vector<int> &fds)
 {
     char dummy;
 
@@ -276,8 +276,8 @@ bool socket_receive_fds(int fd, std::vector<int> &fds)
     iov.iov_base = &dummy;
     iov.iov_len = 1;
 
-    std::size_t n_fds = fds.size();
-    std::vector<char> control(sizeof(struct cmsghdr) + sizeof(int) * n_fds);
+    std::vector<char> control(
+            sizeof(struct cmsghdr) + sizeof(int) * fds.size());
 
     struct msghdr msg;
     msg.msg_name = nullptr;
@@ -294,58 +294,62 @@ bool socket_receive_fds(int fd, std::vector<int> &fds)
     cmsg->cmsg_type = SCM_RIGHTS;
 
     if (recvmsg(fd, &msg, 0) < 0) {
-        return false;
+        return ec_from_errno();
     }
 
     int *data = reinterpret_cast<int *>(CMSG_DATA(cmsg));
-    n_fds = (cmsg->cmsg_len - sizeof(struct cmsghdr)) / sizeof(int);
+    std::size_t n_fds = (cmsg->cmsg_len - sizeof(struct cmsghdr)) / sizeof(int);
     if (n_fds != fds.size()) {
         // Did not receive correct amount of file descriptors
-        return false;
+        return std::errc::bad_message;
     }
 
     for (std::size_t i = 0; i < n_fds; ++i) {
         fds[i] = data[i];
     }
 
-    return true;
+    return oc::success();
 }
 
-bool socket_send_fds(int fd, const std::vector<int> &fds)
+oc::result<void> socket_send_fds(int fd, const std::vector<int> &fds)
 {
-    std::size_t n_fds = fds.size();
-    if (n_fds > 0) {
-        char dummy = '!';
-
-        struct iovec iov;
-        iov.iov_base = &dummy;
-        iov.iov_len = 1;
-
-        std::vector<char> control(sizeof(struct cmsghdr) + sizeof(int) * n_fds);
-
-        struct msghdr msg;
-        msg.msg_name = nullptr;
-        msg.msg_namelen = 0;
-        msg.msg_iov = &iov;
-        msg.msg_iovlen = 1;
-        msg.msg_flags = 0;
-        msg.msg_control = control.data();
-        msg.msg_controllen = control.size();
-
-        struct cmsghdr *cmsg = CMSG_FIRSTHDR(&msg);
-        cmsg->cmsg_len = msg.msg_controllen;
-        cmsg->cmsg_level = SOL_SOCKET;
-        cmsg->cmsg_type = SCM_RIGHTS;
-
-        int *data = reinterpret_cast<int *>(CMSG_DATA(cmsg));
-        for (std::size_t i = 0; i < n_fds; ++i) {
-            data[i] = fds[i];
-        }
-
-        return sendmsg(fd, &msg, 0) >= 0;
+    if (fds.empty()) {
+        return std::errc::invalid_argument;
     }
 
-    return false;
+    char dummy = '!';
+
+    struct iovec iov;
+    iov.iov_base = &dummy;
+    iov.iov_len = 1;
+
+    std::vector<char> control(
+            sizeof(struct cmsghdr) + sizeof(int) * fds.size());
+
+    struct msghdr msg;
+    msg.msg_name = nullptr;
+    msg.msg_namelen = 0;
+    msg.msg_iov = &iov;
+    msg.msg_iovlen = 1;
+    msg.msg_flags = 0;
+    msg.msg_control = control.data();
+    msg.msg_controllen = control.size();
+
+    struct cmsghdr *cmsg = CMSG_FIRSTHDR(&msg);
+    cmsg->cmsg_len = msg.msg_controllen;
+    cmsg->cmsg_level = SOL_SOCKET;
+    cmsg->cmsg_type = SCM_RIGHTS;
+
+    int *data = reinterpret_cast<int *>(CMSG_DATA(cmsg));
+    for (std::size_t i = 0; i < fds.size(); ++i) {
+        data[i] = fds[i];
+    }
+
+    if (sendmsg(fd, &msg, 0) < 0) {
+        return ec_from_errno();
+    }
+
+    return oc::success();
 }
 
 }

--- a/libmbutil/src/string.cpp
+++ b/libmbutil/src/string.cpp
@@ -59,17 +59,14 @@ void replace_all(std::string &source,
     replace_internal(source, from, to, false);
 }
 
-std::vector<std::string> tokenize(const std::string &str,
-                                  const std::string &delims)
+std::vector<std::string> tokenize(std::string str, const std::string &delims)
 {
-    std::vector<char> linebuf(str.begin(), str.end());
-    linebuf.resize(linebuf.size() + 1);
     std::vector<std::string> tokens;
 
     char *temp;
     char *token;
 
-    token = strtok_r(linebuf.data(), delims.c_str(), &temp);
+    token = strtok_r(str.data(), delims.c_str(), &temp);
     while (token != nullptr) {
         tokens.emplace_back(token);
 

--- a/libmbutil/src/vibrate.cpp
+++ b/libmbutil/src/vibrate.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015  Andrew Gunnerson <andrewgunnerson@gmail.com>
+ * Copyright (C) 2015-2018  Andrew Gunnerson <andrewgunnerson@gmail.com>
  *
  * This file is part of DualBootPatcher
  *
@@ -19,50 +19,69 @@
 
 #include "mbutil/vibrate.h"
 
-#include <cerrno>
 #include <cstdio>
 #include <cstring>
 
 #include <fcntl.h>
 #include <unistd.h>
 
+#include "mbcommon/error_code.h"
 #include "mbcommon/finally.h"
-#include "mblog/logging.h"
 
-#define LOG_TAG "mbutil/vibrate"
 
-#define VIBRATOR_PATH           "/sys/class/timed_output/vibrator/enable"
+using namespace std::chrono;
+using namespace std::chrono_literals;
 
 namespace mb::util
 {
 
-bool vibrate(unsigned int timeout_ms, unsigned int additional_wait_ms)
+static constexpr char VIBRATOR_PATH[] =
+    "/sys/class/timed_output/vibrator/enable";
+
+/**
+ * \brief Vibrate and optionally wait
+ *
+ * \param timeout Vibration duration
+ * \param wait Duration to sleep (unrelated to \p timeout)
+ *
+ * \return Nothing if successful. Otherwise, the error.
+ */
+oc::result<void> vibrate(milliseconds timeout, milliseconds wait)
 {
     int fd = open(VIBRATOR_PATH, O_WRONLY);
     if (fd < 0) {
-        LOGW("%s: Failed to open: %s", VIBRATOR_PATH, strerror(errno));
-        return false;
+        return ec_from_errno();
     }
     auto close_fd = finally([&]{
         close(fd);
     });
 
-    if (timeout_ms > 2000) {
-        timeout_ms = 2000;
+    if (timeout > 2s) {
+        timeout = 2s;
     }
 
-    char buf[20];
-    int size = snprintf(buf, sizeof(buf), "%u", timeout_ms);
-    if (write(fd, buf, static_cast<size_t>(size)) < 0) {
-        LOGW("%s: Failed to write: %s", VIBRATOR_PATH, strerror(errno));
-        return false;
+    if (dprintf(fd,  "%u", static_cast<unsigned int>(timeout.count())) < 0) {
+        return ec_from_errno();
     }
 
-    usleep(1000 * (timeout_ms + additional_wait_ms));
+    if (wait.count()) {
+        timespec ts, rem;
+        ts.tv_sec = static_cast<time_t>(duration_cast<seconds>(wait).count());
+        ts.tv_nsec = static_cast<long>(duration_cast<nanoseconds>(
+                wait - seconds(ts.tv_sec)).count());
 
-    LOGD("Vibrated for %u ms and waited an additional %u ms",
-         timeout_ms, additional_wait_ms);
-    return true;
+        while (true) {
+            if (nanosleep(&ts, &rem) == 0) {
+                break;
+            } else if (errno == EINTR) {
+                ts = rem;
+            } else {
+                return ec_from_errno();
+            }
+        }
+    }
+
+    return oc::success();
 }
 
 }

--- a/mbbootui/data.cpp
+++ b/mbbootui/data.cpp
@@ -621,7 +621,7 @@ int DataManager::GetMagicValue(const std::string& varName, std::string& value)
 void DataManager::ReadSettingsFile()
 {
 #ifndef TW_OEM_BUILD
-    mb::util::mkdir_parent(tw_settings_path, 0700);
+    (void) mb::util::mkdir_parent(tw_settings_path, 0700);
 
     LOGI("Attempt to load settings from settings file...");
     LoadValues(tw_settings_path);

--- a/mbbootui/data.cpp
+++ b/mbbootui/data.cpp
@@ -536,12 +536,16 @@ int DataManager::GetMagicValue(const std::string& varName, std::string& value)
             auto const &cpu_temp_path = tw_device.tw_cpu_temp_path();
             if (!cpu_temp_path.empty()) {
                 cpu_temp_file = cpu_temp_path;
-                if (!mb::util::file_first_line(cpu_temp_file, results)) {
+                if (auto r = mb::util::file_first_line(cpu_temp_file)) {
+                    results = std::move(r.value());
+                } else {
                     return -1;
                 }
             } else {
                 cpu_temp_file = "/sys/class/thermal/thermal_zone0/temp";
-                if (!mb::util::file_first_line(cpu_temp_file, results)) {
+                if (auto r = mb::util::file_first_line(cpu_temp_file)) {
+                    results = std::move(r.value());
+                } else {
                     return -1;
                 }
             }

--- a/mbbootui/data.cpp
+++ b/mbbootui/data.cpp
@@ -29,6 +29,7 @@
 #include "mbutil/directory.h"
 #include "mbutil/file.h"
 #include "mbutil/path.h"
+#include "mbutil/vibrate.h"
 
 #include "config/config.hpp"
 #include "gui/blanktimer.hpp"
@@ -627,9 +628,11 @@ void DataManager::ReadSettingsFile()
 
 void DataManager::Vibrate(const std::string& varName)
 {
+    using namespace std::chrono_literals;
+
     int vib_value = 0;
     GetValue(varName, vib_value);
     if (vib_value) {
-        vibrate(vib_value);
+        (void) mb::util::vibrate(std::chrono::milliseconds(vib_value), 0ms);
     }
 }

--- a/mbbootui/gui/action.cpp
+++ b/mbbootui/gui/action.cpp
@@ -765,7 +765,7 @@ int GUIAction::switch_rom(const std::string& arg)
         if (ret == 0) {
             // Skip boot menu for next boot
             static const char *skip_path = "/raw/cache/multiboot/bootui/skip";
-            mb::util::mkdir_parent(skip_path, 0755);
+            (void) mb::util::mkdir_parent(skip_path, 0755);
             (void) mb::util::file_write_data(skip_path, arg.data(), arg.size());
         }
 

--- a/mbbootui/gui/action.cpp
+++ b/mbbootui/gui/action.cpp
@@ -766,7 +766,7 @@ int GUIAction::switch_rom(const std::string& arg)
             // Skip boot menu for next boot
             static const char *skip_path = "/raw/cache/multiboot/bootui/skip";
             mb::util::mkdir_parent(skip_path, 0755);
-            mb::util::file_write_data(skip_path, arg.data(), arg.size());
+            (void) mb::util::file_write_data(skip_path, arg.data(), arg.size());
         }
 
         // Reboot when exiting

--- a/mbbootui/gui/pages.cpp
+++ b/mbbootui/gui/pages.cpp
@@ -1290,7 +1290,7 @@ void PageManager::LoadLanguageList(ZipArchive* package)
         mb::util::delete_recursive(TWFunc::get_resource_path("customlanguages"));
     }
     if (package) {
-        mb::util::mkdir_recursive(TWFunc::get_resource_path("customlanguages"), 0700);
+        (void) mb::util::mkdir_recursive(TWFunc::get_resource_path("customlanguages"), 0700);
         struct utimbuf timestamp = { 1217592000, 1217592000 };  // 8/1/2008 default
 #ifdef HAVE_SELINUX
         mzExtractRecursive(package, "languages", TWFunc::get_resource_path("customlanguages/").c_str(), &timestamp, nullptr, nullptr, nullptr);

--- a/mbbootui/gui/pages.cpp
+++ b/mbbootui/gui/pages.cpp
@@ -1287,7 +1287,7 @@ void PageManager::LoadLanguageList(ZipArchive* package)
 {
     Language_List.clear();
     if (mb::util::path_exists(TWFunc::get_resource_path("customlanguages"), false)) {
-        mb::util::delete_recursive(TWFunc::get_resource_path("customlanguages"));
+        (void) mb::util::delete_recursive(TWFunc::get_resource_path("customlanguages"));
     }
     if (package) {
         (void) mb::util::mkdir_recursive(TWFunc::get_resource_path("customlanguages"), 0700);

--- a/mbbootui/main.cpp
+++ b/mbbootui/main.cpp
@@ -103,7 +103,7 @@ static bool redirect_output_to_file(const char *path, mode_t mode)
 
 static bool detect_device()
 {
-    auto contents = mb::util::file_read_all_v(DEVICE_JSON_PATH);
+    auto contents = mb::util::file_read_all(DEVICE_JSON_PATH);
     if (!contents) {
         LOGE("%s: Failed to read file: %s", DEVICE_JSON_PATH,
              contents.error().message().c_str());

--- a/mbbootui/main.cpp
+++ b/mbbootui/main.cpp
@@ -396,9 +396,9 @@ int main(int argc, char *argv[])
 
     umask(0);
 
-    if (!mb::util::mkdir_recursive(MBBOOTUI_BASE_PATH, 0755)) {
+    if (auto r = mb::util::mkdir_recursive(MBBOOTUI_BASE_PATH, 0755); !r) {
         LOGE("%s: Failed to create directory: %s",
-             MBBOOTUI_BASE_PATH, strerror(errno));
+             MBBOOTUI_BASE_PATH, r.error().message().c_str());
         return EXIT_FAILURE;
     }
 

--- a/mbbootui/main.cpp
+++ b/mbbootui/main.cpp
@@ -103,16 +103,17 @@ static bool redirect_output_to_file(const char *path, mode_t mode)
 
 static bool detect_device()
 {
-    std::vector<unsigned char> contents;
-    if (!mb::util::file_read_all(DEVICE_JSON_PATH, contents)) {
-        LOGE("%s: Failed to read file: %s", DEVICE_JSON_PATH, strerror(errno));
+    auto contents = mb::util::file_read_all_v(DEVICE_JSON_PATH);
+    if (!contents) {
+        LOGE("%s: Failed to read file: %s", DEVICE_JSON_PATH,
+             contents.error().message().c_str());
         return false;
     }
-    contents.push_back('\0');
+    contents.value().push_back('\0');
 
     JsonError error;
 
-    if (!device_from_json(reinterpret_cast<char *>(contents.data()),
+    if (!device_from_json(reinterpret_cast<char *>(contents.value().data()),
                           tw_device, error)) {
         LOGE("%s: Failed to load device", DEVICE_JSON_PATH);
         return false;

--- a/mbbootui/minuitwrp/CMakeLists.txt
+++ b/mbbootui/minuitwrp/CMakeLists.txt
@@ -49,6 +49,7 @@ target_link_libraries(
     PRIVATE
     interface.global.CXXVersion
     mbbootui-config
+    mbutil-static
     AndroidSystemCore::Cutils
     Freetype::Freetype
     PNG::PNG

--- a/mbbootui/minuitwrp/events.cpp
+++ b/mbbootui/minuitwrp/events.cpp
@@ -31,12 +31,13 @@
 #include "config/config.hpp"
 #include "minui.h"
 
+#include "mbutil/vibrate.h"
+
 //#define _EVENT_LOGGING
 
 #define MAX_DEVICES         32
 
-#define VIBRATOR_TIMEOUT_FILE "/sys/class/timed_output/vibrator/enable"
-#define VIBRATOR_TIME_MS    50
+#define VIBRATOR_TIME       50ms
 
 #ifndef SYN_REPORT
 #define SYN_REPORT          0x00
@@ -63,6 +64,8 @@
 #define ABS_MT_TRACKING_ID  0x39
 #define ABS_MT_PRESSURE     0x3a
 #define ABS_MT_DISTANCE     0x3b
+
+using namespace std::chrono_literals;
 
 enum
 {
@@ -110,32 +113,6 @@ static int has_mouse = 0;
 static inline int ABS(int x)
 {
     return x < 0 ? -x : x;
-}
-
-int vibrate(int timeout_ms)
-{
-    char str[20];
-    int fd;
-    int ret;
-
-    if (timeout_ms > 10000) {
-        timeout_ms = 1000;
-    }
-
-    fd = open(VIBRATOR_TIMEOUT_FILE, O_WRONLY);
-    if (fd < 0) {
-        return -1;
-    }
-
-    ret = snprintf(str, sizeof(str), "%d", timeout_ms);
-    ret = write(fd, str, ret);
-    close(fd);
-
-    if (ret < 0) {
-       return -1;
-    }
-
-    return 0;
 }
 
 /* Returns empty tokens */
@@ -735,7 +712,7 @@ static int vk_modify(struct ev *e, struct input_event *ev)
 
                 last_virt_key = e->vks[i].scancode;
 
-                vibrate(VIBRATOR_TIME_MS);
+                (void) mb::util::vibrate(VIBRATOR_TIME, 0ms);
 
                 // Mark that all further movement until lift is discard,
                 // and make sure we don't come back into this area

--- a/mbbootui/minuitwrp/minui.h
+++ b/mbbootui/minuitwrp/minui.h
@@ -96,8 +96,6 @@ int res_create_surface(const char* name, gr_surface* pSurface);
 void res_free_surface(gr_surface surface);
 int res_scale_surface(gr_surface source, gr_surface* destination, float scale_w, float scale_h);
 
-int vibrate(int timeout_ms);
-
 #ifdef __cplusplus
 }
 #endif

--- a/mbbootui/twrp-functions.cpp
+++ b/mbbootui/twrp-functions.cpp
@@ -89,11 +89,10 @@ void TWFunc::Fixup_Time_On_Boot()
 
         struct timespec ts;
         uint64_t offset = 0;
-        std::string offset_str;
         std::string sepoch = "/sys/class/rtc/rtc0/since_epoch";
 
-        if (mb::util::file_first_line(sepoch, offset_str)
-                && convertToUint64(offset_str.c_str(), &offset)) {
+        if (auto r = mb::util::file_first_line(sepoch);
+                r && convertToUint64(r.value().c_str(), &offset)) {
             LOGI("TWFunc::Fixup_Time: Setting time offset from file %s", sepoch.c_str());
 
             ts.tv_sec = offset;
@@ -108,7 +107,8 @@ void TWFunc::Fixup_Time_On_Boot()
                 return;
             }
         } else {
-            LOGI("TWFunc::Fixup_Time: opening %s failed", sepoch.c_str());
+            LOGI("TWFunc::Fixup_Time: opening %s failed: %s",
+                 sepoch.c_str(), r.error().message().c_str());
         }
 
         LOGI("TWFunc::Fixup_Time: will attempt to use the ats files now.");
@@ -208,7 +208,7 @@ int TWFunc::Set_Brightness(std::string brightness_value)
         if (!secondary_brightness_file.empty()) {
             LOGI("Setting secondary brightness control to %s",
                  brightness_value.c_str());
-            mb::util::file_write_data(
+            (void) mb::util::file_write_data(
                     secondary_brightness_file,
                     brightness_value.data(), brightness_value.size());
         }

--- a/mbtool/appsync.cpp
+++ b/mbtool/appsync.cpp
@@ -755,8 +755,11 @@ static bool proxy_process(int fd, bool can_appsync)
         // NOTE: We'll effectively make the connection sychronous because we
         //       always wait for a reply before receiving the next command.
         // See: https://github.com/CyanogenMod/android_frameworks_native/commit/8124b181d4b5a3a44796fdb0e3ea4e4171f102c7
-        bool is_async = util::file_find_one_of(
-                INSTALLD_PATH, { "failed to read transaction id" });
+        bool is_async = false;
+        if (auto r = util::file_find_one_of(INSTALLD_PATH,
+                { "failed to read transaction id" }); r && r.value()) {
+            is_async = true;
+        }
         LOGD("installd is CyanogenMod async version: %d", is_async);
 
         LOGD("---");

--- a/mbtool/appsync.cpp
+++ b/mbtool/appsync.cpp
@@ -922,7 +922,8 @@ int appsync_main(int argc, char *argv[])
     }
 
 
-    if (!util::mkdir_parent(MULTIBOOT_LOG_APPSYNC, 0775) && errno != EEXIST) {
+    if (auto r = util::mkdir_parent(MULTIBOOT_LOG_APPSYNC, 0775);
+            !r && r.error() != std::errc::file_exists) {
         fprintf(stderr, "Failed to create parent directory of %s: %s\n",
                 MULTIBOOT_LOG_APPSYNC, strerror(errno));
         return EXIT_FAILURE;

--- a/mbtool/appsync.cpp
+++ b/mbtool/appsync.cpp
@@ -289,7 +289,7 @@ static int create_new_socket()
 
     chown(addr.sun_path, INSTALLD_SOCKET_UID, INSTALLD_SOCKET_GID);
     chmod(addr.sun_path, INSTALLD_SOCKET_PERMS);
-    util::selinux_set_context(addr.sun_path, INSTALLD_SOCKET_CONTEXT);
+    (void) util::selinux_set_context(addr.sun_path, INSTALLD_SOCKET_CONTEXT);
 
     // Make sure close-on-exec is cleared to the fd remains open across execve()
     fcntl(fd, F_SETFD, 0);

--- a/mbtool/appsyncmanager.cpp
+++ b/mbtool/appsyncmanager.cpp
@@ -58,7 +58,7 @@ public:
 
     Actions on_changed_path() override
     {
-        util::chown(_curr->fts_accpath, "system", "system", 0);
+        (void) util::chown(_curr->fts_accpath, "system", "system", 0);
         return Action::Ok;
     }
 
@@ -124,9 +124,10 @@ bool AppSyncManager::create_shared_data_directory(const std::string &pkg, uid_t 
         return false;
     }
 
-    if (!util::chown(data_path, uid, uid, util::ChownFlag::Recursive)) {
+    if (auto r = util::chown(
+            data_path, uid, uid, util::ChownFlag::Recursive); !r) {
         LOGW("[%s] %s: Failed to chown: %s",
-             pkg.c_str(), data_path.c_str(), strerror(errno));
+             pkg.c_str(), data_path.c_str(), r.error().message().c_str());
         return false;
     }
 
@@ -164,9 +165,9 @@ bool AppSyncManager::mount_shared_directory(const std::string &pkg, uid_t uid)
              pkg.c_str(), target.c_str(), r.error().message().c_str());
         return false;
     }
-    if (!util::chown(target, uid, uid, util::ChownFlag::Recursive)) {
+    if (auto r = util::chown(target, uid, uid, util::ChownFlag::Recursive); !r) {
         LOGW("[%s] %s: Failed to chown: %s",
-             pkg.c_str(), target.c_str(), strerror(errno));
+             pkg.c_str(), target.c_str(), r.error().message().c_str());
         return false;
     }
 

--- a/mbtool/backup.cpp
+++ b/mbtool/backup.cpp
@@ -328,7 +328,9 @@ static Result backup_boot_image(const std::shared_ptr<Rom> &rom,
     struct stat sb;
     if (stat(boot_image_path.c_str(), &sb) == 0) {
         LOGI("=== Backing up %s ===", boot_image_path.c_str());
-        if (!util::copy_file(boot_image_path, boot_image_backup, 0)) {
+        if (auto r = util::copy_file(
+                boot_image_path, boot_image_backup, 0); !r) {
+            LOGE("%s", r.error().message().c_str());
             return Result::Failed;
         }
     } else {
@@ -408,7 +410,8 @@ static Result backup_configs(const std::shared_ptr<Rom> &rom,
     struct stat sb;
     if (stat(config_path.c_str(), &sb) == 0) {
         LOGI("=== Backing up %s ===", config_path.c_str());
-        if (!util::copy_file(config_path, config_backup, 0)) {
+        if (auto r = util::copy_file(config_path, config_backup, 0); !r) {
+            LOGE("%s", r.error().message().c_str());
             return Result::Failed;
         }
     } else {
@@ -417,7 +420,8 @@ static Result backup_configs(const std::shared_ptr<Rom> &rom,
     }
     if (stat(thumbnail_path.c_str(), &sb) == 0) {
         LOGI("=== Backing up %s ===", thumbnail_path.c_str());
-        if (!util::copy_file(thumbnail_path, thumbnail_backup, 0)) {
+        if (auto r = util::copy_file(thumbnail_path, thumbnail_backup, 0); !r) {
+            LOGE("%s", r.error().message().c_str());
             return Result::Failed;
         }
     } else {
@@ -456,7 +460,8 @@ static Result restore_configs(const std::shared_ptr<Rom> &rom,
     struct stat sb;
     if (stat(config_backup.c_str(), &sb) == 0) {
         LOGI("=== Restoring to %s ===", config_path.c_str());
-        if (!util::copy_file(config_backup, config_path, 0)) {
+        if (auto r = util::copy_file(config_backup, config_path, 0); !r) {
+            LOGE("%s", r.error().message().c_str());
             return Result::Failed;
         }
     } else {
@@ -465,7 +470,8 @@ static Result restore_configs(const std::shared_ptr<Rom> &rom,
     }
     if (stat(thumbnail_backup.c_str(), &sb) == 0) {
         LOGI("=== Restoring to %s ===", thumbnail_path.c_str());
-        if (!util::copy_file(thumbnail_backup, thumbnail_path, 0)) {
+        if (auto r = util::copy_file(thumbnail_backup, thumbnail_path, 0); !r) {
+            LOGE("%s", r.error().message().c_str());
             return Result::Failed;
         }
     } else {

--- a/mbtool/backup.cpp
+++ b/mbtool/backup.cpp
@@ -819,10 +819,9 @@ static void warn_selinux_context()
     // the daemon will guarantee that we run in that context. We'll just warn if
     // this happens to not be the case (eg. debugging via command line).
 
-    std::string context;
-    if (util::selinux_get_process_attr(
-            0, util::SELinuxAttr::Current, context)
-            && context != MB_EXEC_CONTEXT) {
+    auto context = util::selinux_get_process_attr(
+            0, util::SELinuxAttr::Current);
+    if (context && context.value() != MB_EXEC_CONTEXT) {
         fprintf(stderr, "WARNING: Not running under %s context\n",
                 MB_EXEC_CONTEXT);
     }

--- a/mbtool/backup.cpp
+++ b/mbtool/backup.cpp
@@ -223,7 +223,8 @@ static bool backup_image(const std::string &output_file,
                          const std::vector<std::string> &exclusions,
                          util::CompressionType compression)
 {
-    if (!util::mkdir_recursive(BACKUP_MNT_DIR, 0755) && errno != EEXIST) {
+    if (auto r = util::mkdir_recursive(BACKUP_MNT_DIR, 0755);
+            !r && r.error() != std::errc::file_exists) {
         LOGE("%s: Failed to create directory: %s",
              BACKUP_MNT_DIR, strerror(errno));
         return false;
@@ -258,9 +259,9 @@ static bool restore_image(const std::string &input_file,
                           const std::vector<std::string> &exclusions,
                           util::CompressionType compression)
 {
-    if (!util::mkdir_parent(image, S_IRWXU)) {
+    if (auto r = util::mkdir_parent(image, S_IRWXU); !r) {
         LOGE("%s: Failed to create parent directory: %s",
-             image.c_str(), strerror(errno));
+             image.c_str(), r.error().message().c_str());
         return false;
     }
 
@@ -277,7 +278,8 @@ static bool restore_image(const std::string &input_file,
         }
     }
 
-    if (!util::mkdir_recursive(BACKUP_MNT_DIR, 0755) && errno != EEXIST) {
+    if (auto r = util::mkdir_recursive(BACKUP_MNT_DIR, 0755);
+            !r && r.error() != std::errc::file_exists) {
         LOGE("%s: Failed to create directory: %s",
              BACKUP_MNT_DIR, strerror(errno));
         return false;
@@ -690,9 +692,9 @@ static bool restore_rom(const std::shared_ptr<Rom> &rom,
     std::string multiboot_dir(MULTIBOOT_DIR);
     multiboot_dir += '/';
     multiboot_dir += rom->id;
-    if (!util::mkdir_recursive(multiboot_dir, 0775)) {
+    if (auto r = util::mkdir_recursive(multiboot_dir, 0775); !r) {
         LOGE("%s: Failed to create directory: %s",
-             multiboot_dir.c_str(), strerror(errno));
+             multiboot_dir.c_str(), r.error().message().c_str());
         return false;
     }
 
@@ -997,9 +999,9 @@ int backup_main(int argc, char *argv[])
         return EXIT_FAILURE;
     }
 
-    if (!util::mkdir_recursive(output_dir, 0755)) {
+    if (auto r = util::mkdir_recursive(output_dir, 0755); !r) {
         fprintf(stderr, "%s: Failed to create directory: %s\n",
-                output_dir.c_str(), strerror(errno));
+                output_dir.c_str(), r.error().message().c_str());
         return EXIT_FAILURE;
     }
 

--- a/mbtool/daemon.cpp
+++ b/mbtool/daemon.cpp
@@ -134,8 +134,8 @@ static bool client_connection(int fd)
         return false;
     }
 
-    util::set_process_title(format("mbtool connection from pid: %u", cred.pid),
-                            nullptr);
+    (void) util::set_process_title(format(
+            "mbtool connection from pid: %u", cred.pid));
 
     LOGD("Client PID: %u", cred.pid);
     LOGD("Client UID: %u", cred.uid);
@@ -277,9 +277,10 @@ static bool run_daemon()
 
             // Change the process name so --replace doesn't kill existing
             // connections
-            if (!util::set_process_title(
-                    "mbtool connection initializing", nullptr)) {
-                LOGE("Failed to set process title: %s", strerror(errno));
+            if (auto ret = util::set_process_title(
+                    "mbtool connection initializing"); !ret) {
+                LOGE("Failed to set process title: %s",
+                     ret.error().message().c_str());
                 _exit(127);
             }
 

--- a/mbtool/daemon.cpp
+++ b/mbtool/daemon.cpp
@@ -360,8 +360,8 @@ static bool daemon_init()
     } else if (log_to_kmsg) {
         log::set_logger(std::make_shared<log::KmsgLogger>(false));
     } else {
-        if (!util::mkdir_parent(MULTIBOOT_LOG_DAEMON, 0775)
-                && errno != EEXIST) {
+        if (auto r = util::mkdir_parent(MULTIBOOT_LOG_DAEMON, 0775);
+                !r && r.error() != std::errc::file_exists) {
             LOGE("Failed to create parent directory of %s: %s",
                  MULTIBOOT_LOG_DAEMON, strerror(errno));
             return false;

--- a/mbtool/emergency.cpp
+++ b/mbtool/emergency.cpp
@@ -224,9 +224,10 @@ bool emergency_reboot()
     }
 
     for (auto const &em : ems) {
-        if (!util::mkdir_recursive(em.mount_point, 0755) && errno != EEXIST) {
+        if (auto r = util::mkdir_recursive(em.mount_point, 0755);
+                !r && r.error() != std::errc::file_exists) {
             LOGW("%s: Failed to create directory: %s",
-                 em.mount_point.c_str(), strerror(errno));
+                 em.mount_point.c_str(), r.error().message().c_str());
         }
 
         if (!util::is_mounted(em.mount_point)) {
@@ -249,7 +250,8 @@ bool emergency_reboot()
         std::string log_path_old(log_path);
         log_path_old += ".old";
 
-        if (!util::mkdir_parent(log_path, 0755) && errno != EEXIST) {
+        if (auto r = util::mkdir_parent(log_path, 0755);
+                !r && r.error() != std::errc::file_exists) {
             LOGW("%s: Failed to create parent directory: %s",
                  log_path.c_str(), strerror(errno));
         }

--- a/mbtool/emergency.cpp
+++ b/mbtool/emergency.cpp
@@ -156,13 +156,16 @@ bool emergency_reboot()
     std::vector<EmergencyMount> ems;
     Device device;
     JsonError error;
+    bool loaded_json = false;
 
-    std::vector<unsigned char> contents;
-    util::file_read_all(DEVICE_JSON_PATH, contents);
-    contents.push_back('\0');
+    auto contents = util::file_read_all_v(DEVICE_JSON_PATH);
+    if (contents) {
+        contents.value().push_back('\0');
 
-    bool loaded_json = device_from_json(
-            reinterpret_cast<char *>(contents.data()), device, error);
+        loaded_json = device_from_json(
+                reinterpret_cast<char *>(contents.value().data()),
+                device, error);
+    }
 
     // /data
     {

--- a/mbtool/emergency.cpp
+++ b/mbtool/emergency.cpp
@@ -143,11 +143,13 @@ struct EmergencyMount
 
 bool emergency_reboot()
 {
-    util::vibrate(100, 150);
-    util::vibrate(100, 150);
-    util::vibrate(100, 150);
-    util::vibrate(100, 150);
-    util::vibrate(100, 150);
+    using namespace std::chrono_literals;
+
+    (void) util::vibrate(100ms, 250ms);
+    (void) util::vibrate(100ms, 250ms);
+    (void) util::vibrate(100ms, 250ms);
+    (void) util::vibrate(100ms, 250ms);
+    (void) util::vibrate(100ms, 250ms);
 
     LOGW("--- EMERGENCY REBOOT FROM MBTOOL ---");
 

--- a/mbtool/emergency.cpp
+++ b/mbtool/emergency.cpp
@@ -228,13 +228,14 @@ bool emergency_reboot()
 
         if (!util::is_mounted(em.mount_point)) {
             for (const std::string &path : em.paths) {
-                if (util::mount(path, em.mount_point, "auto", 0, "")) {
+                if (auto ret = util::mount(path, em.mount_point, "auto", 0, "")) {
                     LOGV("%s: Mounted %s",
                          em.mount_point.c_str(), path.c_str());
                     break;
                 } else {
                     LOGW("%s: Failed to mount %s: %s",
-                         em.mount_point.c_str(), path.c_str(), strerror(errno));
+                         em.mount_point.c_str(), path.c_str(),
+                         ret.error().message().c_str());
                 }
             }
         }
@@ -259,7 +260,7 @@ bool emergency_reboot()
         }
         sync();
 
-        util::umount(em.mount_point);
+        (void) util::umount(em.mount_point);
     }
 
     fix_multiboot_permissions();

--- a/mbtool/emergency.cpp
+++ b/mbtool/emergency.cpp
@@ -158,7 +158,7 @@ bool emergency_reboot()
     JsonError error;
     bool loaded_json = false;
 
-    auto contents = util::file_read_all_v(DEVICE_JSON_PATH);
+    auto contents = util::file_read_all(DEVICE_JSON_PATH);
     if (contents) {
         contents.value().push_back('\0');
 

--- a/mbtool/external/property_service.cpp
+++ b/mbtool/external/property_service.cpp
@@ -416,14 +416,15 @@ static void load_properties(char *data, const char *filter)
 static void load_properties_from_file(const char* filename, const char* filter) {
     std::chrono::system_clock::time_point start = std::chrono::system_clock::now();
 
-    std::vector<unsigned char> data;
-    if (!mb::util::file_read_all(filename, data)) {
-        LOGW("Couldn't load properties from %s", filename);
+    auto data = mb::util::file_read_all_v(filename);
+    if (!data) {
+        LOGW("Couldn't load properties from %s: %s",
+             filename, data.error().message().c_str());
         return;
     }
-    data.push_back('\n');
-    data.push_back('\0');
-    load_properties(reinterpret_cast<char *>(data.data()), filter);
+    data.value().push_back('\n');
+    data.value().push_back('\0');
+    load_properties(reinterpret_cast<char *>(data.value().data()), filter);
 
     std::chrono::system_clock::time_point end = std::chrono::system_clock::now();
     std::chrono::duration<double> elapsed = end - start;

--- a/mbtool/external/property_service.cpp
+++ b/mbtool/external/property_service.cpp
@@ -416,7 +416,7 @@ static void load_properties(char *data, const char *filter)
 static void load_properties_from_file(const char* filename, const char* filter) {
     std::chrono::system_clock::time_point start = std::chrono::system_clock::now();
 
-    auto data = mb::util::file_read_all_v(filename);
+    auto data = mb::util::file_read_all(filename);
     if (!data) {
         LOGW("Couldn't load properties from %s: %s",
              filename, data.error().message().c_str());

--- a/mbtool/image.cpp
+++ b/mbtool/image.cpp
@@ -51,15 +51,14 @@ CreateImageResult create_ext4_image(const std::string &path, uint64_t size)
 {
     // Ensure we have enough space since we're creating a sparse file that may
     // get bigger
-    uint64_t avail;
-    if (!util::mount_get_avail_size(util::dir_name(path), avail)) {
+    if (auto avail = util::mount_get_avail_size(util::dir_name(path)); !avail) {
         LOGE("%s: Failed to get available space: %s", path.c_str(),
-             strerror(errno));
+             avail.error().message().c_str());
         return CreateImageResult::Failed;
-    } else if (avail < size) {
+    } else if (avail.value() < size) {
         LOGE("There is not enough space to create %s", path.c_str());
         LOGE("- Needed:    %" PRIu64 " bytes", size);
-        LOGE("- Available: %" PRIu64 " bytes", avail);
+        LOGE("- Available: %" PRIu64 " bytes", avail.value());
         return CreateImageResult::NotEnoughSpace;
     }
 

--- a/mbtool/init.cpp
+++ b/mbtool/init.cpp
@@ -1101,9 +1101,9 @@ static bool launch_boot_menu()
     }
 
     auto clean_up = finally([]{
-        if (!util::delete_recursive(BOOT_UI_PATH)) {
+        if (auto r = util::delete_recursive(BOOT_UI_PATH); !r) {
             LOGW("%s: Failed to recursively delete: %s",
-                 BOOT_UI_PATH, strerror(errno));
+                 BOOT_UI_PATH, r.error().message().c_str());
         }
     });
 

--- a/mbtool/init.cpp
+++ b/mbtool/init.cpp
@@ -908,9 +908,10 @@ static bool disable_installd()
         }
     }
 
-    if (!util::mount("/dev/null", installd_init, "", MS_BIND | MS_RDONLY, "")) {
+    if (auto ret = util::mount(
+            "/dev/null", installd_init, "", MS_BIND | MS_RDONLY, ""); !ret) {
         LOGE("%s: Failed to bind mount /dev/null: %s",
-             installd_init, strerror(errno));
+             installd_init, ret.error().message().c_str());
         return false;
     }
 
@@ -936,8 +937,10 @@ static bool disable_spota()
         return false;
     }
 
-    if (!util::mount("tmpfs", spota_dir, "tmpfs", MS_RDONLY, "mode=0000")) {
-        LOGE("%s: Failed to mount tmpfs: %s", spota_dir, strerror(errno));
+    if (auto ret = util::mount(
+            "tmpfs", spota_dir, "tmpfs", MS_RDONLY, "mode=0000"); !ret) {
+        LOGE("%s: Failed to mount tmpfs: %s",
+             spota_dir, ret.error().message().c_str());
         return false;
     }
 

--- a/mbtool/init.cpp
+++ b/mbtool/init.cpp
@@ -1215,8 +1215,8 @@ int init_main(int argc, char *argv[])
     mkdir("/system", 0755);
     mkdir("/cache", 0770);
     mkdir("/data", 0771);
-    util::chown("/cache", "system", "cache", 0);
-    util::chown("/data", "system", "system", 0);
+    (void) util::chown("/cache", "system", "cache", 0);
+    (void) util::chown("/data", "system", "system", 0);
 
     // Redirect std{in,out,err} to /dev/null
     open_devnull_stdio();

--- a/mbtool/init.cpp
+++ b/mbtool/init.cpp
@@ -1228,7 +1228,7 @@ int init_main(int argc, char *argv[])
     LOGV("Booting up with version %s (%s)",
          version(), git_version());
 
-    auto contents = util::file_read_all_v(DEVICE_JSON_PATH);
+    auto contents = util::file_read_all(DEVICE_JSON_PATH);
     if (!contents) {
         LOGE("%s: Failed to read file: %s", DEVICE_JSON_PATH,
              contents.error().message().c_str());

--- a/mbtool/init.cpp
+++ b/mbtool/init.cpp
@@ -931,8 +931,10 @@ static bool disable_spota()
         return true;
     }
 
-    if (!util::mkdir_recursive(spota_dir, 0) && errno != EEXIST) {
-        LOGE("%s: Failed to create directory: %s", spota_dir, strerror(errno));
+    if (auto r = util::mkdir_recursive(spota_dir, 0);
+            !r && r.error() != std::errc::file_exists) {
+        LOGE("%s: Failed to create directory: %s", spota_dir,
+             r.error().message().c_str());
         return false;
     }
 
@@ -1011,7 +1013,7 @@ static bool extract_zip(const char *source, const char *target)
     std::string target_file(target);
     target_file += "/exec";
 
-    util::mkdir_recursive(target, 0755);
+    (void) util::mkdir_recursive(target, 0755);
 
     FILE *fp = fopen(target_file.c_str(), "wb");
     if (!fp) {

--- a/mbtool/init.cpp
+++ b/mbtool/init.cpp
@@ -883,10 +883,10 @@ static bool create_layout_version()
         return false;
     }
 
-    if (!util::selinux_set_context(
-            "/data/.layout_version", "u:object_r:install_data_file:s0")) {
+    if (auto ret = util::selinux_set_context("/data/.layout_version",
+            "u:object_r:install_data_file:s0"); !ret) {
         LOGE("%s: Failed to set SELinux context: %s",
-             "/data/.layout_version", strerror(errno));
+             "/data/.layout_version", ret.error().message().c_str());
         return false;
     }
 

--- a/mbtool/initwrapper/devices.cpp
+++ b/mbtool/initwrapper/devices.cpp
@@ -48,7 +48,7 @@
 
 #define UEVENT_LOGGING 0
 
-static char bootdevice[PROP_VALUE_MAX];
+static std::string bootdevice;
 static int device_fd = -1;
 static int pipe_fd[2];
 static volatile bool run_thread = true;
@@ -448,8 +448,8 @@ static std::vector<std::string> get_block_device_symlinks(struct uevent *uevent)
             free(p);
         }
 
-        if (!pdevs.empty() && bootdevice[0] != '\0'
-                && strstr(device.c_str(), bootdevice)) {
+        if (!pdevs.empty() && !bootdevice.empty()
+                && device.find(bootdevice) != std::string::npos) {
             if (!dry_run) {
                 make_link_init(link_path, "/dev/block/bootdevice");
             }
@@ -850,11 +850,12 @@ void device_init(bool dry_run_)
 {
     dry_run = dry_run_;
 
-    bootdevice[0] = '\0';
-    std::optional<std::string> value;
-    if (mb::util::kernel_cmdline_get_option("androidboot.bootdevice", value)
-            && value) {
-        strlcpy(bootdevice, value->c_str(), sizeof(bootdevice));
+    bootdevice.clear();
+    if (auto cmdline = mb::util::kernel_cmdline()) {
+        auto it = cmdline.value().find("androidboot.bootdevice");
+        if (it != cmdline.value().end() && it->second) {
+            bootdevice.swap(*it->second);
+        }
     }
 
     // Is 256K enough? udev uses 16MB!

--- a/mbtool/initwrapper/devices.cpp
+++ b/mbtool/initwrapper/devices.cpp
@@ -641,7 +641,7 @@ static void handle_generic_device_event(struct uevent *uevent)
                     return;
                 }
                 if (!dry_run) {
-                    mb::util::mkdir_parent(devpath, 0755);
+                    (void) mb::util::mkdir_parent(devpath, 0755);
                 }
             } else {
                 // This imitates the file system that would be created

--- a/mbtool/initwrapper/util.cpp
+++ b/mbtool/initwrapper/util.cpp
@@ -56,9 +56,9 @@ void sanitize(char *s)
 
 void make_link_init(const char *oldpath, const char *newpath)
 {
-    if (!mb::util::mkdir_parent(newpath, 0755)) {
+    if (auto r = mb::util::mkdir_parent(newpath, 0755); !r) {
         LOGE("Failed to create parent directory of %s: %s",
-             newpath, strerror(errno));
+             newpath, r.error().message().c_str());
     }
 
     if (symlink(oldpath, newpath) < 0) {

--- a/mbtool/initwrapper/util.cpp
+++ b/mbtool/initwrapper/util.cpp
@@ -69,11 +69,11 @@ void make_link_init(const char *oldpath, const char *newpath)
 
 void remove_link(const char *oldpath, const char *newpath)
 {
-    std::string path;
-    if (!mb::util::read_link(newpath, path)) {
+    auto path = mb::util::read_link(newpath);
+    if (!path) {
         return;
     }
-    if (path == oldpath) {
+    if (path.value() == oldpath) {
         unlink(newpath);
     }
 }

--- a/mbtool/installer.cpp
+++ b/mbtool/installer.cpp
@@ -200,11 +200,12 @@ static bool log_unmount_all(const std::string &dir)
 
 static bool log_delete_recursive(const std::string &path)
 {
-    bool ret = util::delete_recursive(path);
-    if (!ret) {
-        LOGE("Failed to recursively remove %s", path.c_str());
+    if (auto r = util::delete_recursive(path); !r) {
+        LOGE("Failed to recursively remove %s: %s",
+             path.c_str(), r.error().message().c_str());
+        return false;
     }
-    return ret;
+    return true;
 }
 
 static bool log_copy_dir(const std::string &source,
@@ -444,7 +445,7 @@ bool Installer::destroy_chroot() const
         return false;
     }
 
-    util::delete_recursive(_chroot);
+    (void) util::delete_recursive(_chroot);
 
     if (log_is_mounted("/efs")) {
         log_umount("/efs");

--- a/mbtool/installer.cpp
+++ b/mbtool/installer.cpp
@@ -1552,8 +1552,10 @@ Installer::ProceedState Installer::install_stage_set_up_chroot()
     LOGD("[Installer] Chroot set up stage");
 
     // Save a copy of the boot image that we'll restore if the installation fails
-    if (!util::copy_contents(_boot_block_dev, _temp + "/boot.orig")) {
-        display_msg("Failed to backup boot partition");
+    if (auto r = util::copy_contents(
+            _boot_block_dev, _temp + "/boot.orig"); !r) {
+        LOGE("%s", r.error().message().c_str());
+        display_msg("Failed to back up boot partition");
         return ProceedState::Fail;
     }
 

--- a/mbtool/installer.cpp
+++ b/mbtool/installer.cpp
@@ -1350,7 +1350,7 @@ Installer::ProceedState Installer::install_stage_check_device()
 {
     LOGD("[Installer] Device verification stage");
 
-    auto contents = util::file_read_all_v(_temp + "/device.json");
+    auto contents = util::file_read_all(_temp + "/device.json");
     if (!contents) {
         display_msg("Failed to read device.json");
         return ProceedState::Fail;

--- a/mbtool/installer.cpp
+++ b/mbtool/installer.cpp
@@ -1907,14 +1907,16 @@ Installer::ProceedState Installer::install_stage_finish()
     }
 
     // Update checksums
-    util::Sha512Digest digest;
-
-    if (!util::sha512_hash(temp_boot_img, digest)) {
+    auto digest = util::sha512_hash(temp_boot_img);
+    if (!digest) {
+        LOGE("%s: Failed to compute sha512sum: %s",
+             temp_boot_img.c_str(), digest.error().message().c_str());
         display_msg("Failed to compute sha512sum of new boot image");
         return ProceedState::Fail;
     }
 
-    std::string hash = util::hex_string(digest.data(), digest.size());
+    std::string hash = util::hex_string(digest.value().data(),
+                                        digest.value().size());
 
     std::unordered_map<std::string, std::string> props;
     checksums_read(&props);

--- a/mbtool/installer_util.cpp
+++ b/mbtool/installer_util.cpp
@@ -303,7 +303,7 @@ bool InstallerUtil::patch_boot_image(const std::string &input_file,
     }
 
     auto delete_temp_dir = finally([&]{
-        util::delete_recursive(tmpdir);
+        (void) util::delete_recursive(tmpdir);
     });
 
     Reader reader;
@@ -484,7 +484,7 @@ bool InstallerUtil::patch_ramdisk(const std::string &input_file,
     }
 
     auto delete_temp_dir = finally([&]{
-        util::delete_recursive(tmpdir);
+        (void) util::delete_recursive(tmpdir);
     });
 
     int format;

--- a/mbtool/installer_util.cpp
+++ b/mbtool/installer_util.cpp
@@ -236,19 +236,20 @@ bool InstallerUtil::pack_ramdisk(const std::string &input_dir,
 
         const char *curpath = archive_entry_pathname(entry.get());
         if (curpath && !input_dir.empty()) {
-            std::string relpath;
-            if (!util::relative_path(curpath, input_dir, relpath)) {
+            auto relpath = util::relative_path(curpath, input_dir);
+            if (!relpath) {
                 LOGE("Failed to compute relative path of %s starting at %s: %s",
-                     curpath, input_dir.c_str(), strerror(errno));
+                     curpath, input_dir.c_str(),
+                     relpath.error().message().c_str());
                 return false;
             }
-            if (relpath.empty()) {
+            if (relpath.value().empty()) {
                 // If the relative path is empty, then the current path is
                 // the root of the directory tree. We don't need that, so
                 // skip it.
                 continue;
             }
-            archive_entry_set_pathname(entry.get(), relpath.c_str());
+            archive_entry_set_pathname(entry.get(), relpath.value().c_str());
         }
 
         ret = archive_write_header(aout.get(), entry.get());

--- a/mbtool/main.cpp
+++ b/mbtool/main.cpp
@@ -175,9 +175,9 @@ int main(int argc, char *argv[])
         return EXIT_FAILURE;
     }
 
-    if (!mb::util::set_process_title_init(argc, argv)) {
+    if (auto ret = mb::util::set_process_title_init(argc, argv); !ret) {
         fprintf(stderr, "set_process_title_init() failed: %s\n",
-                strerror(errno));
+                ret.error().message().c_str());
         return EXIT_FAILURE;
     }
 

--- a/mbtool/miniadbd.cpp
+++ b/mbtool/miniadbd.cpp
@@ -89,9 +89,9 @@ static bool initialize_adb()
              USB_FFS_ADB_PATH, strerror(errno));
         ret = false;
     }
-    if (!util::mount("adb", USB_FFS_ADB_PATH, "functionfs", 0, "")) {
+    if (auto r = util::mount("adb", USB_FFS_ADB_PATH, "functionfs", 0, ""); !r) {
         LOGW("%s: Failed to mount functionfs: %s",
-             USB_FFS_ADB_PATH, strerror(errno));
+             USB_FFS_ADB_PATH, r.error().message().c_str());
         ret = false;
     }
 

--- a/mbtool/miniadbd.cpp
+++ b/mbtool/miniadbd.cpp
@@ -84,9 +84,9 @@ static bool initialize_adb()
     ret = write_file("/sys/class/android_usb/android0/enable", "1", 1) && ret;
 
     // Create functionfs paths
-    if (!util::mkdir_recursive(USB_FFS_ADB_PATH, 0770)) {
+    if (auto r = util::mkdir_recursive(USB_FFS_ADB_PATH, 0770); !r) {
         LOGW("%s: Failed to create directory: %s",
-             USB_FFS_ADB_PATH, strerror(errno));
+             USB_FFS_ADB_PATH, r.error().message().c_str());
         ret = false;
     }
     if (auto r = util::mount("adb", USB_FFS_ADB_PATH, "functionfs", 0, ""); !r) {

--- a/mbtool/mount_fstab.cpp
+++ b/mbtool/mount_fstab.cpp
@@ -733,8 +733,6 @@ static bool process_fstab(const char *path, const std::shared_ptr<Rom> &rom,
                           const Device &device, MountFlags flags,
                           FstabRecs &recs)
 {
-    std::vector<util::FstabRec> fstab;
-
     recs.gen.clear();
     recs.system.clear();
     recs.cache.clear();
@@ -742,11 +740,13 @@ static bool process_fstab(const char *path, const std::shared_ptr<Rom> &rom,
     recs.extsd.clear();
 
     // Read original fstab file
-    fstab = util::read_fstab(path);
-    if (fstab.empty()) {
-        LOGE("%s: Failed to read fstab", path);
+    auto fstab_ret = util::read_fstab(path);
+    if (!fstab_ret) {
+        LOGE("%s: Failed to read fstab: %s",
+             path, fstab_ret.error().message().c_str());
         return false;
     }
+    auto &&fstab = fstab_ret.value();
 
     bool include_sdcard0 = !(device.flags() & DeviceFlag::FstabSkipSdcard0);
 

--- a/mbtool/mount_fstab.cpp
+++ b/mbtool/mount_fstab.cpp
@@ -609,9 +609,8 @@ static bool disable_fsck(const char *fsck_binary)
     target += "/";
     target += util::base_name(fsck_binary);
 
-    if (!util::copy_file(FSCK_WRAPPER, target, 0)) {
-        LOGE("Failed to copy %s to %s: %s",
-             FSCK_WRAPPER, target.c_str(), strerror(errno));
+    if (auto r = util::copy_file(FSCK_WRAPPER, target, 0); !r) {
+        LOGE("%s", r.error().message().c_str());
         return false;
     }
 
@@ -652,7 +651,8 @@ static bool copy_mount_exfat()
         return errno == ENOENT;
     }
 
-    if (!util::copy_file(our_mount_exfat, target, 0)) {
+    if (auto r = util::copy_file(our_mount_exfat, target, 0); !r) {
+        LOGE("%s", r.error().message().c_str());
         return false;
     }
 

--- a/mbtool/multiboot.cpp
+++ b/mbtool/multiboot.cpp
@@ -174,7 +174,7 @@ bool copy_system(const std::string &source, const std::string &target)
  */
 bool fix_multiboot_permissions()
 {
-    util::create_empty_file(MULTIBOOT_DIR "/.nomedia");
+    (void) util::create_empty_file(MULTIBOOT_DIR "/.nomedia");
 
     if (!util::chown(MULTIBOOT_DIR, "media_rw", "media_rw",
                      util::ChownFlag::Recursive)) {

--- a/mbtool/multiboot.cpp
+++ b/mbtool/multiboot.cpp
@@ -176,14 +176,17 @@ bool fix_multiboot_permissions()
 {
     (void) util::create_empty_file(MULTIBOOT_DIR "/.nomedia");
 
-    if (!util::chown(MULTIBOOT_DIR, "media_rw", "media_rw",
-                     util::ChownFlag::Recursive)) {
-        LOGE("Failed to chown %s", MULTIBOOT_DIR);
+    if (auto r = util::chown(MULTIBOOT_DIR, "media_rw", "media_rw",
+                             util::ChownFlag::Recursive); !r) {
+        LOGE("Failed to chown %s: %s", MULTIBOOT_DIR,
+             r.error().message().c_str());
         return false;
     }
 
-    if (!util::chmod(MULTIBOOT_DIR, 0775, util::ChmodFlag::Recursive)) {
-        LOGE("Failed to chmod %s", MULTIBOOT_DIR);
+    if (auto r = util::chmod(MULTIBOOT_DIR, 0775,
+                             util::ChmodFlag::Recursive); !r) {
+        LOGE("Failed to chmod %s: %s", MULTIBOOT_DIR,
+             r.error().message().c_str());
         return false;
     }
 

--- a/mbtool/multiboot.cpp
+++ b/mbtool/multiboot.cpp
@@ -80,11 +80,11 @@ public:
 
         // _target is the correct parameter here (or pathbuf and
         // CopyFlag::ExcludeTopLevel flag)
-        if (!util::copy_dir(_curr->fts_accpath, _target,
-                            util::CopyFlag::CopyAttributes
-                          | util::CopyFlag::CopyXattrs)) {
-            _error_msg = format("%s: Failed to copy directory: %s",
-                                _curr->fts_path, strerror(errno));
+        if (auto r = util::copy_dir(_curr->fts_accpath, _target,
+                                    util::CopyFlag::CopyAttributes
+                                  | util::CopyFlag::CopyXattrs); !r) {
+            _error_msg = format("Failed to copy directory: %s",
+                                r.error().message().c_str());
             LOGW("%s", _error_msg.c_str());
             return Action::Skip | Action::Fail;
         }
@@ -94,14 +94,14 @@ public:
     Actions on_reached_directory_post() override
     {
         if (_curr->fts_level == 0) {
-            if (!util::copy_stat(_curr->fts_accpath, _target)) {
+            if (auto r = util::copy_stat(_curr->fts_accpath, _target); !r) {
                 LOGE("%s: Failed to copy attributes: %s",
-                     _target.c_str(), strerror(errno));
+                     _target.c_str(), r.error().message().c_str());
                 return Action::Fail;
             }
-            if (!util::copy_xattrs(_curr->fts_accpath, _target)) {
+            if (auto r = util::copy_xattrs(_curr->fts_accpath, _target); !r) {
                 LOGE("%s: Failed to copy xattrs: %s",
-                     _target.c_str(), strerror(errno));
+                     _target.c_str(), r.error().message().c_str());
                 return Action::Fail;
             }
         }
@@ -138,11 +138,11 @@ private:
 
     bool copy_path()
     {
-        if (!util::copy_file(_curr->fts_accpath, _curtgtpath,
-                             util::CopyFlag::CopyAttributes
-                           | util::CopyFlag::CopyXattrs)) {
-            _error_msg = format("%s: Failed to copy file: %s",
-                                _curr->fts_path, strerror(errno));
+        if (auto r = util::copy_file(_curr->fts_accpath, _curtgtpath,
+                                     util::CopyFlag::CopyAttributes
+                                   | util::CopyFlag::CopyXattrs); !r) {
+            _error_msg = format("Failed to copy file: %s",
+                                r.error().message().c_str());
             LOGW("%s", _error_msg.c_str());
             return false;
         }

--- a/mbtool/multiboot.h
+++ b/mbtool/multiboot.h
@@ -49,6 +49,7 @@
 #define PROP_BLOCK_DEV_RECOVERY_PATHS   "ro.patcher.blockdevs.recovery"
 #define PROP_BLOCK_DEV_EXTRA_PATHS      "ro.patcher.blockdevs.extra"
 #define PROP_USE_FUSE_EXFAT             "ro.patcher.use_fuse_exfat"
+#define PROP_DEVICE                     "ro.patcher.device"
 
 #define PROP_MULTIBOOT_VERSION          "ro.multiboot.version"
 #define PROP_MULTIBOOT_ROM_ID           "ro.multiboot.romid"

--- a/mbtool/ramdisk_patcher.cpp
+++ b/mbtool/ramdisk_patcher.cpp
@@ -220,7 +220,8 @@ static bool _rp_add_binaries(const std::string &dir,
         target += "/";
         target += item.to;
 
-        if (!util::copy_file(source, target, 0)) {
+        if (auto r = util::copy_file(source, target, 0); !r) {
+            LOGE("%s", r.error().message().c_str());
             return false;
         }
         if (chmod(target.c_str(), item.perm) < 0) {
@@ -391,7 +392,8 @@ static bool _rp_add_device_json(const std::string &dir,
     std::string device_json(dir);
     device_json += "/device.json";
 
-    if (!util::copy_file(device_json_file, device_json, 0)) {
+    if (auto r = util::copy_file(device_json_file, device_json, 0); !r) {
+        LOGE("%s", r.error().message().c_str());
         return false;
     }
 

--- a/mbtool/ramdisk_patcher.cpp
+++ b/mbtool/ramdisk_patcher.cpp
@@ -36,6 +36,7 @@
 #include "mbutil/path.h"
 
 #include "installer_util.h"
+#include "multiboot.h"
 
 #define LOG_TAG "mbtool/ramdisk_patcher"
 
@@ -158,8 +159,8 @@ static bool _rp_patch_default_prop(const std::string &dir,
 
     // Write new properties
     if (fputc('\n', fp_out) == EOF
-            || fprintf(fp_out, "ro.patcher.device=%s\n", device_id.c_str()) < 0
-            || fprintf(fp_out, "ro.patcher.use_fuse_exfat=%s\n",
+            || fprintf(fp_out, PROP_DEVICE "=%s\n", device_id.c_str()) < 0
+            || fprintf(fp_out, PROP_USE_FUSE_EXFAT "=%s\n",
                        use_fuse_exfat ? "true" : "false") < 0) {
         LOGE("%s: Failed to write properties: %s",
              tmp_path.c_str(), strerror(errno));

--- a/mbtool/rom_installer.cpp
+++ b/mbtool/rom_installer.cpp
@@ -581,10 +581,9 @@ int rom_installer_main(int argc, char *argv[])
     // the daemon will guarantee that we run in that context. We'll just warn if
     // this happens to not be the case (eg. debugging via command line).
 
-    std::string context;
-    if (util::selinux_get_process_attr(
-            0, util::SELinuxAttr::Current, context)
-            && context != MB_EXEC_CONTEXT) {
+    auto context = util::selinux_get_process_attr(
+            0, util::SELinuxAttr::Current);
+    if (context && context.value() != MB_EXEC_CONTEXT) {
         fprintf(stderr, "WARNING: Not running under %s context\n",
                 MB_EXEC_CONTEXT);
     }

--- a/mbtool/sepolpatch.cpp
+++ b/mbtool/sepolpatch.cpp
@@ -961,20 +961,23 @@ static bool fix_data_media_rules(policydb_t *pdb)
         return true;
     }
 
-    std::string context;
-    if (!util::selinux_lget_context(path, context)) {
-        LOGE("%s: Failed to get context: %s", path, strerror(errno));
+    auto context = util::selinux_lget_context(path);
+    if (!context) {
+        LOGE("%s: Failed to get context: %s",
+             path, context.error().message().c_str());
         path = "/data/media";
-        if (!util::selinux_lget_context(path, context)) {
-            LOGE("%s: Failed to get context: %s", path, strerror(errno));
+        context = util::selinux_lget_context(path);
+        if (!context) {
+            LOGE("%s: Failed to get context: %s",
+                 path, context.error().message().c_str());
             // Don't fail if /data/media does not exist
             return errno == ENOENT;
         }
     }
 
-    std::vector<std::string> pieces = split(context, ':');
+    std::vector<std::string> pieces = split(context.value(), ':');
     if (pieces.size() < 3) {
-        LOGE("%s: Malformed context string: %s", path, context.c_str());
+        LOGE("%s: Malformed context string: %s", path, context.value().c_str());
         return false;
     }
     const std::string &type = pieces[2];

--- a/mbtool/switcher.cpp
+++ b/mbtool/switcher.cpp
@@ -355,7 +355,7 @@ SwitchRomResult switch_rom(const std::string &id,
         // If memory becomes an issue, an alternative method is to create a
         // temporary directory in /data/multiboot/ that's only writable by root
         // and copy the images there.
-        if (auto r = util::file_read_all_v(f.image)) {
+        if (auto r = util::file_read_all(f.image)) {
             f.data = std::move(r.value());
         } else {
             LOGE("%s: Failed to read image: %s",
@@ -457,7 +457,7 @@ bool set_kernel(const std::string &id, const std::string &boot_blockdev)
         return false;
     }
 
-    auto data = util::file_read_all_v(boot_blockdev);
+    auto data = util::file_read_all(boot_blockdev);
     if (!data) {
         LOGE("%s: Failed to read block device: %s",
              boot_blockdev.c_str(), data.error().message().c_str());

--- a/mbtool/switcher.cpp
+++ b/mbtool/switcher.cpp
@@ -157,7 +157,7 @@ bool checksums_write(const std::unordered_map<std::string, std::string> &props)
     }
 
     util::mkdir_parent(checksums_path, 0755);
-    util::create_empty_file(checksums_path);
+    (void) util::create_empty_file(checksums_path);
 
     if (!util::chown(checksums_path, 0, 0, 0)) {
         LOGW("%s: Failed to chown file: %s",
@@ -323,8 +323,7 @@ SwitchRomResult switch_rom(const std::string &id,
     Roms roms;
     roms.add_installed();
 
-    auto r = roms.find_by_id(id);
-    if (!r) {
+    if (!roms.find_by_id(id)) {
         LOGE("Invalid ROM ID: %s", id.c_str());
         return SwitchRomResult::Failed;
     }
@@ -356,9 +355,11 @@ SwitchRomResult switch_rom(const std::string &id,
         // If memory becomes an issue, an alternative method is to create a
         // temporary directory in /data/multiboot/ that's only writable by root
         // and copy the images there.
-        if (!util::file_read_all(f.image, f.data)) {
+        if (auto r = util::file_read_all_v(f.image)) {
+            f.data = std::move(r.value());
+        } else {
             LOGE("%s: Failed to read image: %s",
-                 f.image.c_str(), strerror(errno));
+                 f.image.c_str(), r.error().message().c_str());
             return SwitchRomResult::Failed;
         }
 
@@ -398,11 +399,10 @@ SwitchRomResult switch_rom(const std::string &id,
 
     // Now we can flash the images
     for (Flashable &f : flashables) {
-        // Cast is okay. The data is just passed to fwrite (ie. no signed
-        // extension issues)
-        if (!util::file_write_data(f.block_dev, f.data.data(), f.data.size())) {
+        if (auto r = util::file_write_data(
+                f.block_dev, f.data.data(), f.data.size()); !r) {
             LOGE("%s: Failed to write image: %s",
-                 f.block_dev.c_str(), strerror(errno));
+                 f.block_dev.c_str(), r.error().message().c_str());
             return SwitchRomResult::Failed;
         }
     }
@@ -446,8 +446,7 @@ bool set_kernel(const std::string &id, const std::string &boot_blockdev)
     Roms roms;
     roms.add_installed();
 
-    auto r = roms.find_by_id(id);
-    if (!r) {
+    if (!roms.find_by_id(id)) {
         LOGE("Invalid ROM ID: %s", id.c_str());
         return false;
     }
@@ -458,17 +457,16 @@ bool set_kernel(const std::string &id, const std::string &boot_blockdev)
         return false;
     }
 
-    std::vector<unsigned char> data;
-
-    if (!util::file_read_all(boot_blockdev, data)) {
+    auto data = util::file_read_all_v(boot_blockdev);
+    if (!data) {
         LOGE("%s: Failed to read block device: %s",
-             boot_blockdev.c_str(), strerror(errno));
+             boot_blockdev.c_str(), data.error().message().c_str());
         return false;
     }
 
     // Get actual sha512sum
     std::array<unsigned char, SHA512_DIGEST_LENGTH> digest;
-    SHA512(data.data(), data.size(), digest.data());
+    SHA512(data.value().data(), data.value().size(), digest.data());
     std::string hash = util::hex_string(digest.data(), digest.size());
 
     // Add to checksums.prop
@@ -481,9 +479,10 @@ bool set_kernel(const std::string &id, const std::string &boot_blockdev)
 
     // Cast is okay. The data is just passed to fwrite (ie. no signed
     // extension issues)
-    if (!util::file_write_data(bootimg_path, data.data(), data.size())) {
+    if (auto r = util::file_write_data(
+            bootimg_path, data.value().data(), data.value().size()); !r) {
         LOGE("%s: Failed to write image: %s",
-             bootimg_path.c_str(), strerror(errno));
+             bootimg_path.c_str(), r.error().message().c_str());
         return false;
     }
 

--- a/mbtool/switcher.cpp
+++ b/mbtool/switcher.cpp
@@ -156,7 +156,7 @@ bool checksums_write(const std::unordered_map<std::string, std::string> &props)
              checksums_path.c_str(), strerror(errno));
     }
 
-    util::mkdir_parent(checksums_path, 0755);
+    (void) util::mkdir_parent(checksums_path, 0755);
     (void) util::create_empty_file(checksums_path);
 
     if (!util::chown(checksums_path, 0, 0, 0)) {
@@ -328,9 +328,9 @@ SwitchRomResult switch_rom(const std::string &id,
         return SwitchRomResult::Failed;
     }
 
-    if (!util::mkdir_recursive(multiboot_path, 0775)) {
+    if (auto r = util::mkdir_recursive(multiboot_path, 0775); !r) {
         LOGE("%s: Failed to create directory: %s",
-             multiboot_path.c_str(), strerror(errno));
+             multiboot_path.c_str(), r.error().message().c_str());
         return SwitchRomResult::Failed;
     }
 
@@ -451,9 +451,9 @@ bool set_kernel(const std::string &id, const std::string &boot_blockdev)
         return false;
     }
 
-    if (!util::mkdir_recursive(multiboot_path, 0775)) {
+    if (auto r = util::mkdir_recursive(multiboot_path, 0775); !r) {
         LOGE("%s: Failed to create directory: %s",
-             multiboot_path.c_str(), strerror(errno));
+             multiboot_path.c_str(), r.error().message().c_str());
         return false;
     }
 

--- a/mbtool/switcher.cpp
+++ b/mbtool/switcher.cpp
@@ -159,9 +159,9 @@ bool checksums_write(const std::unordered_map<std::string, std::string> &props)
     (void) util::mkdir_parent(checksums_path, 0755);
     (void) util::create_empty_file(checksums_path);
 
-    if (!util::chown(checksums_path, 0, 0, 0)) {
+    if (auto r = util::chown(checksums_path, 0, 0, 0); !r) {
         LOGW("%s: Failed to chown file: %s",
-             checksums_path.c_str(), strerror(errno));
+             checksums_path.c_str(), r.error().message().c_str());
     }
     if (chmod(checksums_path.c_str(), 0700) < 0) {
         LOGW("%s: Failed to chmod file: %s",

--- a/mbtool/update_binary.cpp
+++ b/mbtool/update_binary.cpp
@@ -118,14 +118,15 @@ Installer::ProceedState RecoveryInstaller::on_initialize()
 RecoveryInstaller::ProceedState RecoveryInstaller::on_set_up_chroot()
 {
     // Copy /etc/fstab
-    util::copy_file("/etc/fstab", in_chroot("/etc/fstab"),
-                    util::CopyFlag::CopyAttributes
-                  | util::CopyFlag::CopyXattrs);
+    (void) util::copy_file("/etc/fstab", in_chroot("/etc/fstab"),
+                           util::CopyFlag::CopyAttributes
+                         | util::CopyFlag::CopyXattrs);
 
     // Copy /etc/recovery.fstab
-    util::copy_file("/etc/recovery.fstab", in_chroot("/etc/recovery.fstab"),
-                    util::CopyFlag::CopyAttributes
-                  | util::CopyFlag::CopyXattrs);
+    (void) util::copy_file("/etc/recovery.fstab",
+                           in_chroot("/etc/recovery.fstab"),
+                           util::CopyFlag::CopyAttributes
+                         | util::CopyFlag::CopyXattrs);
 
     return ProceedState::Continue;
 }
@@ -134,8 +135,9 @@ void RecoveryInstaller::on_cleanup(Installer::ProceedState ret)
 {
     (void) ret;
 
-    if (!util::copy_file("/tmp/recovery.log", MULTIBOOT_LOG_INSTALLER, 0)) {
-        LOGE("Failed to copy log file: %s", strerror(errno));
+    if (auto r = util::copy_file(
+            "/tmp/recovery.log", MULTIBOOT_LOG_INSTALLER, 0); !r) {
+        LOGE("Failed to copy log file: %s", r.error().message().c_str());
     }
 
     fix_multiboot_permissions();

--- a/mbtool/utilities.cpp
+++ b/mbtool/utilities.cpp
@@ -72,7 +72,7 @@ static bool get_device(const char *path, Device &device)
     LOGD("ro.product.device = %s", prop_product_device.c_str());
     LOGD("ro.build.product = %s", prop_build_product.c_str());
 
-    auto contents = util::file_read_all_v(path);
+    auto contents = util::file_read_all(path);
     if (!contents) {
         LOGE("%s: Failed to read file: %s", path,
              contents.error().message().c_str());
@@ -334,7 +334,7 @@ public:
         LOGD("%s -> %s", _curr->fts_path, name.c_str());
 
         if (name == "META-INF/com/google/android/aroma-config.in") {
-            auto data = util::file_read_all_v(_curr->fts_accpath);
+            auto data = util::file_read_all(_curr->fts_accpath);
             if (!data) {
                 LOGE("Failed to read: %s: %s", _curr->fts_path,
                      data.error().message().c_str());

--- a/mbtool/utilities.cpp
+++ b/mbtool/utilities.cpp
@@ -72,18 +72,19 @@ static bool get_device(const char *path, Device &device)
     LOGD("ro.product.device = %s", prop_product_device.c_str());
     LOGD("ro.build.product = %s", prop_build_product.c_str());
 
-    std::vector<unsigned char> contents;
-    if (!util::file_read_all(path, contents)) {
-        LOGE("%s: Failed to read file: %s", path, strerror(errno));
+    auto contents = util::file_read_all_v(path);
+    if (!contents) {
+        LOGE("%s: Failed to read file: %s", path,
+             contents.error().message().c_str());
         return false;
     }
-    contents.push_back('\0');
+    contents.value().push_back('\0');
 
     std::vector<Device> devices;
     JsonError error;
 
-    if (!device_list_from_json(reinterpret_cast<const char *>(contents.data()),
-                               devices, error)) {
+    if (!device_list_from_json(reinterpret_cast<const char *>(
+            contents.value().data()), devices, error)) {
         LOGE("%s: Failed to load devices", path);
         return false;
     }
@@ -206,9 +207,9 @@ static bool utilities_wipe_multiboot(const char *rom_id)
     return wipe_multiboot(rom);
 }
 
-static void generate_aroma_config(std::vector<unsigned char> *data)
+static void generate_aroma_config(std::vector<unsigned char> &data)
 {
-    std::string str_data(data->begin(), data->end());
+    std::string str_data(data.begin(), data.end());
 
     std::string rom_menu_items;
     std::string rom_selection_items;
@@ -252,7 +253,7 @@ static void generate_aroma_config(std::vector<unsigned char> *data)
     util::replace_all(str_data, "@DATA_MOUNT_POINT@", Roms::get_data_partition());
     util::replace_all(str_data, "@EXTSD_MOUNT_POINT@", Roms::get_extsd_partition());
 
-    data->assign(str_data.begin(), str_data.end());
+    data.assign(str_data.begin(), str_data.end());
 }
 
 class AromaGenerator : public util::FtsWrapper
@@ -333,16 +334,17 @@ public:
         LOGD("%s -> %s", _curr->fts_path, name.c_str());
 
         if (name == "META-INF/com/google/android/aroma-config.in") {
-            std::vector<unsigned char> data;
-            if (!util::file_read_all(_curr->fts_accpath, data)) {
-                LOGE("Failed to read: %s", _curr->fts_path);
+            auto data = util::file_read_all_v(_curr->fts_accpath);
+            if (!data) {
+                LOGE("Failed to read: %s: %s", _curr->fts_path,
+                     data.error().message().c_str());
                 return Action::Fail;
             }
 
-            generate_aroma_config(&data);
+            generate_aroma_config(data.value());
 
             name = "META-INF/com/google/android/aroma-config";
-            bool ret = add_file(name, data);
+            bool ret = add_file(name, data.value());
             return ret ? Action::Ok : Action::Fail;
         } else {
             bool ret = add_file(name, _curr->fts_accpath);

--- a/mbtool/wipe.cpp
+++ b/mbtool/wipe.cpp
@@ -216,7 +216,7 @@ bool wipe_system(const std::shared_ptr<Rom> &rom)
         // Ensure the image is no longer mounted
         std::string mount_point("/raw/images/");
         mount_point += rom->id;
-        util::umount(mount_point);
+        (void) util::umount(mount_point);
 
         ret = log_wipe_file(path);
     } else {

--- a/mbtool/wipe.cpp
+++ b/mbtool/wipe.cpp
@@ -198,9 +198,13 @@ static bool log_wipe_directory(const std::string &mountpoint,
 static bool log_delete_recursive(const std::string &path)
 {
     LOGV("Recursively deleting %s", path.c_str());
-    bool ret = util::delete_recursive(path);
-    LOGV("-> %s", ret ? "Succeeded" : "Failed");
-    return ret;
+    if (auto r = util::delete_recursive(path)) {
+        LOGV("-> Succeeded");
+        return true;
+    } else {
+        LOGV("-> Failed: %s", r.error().message().c_str());
+        return false;
+    }
 }
 
 bool wipe_system(const std::shared_ptr<Rom> &rom)

--- a/odinupdater/odinupdater.cpp
+++ b/odinupdater/odinupdater.cpp
@@ -562,16 +562,15 @@ static bool copy_dir_if_exists(const char *source_dir,
         return false;
     }
 
-    bool ret = mb::util::copy_dir(source_dir, target_dir,
+    auto ret = mb::util::copy_dir(source_dir, target_dir,
                                   mb::util::CopyFlag::CopyAttributes
                                 | mb::util::CopyFlag::CopyXattrs
                                 | mb::util::CopyFlag::ExcludeTopLevel);
     if (!ret) {
-        error("Failed to copy %s to %s: %s",
-              source_dir, target_dir, strerror(errno));
+        error("%s", ret.error().message().c_str());
     }
 
-    return ret;
+    return !!ret;
 }
 
 // Looping is necessary in Touchwiz, which sometimes fails to unmount the


### PR DESCRIPTION
This also keeps logging in libmbutil to a minimum. Ideally, it would return enough information that the caller could perform any necessary logging. Also, `fts.cpp` was left untouched in this PR. It will be updated to use C++ iterators in a later PR.