### PR TITLE
mbtool: daemon: Don't unshare mount namespace in listening process

### DIFF
--- a/mbtool/daemon.cpp
+++ b/mbtool/daemon.cpp
@@ -565,11 +565,6 @@ int daemon_main(int argc, char *argv[])
         return EXIT_FAILURE;
     }
 
-    if (!no_unshare && unshare(CLONE_NEWNS) < 0) {
-        fprintf(stderr, "unshare() failed: %s\n", strerror(errno));
-        return EXIT_FAILURE;
-    }
-
     if (patch_sepolicy) {
         patch_loaded_sepolicy(SELinuxPatch::Main);
     }


### PR DESCRIPTION
Creating a new mount namespace in the main/listening process of the
mbtool daemon causes apps to not be able to access the internal storage
on TouchWiz Oreo ROMs (at least in the G955FXXU1CRD7 firmware).

This change shouldn't affect anything since the main process didn't
mount anything anyway. The child processes spawned when a connections
are made will still unshare their mount namespaces.

Fixes: #1167

Signed-off-by: Andrew Gunnerson <andrewgunnerson@gmail.com>