### PR TITLE
libmbutil: remount_ro_done(): Fix incorrect check causing 1 minute delay during emergency reboot

### DIFF
--- a/libmbutil/src/reboot.cpp
+++ b/libmbutil/src/reboot.cpp
@@ -78,12 +78,12 @@ static bool remount_ro_done()
 
     for (auto const &entry : entries.value()) {
         if (starts_with(entry.source, "/dev/block")
-                && !starts_with(entry.vfs_options, "rw,")) {
-            return true;
+                && starts_with(entry.vfs_options, "rw,")) {
+            return false;
         }
     }
 
-    return false;
+    return true;
 }
 
 static bool remount_ro()


### PR DESCRIPTION
Signed-off-by: Andrew Gunnerson <andrewgunnerson@gmail.com>