### PR TITLE
Use std::this_thread::sleep_for() instead of C/POSIX sleep functions

### DIFF
--- a/libmbutil/src/path.cpp
+++ b/libmbutil/src/path.cpp
@@ -20,6 +20,7 @@
 #include "mbutil/path.h"
 
 #include <chrono>
+#include <thread>
 #include <vector>
 
 #include <cerrno>
@@ -287,13 +288,14 @@ int path_compare(const std::string &path1, const std::string &path2)
 bool wait_for_path(const std::string &path, std::chrono::milliseconds timeout)
 {
     using namespace std::chrono;
+    using namespace std::chrono_literals;
 
     auto until = steady_clock::now() + timeout;
     struct stat sb;
     int ret;
 
     while ((ret = stat(path.c_str(), &sb)) < 0 && steady_clock::now() < until) {
-        usleep(10000);
+        std::this_thread::sleep_for(10ms);
     }
 
     return ret == 0;

--- a/libmbutil/src/selinux.cpp
+++ b/libmbutil/src/selinux.cpp
@@ -19,8 +19,12 @@
 
 #include "mbutil/selinux.h"
 
+#include <chrono>
+#include <thread>
+
 #include <cerrno>
 #include <cstring>
+
 #include <fcntl.h>
 #include <sys/mman.h>
 #include <sys/stat.h>
@@ -100,6 +104,8 @@ private:
 
 bool selinux_read_policy(const std::string &path, policydb_t *pdb)
 {
+    using namespace std::chrono_literals;
+
     struct policy_file pf;
     struct stat sb;
     void *map;
@@ -111,7 +117,7 @@ bool selinux_read_policy(const std::string &path, policydb_t *pdb)
             LOGE("[%d/%d] %s: Failed to open sepolicy: %s",
                  i + 1, OPEN_ATTEMPTS, path.c_str(), strerror(errno));
             if (errno == EBUSY) {
-                usleep(500 * 1000);
+                std::this_thread::sleep_for(500ms);
                 continue;
             } else {
                 return false;
@@ -157,6 +163,8 @@ bool selinux_read_policy(const std::string &path, policydb_t *pdb)
 // See: http://marc.info/?l=selinux&m=141882521027239&w=2
 bool selinux_write_policy(const std::string &path, policydb_t *pdb)
 {
+    using namespace std::chrono_literals;
+
     void *data;
     size_t len;
     sepol_handle_t *handle;
@@ -185,7 +193,7 @@ bool selinux_write_policy(const std::string &path, policydb_t *pdb)
             LOGE("[%d/%d] %s: Failed to open sepolicy: %s",
                  i + 1, OPEN_ATTEMPTS, path.c_str(), strerror(errno));
             if (errno == EBUSY) {
-                usleep(500 * 1000);
+                std::this_thread::sleep_for(500ms);
                 continue;
             } else {
                 return false;

--- a/libmbutil/src/vibrate.cpp
+++ b/libmbutil/src/vibrate.cpp
@@ -19,6 +19,8 @@
 
 #include "mbutil/vibrate.h"
 
+#include <thread>
+
 #include <cstdio>
 #include <cstring>
 
@@ -60,26 +62,11 @@ oc::result<void> vibrate(milliseconds timeout, milliseconds wait)
         timeout = 2s;
     }
 
-    if (dprintf(fd,  "%u", static_cast<unsigned int>(timeout.count())) < 0) {
+    if (dprintf(fd, "%u", static_cast<unsigned int>(timeout.count())) < 0) {
         return ec_from_errno();
     }
 
-    if (wait.count()) {
-        timespec ts, rem;
-        ts.tv_sec = static_cast<time_t>(duration_cast<seconds>(wait).count());
-        ts.tv_nsec = static_cast<long>(duration_cast<nanoseconds>(
-                wait - seconds(ts.tv_sec)).count());
-
-        while (true) {
-            if (nanosleep(&ts, &rem) == 0) {
-                break;
-            } else if (errno == EINTR) {
-                ts = rem;
-            } else {
-                return ec_from_errno();
-            }
-        }
-    }
+    std::this_thread::sleep_for(wait);
 
     return oc::success();
 }

--- a/mbtool/appsync.cpp
+++ b/mbtool/appsync.cpp
@@ -21,6 +21,7 @@
 
 #include <algorithm>
 #include <chrono>
+#include <thread>
 
 #include <cassert>
 #include <cstdio>
@@ -399,7 +400,7 @@ static int connect_to_installd()
         LOGV("Connecting to installd [Attempt %d/%d]", attempt + 1, 5);
         if (connect(fd, reinterpret_cast<sockaddr *>(&addr), sizeof(addr)) < 0) {
             LOGW("Failed: %s", strerror(errno));
-            sleep(1);
+            std::this_thread::sleep_for(1s);
         } else {
             break;
         }

--- a/mbtool/daemon.cpp
+++ b/mbtool/daemon.cpp
@@ -20,6 +20,8 @@
 #include "daemon.h"
 
 #include <algorithm>
+#include <chrono>
+#include <thread>
 
 #include <fcntl.h>
 #include <getopt.h>
@@ -482,6 +484,8 @@ static void daemon_usage(bool error)
 
 int daemon_main(int argc, char *argv[])
 {
+    using namespace std::chrono_literals;
+
     int opt;
     bool fork_flag = false;
     bool replace_flag = false;
@@ -611,7 +615,7 @@ int daemon_main(int argc, char *argv[])
         }
 
         // Give processes a chance to exit
-        usleep(500000);
+        std::this_thread::sleep_for(500ms);
     }
 
     if (fork_flag) {

--- a/mbtool/mount_fstab.cpp
+++ b/mbtool/mount_fstab.cpp
@@ -20,6 +20,8 @@
 #include "mount_fstab.h"
 
 #include <algorithm>
+#include <chrono>
+#include <thread>
 
 #include <cerrno>
 #include <cstdio>
@@ -457,6 +459,8 @@ static std::vector<std::string> split_patterns(const char *patterns)
 static bool mount_extsd_fstab_entries(const std::vector<util::FstabRec> &extsd_recs,
                                       const char *mount_point, mode_t perms)
 {
+    using namespace std::chrono_literals;
+
     if (extsd_recs.empty()) {
         LOGD("No external SD fstab entries to mount");
         return true;
@@ -515,7 +519,7 @@ static bool mount_extsd_fstab_entries(const std::vector<util::FstabRec> &extsd_r
 
         if (i < max_attempts - 1) {
             LOGW("No external SD patterns were matched; waiting 1 second");
-            sleep(1);
+            std::this_thread::sleep_for(1s);
         }
     }
 

--- a/odinupdater/odinupdater.cpp
+++ b/odinupdater/odinupdater.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2017  Andrew Gunnerson <andrewgunnerson@gmail.com>
+ * Copyright (C) 2016-2018  Andrew Gunnerson <andrewgunnerson@gmail.com>
  *
  * This file is part of DualBootPatcher
  *
@@ -18,7 +18,9 @@
  */
 
 #include <algorithm>
+#include <chrono>
 #include <memory>
+#include <thread>
 #include <vector>
 
 #include <cerrno>
@@ -692,6 +694,8 @@ static bool copy_dir_if_exists(const char *source_dir,
 // fuse mountpoint on the first try (kernel bug?)
 static bool retry_unmount(const char *mount_point, unsigned int attempts)
 {
+    using namespace std::chrono_literals;
+
     for (unsigned int attempt = 0; attempt < attempts; ++attempt) {
         info("[Attempt %d/%d] Unmounting %s",
              attempt + 1, attempts, mount_point);
@@ -701,7 +705,7 @@ static bool retry_unmount(const char *mount_point, unsigned int attempts)
                   mount_point, strerror(errno));
             info("[Attempt %d/%d] Waiting 1 second before next attempt",
                  attempt + 1, attempts);
-            sleep(1);
+            std::this_thread::sleep_for(1s);
             continue;
         }
 


### PR DESCRIPTION
std::this_thread::sleep_for() is more versatile and properly handles
EINTR (at least with libstdc++).

Signed-off-by: Andrew Gunnerson <andrewgunnerson@gmail.com>