### PR TITLE
Update 02_galaxy_a_j.yml

### DIFF
--- a/data/devices/samsung/02_galaxy_a_j.yml
+++ b/data/devices/samsung/02_galaxy_a_j.yml
@@ -624,3 +624,56 @@
     graphics_backends:
       - fbdev
     theme: portrait_hdpi
+
+
+- name: Samsung Galaxy Docomo J
+  id: js01lte
+  codenames:
+    - js01lte
+    - js01lte-dcm
+    - sc02f
+    - SC02F
+    - SC-02F
+  architecture: armeabi-v7a
+
+  block_devs:
+    base_dirs:
+      - /dev/block/platform/msm_sdcc.1/by-name
+      - /dev/block/bootdevice/by-name
+    system:
+      - /dev/block/platform/msm_sdcc.1/by-name/system
+      - /dev/block/bootdevice/by-name/system
+      - /dev/block/mmcblk0p23
+    cache:
+      - /dev/block/platform/msm_sdcc.1/by-name/cache
+      - /dev/block/bootdevice/by-name/cache
+      - /dev/block/mmcblk0p24
+    data:
+      - /dev/block/platform/msm_sdcc.1/by-name/userdata
+      - /dev/block/bootdevice/by-name/userdata
+      - /dev/block/mmcblk0p25
+    boot:
+      - /dev/block/platform/msm_sdcc.1/by-name/boot
+      - /dev/block/bootdevice/by-name/boot
+      - /dev/block/mmcblk0p14
+    recovery:
+      - /dev/block/platform/msm_sdcc.1/by-name/recovery
+      - /dev/block/bootdevice/recovery
+      - /dev/block/mmcblk0p15
+    extra:
+      - /dev/block/platform/msm_sdcc.1/by-name/modem
+      - /dev/block/bootdevice/modem
+      - /dev/block/mmcblk0p2
+
+  boot_ui:
+    supported: true
+    flags:
+      - TW_QCOM_RTC_FIX
+      - TW_HAS_DOWNLOAD_MODE
+    graphics_backends:
+      - fbdev
+    brightness_path: /sys/devices/mdp.0/qcom,mdss_fb_primary.173/leds/lcd-backlight/brightness
+    max_brightness: 255
+    default_brightness: 162
+    pixel_format: RGBX_8888
+    theme: portrait_hdpi


### PR DESCRIPTION
- name: Samsung Galaxy Docomo J
  id: js01lte
  codenames:
    - js01lte
    - js01lte-dcm
    - sc02f
    - SC02F
    - SC-02F
  architecture: armeabi-v7a

  block_devs:
    base_dirs:
      - /dev/block/platform/msm_sdcc.1/by-name
      - /dev/block/bootdevice/by-name
    system:
      - /dev/block/platform/msm_sdcc.1/by-name/system
      - /dev/block/bootdevice/by-name/system
      - /dev/block/mmcblk0p23
    cache:
      - /dev/block/platform/msm_sdcc.1/by-name/cache
      - /dev/block/bootdevice/by-name/cache
      - /dev/block/mmcblk0p24
    data:
      - /dev/block/platform/msm_sdcc.1/by-name/userdata
      - /dev/block/bootdevice/by-name/userdata
      - /dev/block/mmcblk0p25
    boot:
      - /dev/block/platform/msm_sdcc.1/by-name/boot
      - /dev/block/bootdevice/by-name/boot
      - /dev/block/mmcblk0p14
    recovery:
      - /dev/block/platform/msm_sdcc.1/by-name/recovery
      - /dev/block/bootdevice/recovery
      - /dev/block/mmcblk0p15
    extra:
      - /dev/block/platform/msm_sdcc.1/by-name/modem
      - /dev/block/bootdevice/modem
      - /dev/block/mmcblk0p2

  boot_ui:
    supported: true
    flags:
      - TW_QCOM_RTC_FIX
      - TW_HAS_DOWNLOAD_MODE
    graphics_backends:
      - fbdev
    brightness_path: /sys/devices/mdp.0/qcom,mdss_fb_primary.173/leds/lcd-backlight/brightness
    max_brightness: 255
    default_brightness: 162
    pixel_format: RGBX_8888
    theme: portrait_hdpi