### PR TITLE
libmbutil: Change file_read_all() to return std::string

### DIFF
--- a/examples/libmbpatcher_test.cpp
+++ b/examples/libmbpatcher_test.cpp
@@ -42,8 +42,7 @@ public:
     }
 };
 
-static bool file_read_all(const std::string &path,
-                          std::vector<unsigned char> &data_out)
+static bool file_read_all(const std::string &path, std::string &data_out)
 {
     FILE *fp = fopen(path.c_str(), "rbe");
     if (!fp) {
@@ -61,7 +60,7 @@ static bool file_read_all(const std::string &path,
         return false;
     }
 
-    std::vector<unsigned char> data(static_cast<size_t>(size));
+    std::string data(static_cast<size_t>(size), '\0');
     if (fread(data.data(), data.size(), 1, fp) != 1) {
         fclose(fp);
         return false;
@@ -75,7 +74,7 @@ static bool file_read_all(const std::string &path,
 
 static bool get_device(const char *path, mb::device::Device &device)
 {
-    std::vector<unsigned char> contents;
+    std::string contents;
     if (!file_read_all(path, contents)) {
         fprintf(stderr, "%s: Failed to read file: %s\n", path, strerror(errno));
         return false;
@@ -84,8 +83,7 @@ static bool get_device(const char *path, mb::device::Device &device)
 
     mb::device::JsonError error;
 
-    if (!mb::device::device_from_json(
-            reinterpret_cast<const char *>(contents.data()), device, error)) {
+    if (!mb::device::device_from_json(contents, device, error)) {
         fprintf(stderr, "%s: Failed to load devices\n", path);
         return false;
     }

--- a/libmbutil/include/mbutil/file.h
+++ b/libmbutil/include/mbutil/file.h
@@ -33,7 +33,7 @@ oc::result<void> file_write_data(const std::string &path,
                                  const void *data, size_t size);
 oc::result<bool> file_find_one_of(const std::string &path,
                                   const std::vector<std::string> &items);
-oc::result<std::vector<unsigned char>> file_read_all(const std::string &path);
+oc::result<std::string> file_read_all(const std::string &path);
 
 oc::result<uint64_t> get_blockdev_size(const std::string &path);
 

--- a/libmbutil/src/cmdline.cpp
+++ b/libmbutil/src/cmdline.cpp
@@ -35,10 +35,9 @@ oc::result<KernelCmdlineArgs> kernel_cmdline()
         data.pop_back();
     }
 
-    std::string_view args(reinterpret_cast<char *>(data.data()), data.size());
     KernelCmdlineArgs result;
 
-    for (auto const &item : split_sv(args, " ")) {
+    for (auto const &item : split_sv(data, " ")) {
         if (item.empty()) {
             continue;
         }

--- a/libmbutil/src/file.cpp
+++ b/libmbutil/src/file.cpp
@@ -176,7 +176,7 @@ oc::result<bool> file_find_one_of(const std::string &path,
     return false;
 }
 
-oc::result<std::vector<unsigned char>> file_read_all(const std::string &path)
+oc::result<std::string> file_read_all(const std::string &path)
 {
     ScopedFILE fp(fopen(path.c_str(), "rbe"), fclose);
     if (!fp) {
@@ -196,7 +196,7 @@ oc::result<std::vector<unsigned char>> file_read_all(const std::string &path)
         return ec_from_errno();
     }
 
-    std::vector<unsigned char> data(static_cast<size_t>(size));
+    std::string data(static_cast<size_t>(size), '\0');
 
     if (fread(data.data(), data.size(), 1, fp.get()) != 1) {
         if (ferror(fp.get())) {

--- a/mbbootui/main.cpp
+++ b/mbbootui/main.cpp
@@ -110,12 +110,10 @@ static bool detect_device()
              contents.error().message().c_str());
         return false;
     }
-    contents.value().push_back('\0');
 
     JsonError error;
 
-    if (!device_from_json(reinterpret_cast<char *>(contents.value().data()),
-                          tw_device, error)) {
+    if (!device_from_json(contents.value(), tw_device, error)) {
         LOGE("%s: Failed to load device", DEVICE_JSON_PATH);
         return false;
     }

--- a/mbtool/emergency.cpp
+++ b/mbtool/emergency.cpp
@@ -160,11 +160,7 @@ bool emergency_reboot()
 
     auto contents = util::file_read_all(DEVICE_JSON_PATH);
     if (contents) {
-        contents.value().push_back('\0');
-
-        loaded_json = device_from_json(
-                reinterpret_cast<char *>(contents.value().data()),
-                device, error);
+        loaded_json = device_from_json(contents.value(), device, error);
     }
 
     // /data

--- a/mbtool/init.cpp
+++ b/mbtool/init.cpp
@@ -1171,7 +1171,6 @@ int init_main(int argc, char *argv[])
         critical_failure();
         return EXIT_FAILURE;
     }
-    contents.value().push_back('\0');
 
     // Start probing for devices so we have somewhere to write logs for
     // critical_failure()
@@ -1181,8 +1180,7 @@ int init_main(int argc, char *argv[])
     Device device;
     JsonError error;
 
-    if (!device_from_json(reinterpret_cast<char *>(
-            contents.value().data()), device, error)) {
+    if (!device_from_json(contents.value(), device, error)) {
         LOGE("%s: Failed to load device definition", DEVICE_JSON_PATH);
         critical_failure();
         return EXIT_FAILURE;

--- a/mbtool/installer.cpp
+++ b/mbtool/installer.cpp
@@ -1351,12 +1351,10 @@ Installer::ProceedState Installer::install_stage_check_device()
         display_msg("Failed to read device.json");
         return ProceedState::Fail;
     }
-    contents.value().push_back('\0');
 
     JsonError error;
 
-    if (!device_from_json(reinterpret_cast<char *>(contents.value().data()),
-                          _device, error)) {
+    if (!device_from_json(contents.value(), _device, error)) {
         display_msg("Error when loading device.json");
         return ProceedState::Fail;
     }

--- a/mbtool/switcher.cpp
+++ b/mbtool/switcher.cpp
@@ -176,7 +176,7 @@ struct Flashable
     std::string block_dev;
     std::string expected_hash;
     std::string hash;
-    std::vector<unsigned char> data;
+    std::string data;
 };
 
 /*!
@@ -358,7 +358,8 @@ SwitchRomResult switch_rom(const std::string &id,
 
         // Get actual sha512sum
         std::array<unsigned char, SHA512_DIGEST_LENGTH> digest;
-        SHA512(f.data.data(), f.data.size(), digest.data());
+        SHA512(reinterpret_cast<const unsigned char *>(f.data.data()),
+               f.data.size(), digest.data());
         f.hash = util::hex_string(digest.data(), digest.size());
 
         if (force_update_checksums) {
@@ -459,7 +460,8 @@ bool set_kernel(const std::string &id, const std::string &boot_blockdev)
 
     // Get actual sha512sum
     std::array<unsigned char, SHA512_DIGEST_LENGTH> digest;
-    SHA512(data.value().data(), data.value().size(), digest.data());
+    SHA512(reinterpret_cast<const unsigned char *>(data.value().data()),
+           data.value().size(), digest.data());
     std::string hash = util::hex_string(digest.data(), digest.size());
 
     // Add to checksums.prop

--- a/mbtool/utilities.cpp
+++ b/mbtool/utilities.cpp
@@ -78,13 +78,11 @@ static bool get_device(const char *path, Device &device)
              contents.error().message().c_str());
         return false;
     }
-    contents.value().push_back('\0');
 
     std::vector<Device> devices;
     JsonError error;
 
-    if (!device_list_from_json(reinterpret_cast<const char *>(
-            contents.value().data()), devices, error)) {
+    if (!device_list_from_json(contents.value(), devices, error)) {
         LOGE("%s: Failed to load devices", path);
         return false;
     }
@@ -207,10 +205,8 @@ static bool utilities_wipe_multiboot(const char *rom_id)
     return wipe_multiboot(rom);
 }
 
-static void generate_aroma_config(std::vector<unsigned char> &data)
+static void generate_aroma_config(std::string &data)
 {
-    std::string str_data(data.begin(), data.end());
-
     std::string rom_menu_items;
     std::string rom_selection_items;
 
@@ -241,19 +237,17 @@ static void generate_aroma_config(std::vector<unsigned char> &data)
     std::string first_index = format("%d", 2 + 1);
     std::string last_index = format("%zu", 2 + roms.roms.size());
 
-    util::replace_all(str_data, "\t", "\\t");
-    util::replace_all(str_data, "@MBTOOL_VERSION@", version());
-    util::replace_all(str_data, "@ROM_MENU_ITEMS@", rom_menu_items);
-    util::replace_all(str_data, "@ROM_SELECTION_ITEMS@", rom_selection_items);
-    util::replace_all(str_data, "@FIRST_INDEX@", first_index);
-    util::replace_all(str_data, "@LAST_INDEX@", last_index);
+    util::replace_all(data, "\t", "\\t");
+    util::replace_all(data, "@MBTOOL_VERSION@", version());
+    util::replace_all(data, "@ROM_MENU_ITEMS@", rom_menu_items);
+    util::replace_all(data, "@ROM_SELECTION_ITEMS@", rom_selection_items);
+    util::replace_all(data, "@FIRST_INDEX@", first_index);
+    util::replace_all(data, "@LAST_INDEX@", last_index);
 
-    util::replace_all(str_data, "@SYSTEM_MOUNT_POINT@", Roms::get_system_partition());
-    util::replace_all(str_data, "@CACHE_MOUNT_POINT@", Roms::get_cache_partition());
-    util::replace_all(str_data, "@DATA_MOUNT_POINT@", Roms::get_data_partition());
-    util::replace_all(str_data, "@EXTSD_MOUNT_POINT@", Roms::get_extsd_partition());
-
-    data.assign(str_data.begin(), str_data.end());
+    util::replace_all(data, "@SYSTEM_MOUNT_POINT@", Roms::get_system_partition());
+    util::replace_all(data, "@CACHE_MOUNT_POINT@", Roms::get_cache_partition());
+    util::replace_all(data, "@DATA_MOUNT_POINT@", Roms::get_data_partition());
+    util::replace_all(data, "@EXTSD_MOUNT_POINT@", Roms::get_extsd_partition());
 }
 
 class AromaGenerator : public util::FtsWrapper


### PR DESCRIPTION
There are more/better helper functions for std::string and there's no
reason not to use it now that std::string::data() returns a mutable
pointer in C++17.

Signed-off-by: Andrew Gunnerson <andrewgunnerson@gmail.com>