### PR TITLE
mbtool: installer_util.cpp: Choose a temp dir that always exists

### DIFF
--- a/mbtool/installer_util.cpp
+++ b/mbtool/installer_util.cpp
@@ -477,7 +477,7 @@ bool InstallerUtil::patch_ramdisk(const std::string &input_file,
     }
 
     // Must not be a symlink or ARCHIVE_EXTRACT_SECURE_SYMLINKS will not work
-    std::string tmpdir("/tmp/mbtool.XXXXXX");
+    std::string tmpdir("/multiboot/mbtool.XXXXXX");
 
     if (!mkdtemp(tmpdir.data())) {
         LOGE("Failed to create temporary directory: %s", strerror(errno));


### PR DESCRIPTION
Signed-off-by: Andrew Gunnerson <andrewgunnerson@gmail.com>