### PR TITLE
mbtool: Allow system_server to use fds from mbtool (fixes framework reboot on TW Oreo)

### DIFF
--- a/mbtool/sepolpatch.cpp
+++ b/mbtool/sepolpatch.cpp
@@ -1043,6 +1043,10 @@ static bool create_mbtool_types(policydb_t *pdb)
     // Allow zygote to write to our stdout pipe when rebooting
     ff(add_rules(pdb, "zygote", "init", "fifo_file", { "write" }));
 
+    // Allow 'am' to use fds (eg. pipes) inherited from the daemon
+    ff(add_rules(pdb, "system_server", "mb_exec", "fd", { "use" }));
+    ff(add_rules(pdb, "system_server", "mb_exec", "fifo_file", { "write" }));
+
     // Allow rebooting via the android.intent.action.REBOOT intent
     if (find_type(pdb, "activity_service")) {
         ff(add_rules(pdb, "zygote", "activity_service", "service_manager", { "find" }));


### PR DESCRIPTION
Signed-off-by: Andrew Gunnerson <andrewgunnerson@gmail.com>