### PR TITLE
mbtool: Remove old ro.patcher.blockdevs properties

### DIFF
--- a/mbtool/init.cpp
+++ b/mbtool/init.cpp
@@ -695,22 +695,6 @@ static bool add_props_to_default_prop(const Device &device)
     // Write ROM ID property
     fprintf(fp.get(), PROP_MULTIBOOT_ROM_ID "=%s\n", get_rom_id().c_str());
 
-    // Block device paths (deprecated)
-    fprintf(fp.get(), "ro.patcher.blockdevs.base=%s\n",
-            encode_list(device.block_dev_base_dirs()).c_str());
-    fprintf(fp.get(), "ro.patcher.blockdevs.system=%s\n",
-            encode_list(device.system_block_devs()).c_str());
-    fprintf(fp.get(), "ro.patcher.blockdevs.cache=%s\n",
-            encode_list(device.cache_block_devs()).c_str());
-    fprintf(fp.get(), "ro.patcher.blockdevs.data=%s\n",
-            encode_list(device.data_block_devs()).c_str());
-    fprintf(fp.get(), "ro.patcher.blockdevs.boot=%s\n",
-            encode_list(device.boot_block_devs()).c_str());
-    fprintf(fp.get(), "ro.patcher.blockdevs.recovery=%s\n",
-            encode_list(device.recovery_block_devs()).c_str());
-    fprintf(fp.get(), "ro.patcher.blockdevs.extra=%s\n",
-            encode_list(device.extra_block_devs()).c_str());
-
     return true;
 }
 

--- a/mbtool/multiboot.h
+++ b/mbtool/multiboot.h
@@ -41,13 +41,6 @@
 #define FILE_CONTEXTS_BIN               "/file_contexts.bin"
 #define FILE_CONTEXTS                   "/file_contexts"
 
-#define PROP_BLOCK_DEV_BASE_DIRS        "ro.patcher.blockdevs.base"
-#define PROP_BLOCK_DEV_SYSTEM_PATHS     "ro.patcher.blockdevs.system"
-#define PROP_BLOCK_DEV_CACHE_PATHS      "ro.patcher.blockdevs.cache"
-#define PROP_BLOCK_DEV_DATA_PATHS       "ro.patcher.blockdevs.data"
-#define PROP_BLOCK_DEV_BOOT_PATHS       "ro.patcher.blockdevs.boot"
-#define PROP_BLOCK_DEV_RECOVERY_PATHS   "ro.patcher.blockdevs.recovery"
-#define PROP_BLOCK_DEV_EXTRA_PATHS      "ro.patcher.blockdevs.extra"
 #define PROP_USE_FUSE_EXFAT             "ro.patcher.use_fuse_exfat"
 #define PROP_DEVICE                     "ro.patcher.device"
 


### PR DESCRIPTION
These have been deprecated for a while and aren't used by anything.

Signed-off-by: Andrew Gunnerson <andrewgunnerson@gmail.com>