### PR TITLE
Store DualBootPatcher properties in /dbp.prop instead of /default.prop

### DIFF
--- a/mbtool/include/util/property_service.h
+++ b/mbtool/include/util/property_service.h
@@ -46,6 +46,8 @@ public:
     void load_boot_props();
     void load_system_props();
 
+    bool load_properties_file(const std::string &path, std::string_view filter);
+
 private:
     bool m_initialized;
     int m_setter_fd;
@@ -61,6 +63,4 @@ private:
     void socket_handle_set_property_impl(SocketConnection &socket,
                                          const std::string &name,
                                          std::string_view value, bool legacy);
-
-    bool load_properties_file(const std::string &path, std::string_view filter);
 };

--- a/mbtool/installer.cpp
+++ b/mbtool/installer.cpp
@@ -1874,7 +1874,8 @@ Installer::ProceedState Installer::install_stage_finish()
 
     std::vector<std::function<RamdiskPatcherFn>> rps{
         rp_write_rom_id(_rom->id),
-        rp_patch_default_prop(_detected_device, _use_fuse_exfat),
+        rp_restore_default_prop(),
+        rp_add_dbp_prop(_detected_device, _use_fuse_exfat),
         rp_add_binaries(_temp + "/binaries"),
         rp_symlink_fuse_exfat(),
         rp_symlink_init(),

--- a/mbtool/mount_fstab.cpp
+++ b/mbtool/mount_fstab.cpp
@@ -377,8 +377,7 @@ static bool try_extsd_mount(const char *block_dev, const char *mount_point)
         use_fuse_exfat = true;
     }
 
-    std::string value = util::property_file_get_string(
-            DEFAULT_PROP_PATH, PROP_USE_FUSE_EXFAT, "");
+    std::string value = util::property_get_string(PROP_USE_FUSE_EXFAT, "");
     if (!value.empty()) {
         LOGD("fuse-exfat override: %s", value.c_str());
         if (value == "true") {

--- a/mbtool/multiboot.h
+++ b/mbtool/multiboot.h
@@ -34,6 +34,7 @@
 #define PACKAGES_XML                    "/data/system/packages.xml"
 
 #define DEFAULT_PROP_PATH               "/default.prop"
+#define DBP_PROP_PATH                   "/dbp.prop"
 
 #define DEVICE_JSON_PATH                "/device.json"
 

--- a/mbtool/ramdisk_patcher.h
+++ b/mbtool/ramdisk_patcher.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017  Andrew Gunnerson <andrewgunnerson@gmail.com>
+ * Copyright (C) 2017-2018  Andrew Gunnerson <andrewgunnerson@gmail.com>
  *
  * This file is part of DualBootPatcher
  *
@@ -26,13 +26,16 @@
 namespace mb
 {
 
-typedef bool (RamdiskPatcherFn)(const std::string &dir);
+using RamdiskPatcherFn = bool(const std::string &dir);
 
 std::function<RamdiskPatcherFn>
 rp_write_rom_id(const std::string &rom_id);
 
 std::function<RamdiskPatcherFn>
-rp_patch_default_prop(const std::string &device_id, bool use_fuse_exfat);
+rp_restore_default_prop();
+
+std::function<RamdiskPatcherFn>
+rp_add_dbp_prop(const std::string &device_id, bool use_fuse_exfat);
 
 std::function<RamdiskPatcherFn>
 rp_add_binaries(const std::string &binaries_dir);


### PR DESCRIPTION
Some devices have `/default.prop` symlinked to some other file that's not in the ramdisk, which prevents properties from being written to it during installation. The properties don't really have to live in that file though. This PR updates mbtool to write the properties to `/dbp.prop` and ensures that it gets loaded during boot. For mbtool's pre-boot phase, the file is explicitly loaded to the property service. For the Android init phase, a oneshot service is added to load the file.

Fixes: #1191