### PR TITLE
libmbutil: Remove unneeded MountError::EndOfFile error code

### DIFF
--- a/libmbutil/include/mbutil/mount.h
+++ b/libmbutil/include/mbutil/mount.h
@@ -29,8 +29,7 @@ namespace mb::util
 
 enum class MountError
 {
-    EndOfFile = 1,
-    PathNotMounted,
+    PathNotMounted = 1,
 };
 
 std::error_code make_error_code(MountError e);

--- a/libmbutil/src/mount.cpp
+++ b/libmbutil/src/mount.cpp
@@ -83,8 +83,6 @@ const char * MountErrorCategory::name() const noexcept
 std::string MountErrorCategory::message(int ev) const
 {
     switch (static_cast<MountError>(ev)) {
-    case MountError::EndOfFile:
-        return "end of file";
     case MountError::PathNotMounted:
         return "path not mounted";
     default:


### PR DESCRIPTION
Signed-off-by: Andrew Gunnerson <andrewgunnerson@gmail.com>