### PR TITLE
mbtool: sepolpatch.cpp: Allow untrusted_app_25-labeled processes to talk to mb_exec-labeled sockets

### DIFF
--- a/mbtool/sepolpatch.cpp
+++ b/mbtool/sepolpatch.cpp
@@ -1026,9 +1026,13 @@ static bool create_mbtool_types(policydb_t *pdb)
     }
 
     // Allow apps to connect to the daemon
-    ff(add_rules(pdb, "untrusted_app", "mb_exec", "unix_stream_socket", {
-        "connectto",
-    }));
+    for (auto const &type : { "untrusted_app", "untrusted_app_25" }) {
+        if (find_type(pdb, type)) {
+            ff(add_rules(pdb, type, "mb_exec", "unix_stream_socket", {
+                "connectto",
+            }));
+        }
+    }
 
     // Allow zygote to write to our stdout pipe when rebooting
     ff(add_rules(pdb, "zygote", "init", "fifo_file", { "write" }));


### PR DESCRIPTION
AOSP now labels apps with different types depending on their target API
version. untrustd_app_25 is used to label any app targeting API 25 or
lower (including the DualBootPatcher app).

https://android.googlesource.com/platform/system/sepolicy/+/bacb6d79360f3591680b215177602dcdc3181bf3

(Fixes #1020)