### PR TITLE
Fix of spanish language writing error

### DIFF
--- a/Android_GUI/res/values-es/strings.xml
+++ b/Android_GUI/res/values-es/strings.xml
@@ -54,7 +54,7 @@ mbtool. Esto puede ocurrir si el acceso root fue denegado o si el ramdisk no est
   <!--Default name for the multi-slot ROMs-->
   <string name="multislot">Multi espacio %s</string>
   <!--Default name for the data-slot ROMs-->
-  <string name="dataslot">%s (Eanura de Datos)</string>
+  <string name="dataslot">%s (Ranura de Datos)</string>
   <!--Default name for the extsd-slot ROMs-->
   <string name="extsdslot">%s (Espacio SD-ext)</string>
   <!--Text shown when a ROM's version could not be detected-->


### PR DESCRIPTION
The description of a ROM in data slot says:

Eanura de Datos

When should I say:

Ranura de Datos