### PR TITLE
mbtool: Fix boot image corruption caused by reading and writing to the same file

### DIFF
--- a/Android_GUI/src/com/github/chenxiaolong/dualbootpatcher/socket/MbtoolUtils.kt
+++ b/Android_GUI/src/com/github/chenxiaolong/dualbootpatcher/socket/MbtoolUtils.kt
@@ -37,7 +37,7 @@ object MbtoolUtils {
             // Snapshot builds
             minVersionMap[Feature.DAEMON] = Version("9.1.0.r54")
             minVersionMap[Feature.APP_SHARING] = Version("8.0.0.r2155")
-            minVersionMap[Feature.IN_APP_INSTALLATION] = Version("8.0.0.r2859")
+            minVersionMap[Feature.IN_APP_INSTALLATION] = Version("9.3.0.r768")
         } else {
             // Debug/release builds
             minVersionMap[Feature.DAEMON] = Version("9.1.0")

--- a/mbtool/installer_util.cpp
+++ b/mbtool/installer_util.cpp
@@ -395,6 +395,8 @@ bool InstallerUtil::patch_boot_image(const std::string &input_file,
         }
 
         auto type = out_entry.type();
+        LOGD("%s: Writer is requesting entry type: %d",
+             output_file.c_str(), *type);
 
         // Write entry metadata
         ret = writer.write_entry(out_entry);
@@ -406,6 +408,9 @@ bool InstallerUtil::patch_boot_image(const std::string &input_file,
 
         // Special case for loki aboot
         if (*type == ENTRY_TYPE_ABOOT) {
+            LOGD("%s: Copying aboot partition: %s",
+                 output_file.c_str(), ABOOT_PARTITION);
+
             if (bi_copy_file_to_data(ABOOT_PARTITION, writer)) {
                 return false;
             }
@@ -413,7 +418,8 @@ bool InstallerUtil::patch_boot_image(const std::string &input_file,
             ret = reader.go_to_entry(in_entry, *type);
             if (!ret) {
                 if (ret.error() == ReaderError::EndOfEntries) {
-                    LOGV("Skipping non existent boot image entry: %d", *type);
+                    LOGV("%s: Skipping non-existent boot image entry: %d",
+                         input_file.c_str(), *type);
                     continue;
                 } else {
                     LOGE("%s: Failed to go to entry: %d: %s",
@@ -424,6 +430,8 @@ bool InstallerUtil::patch_boot_image(const std::string &input_file,
             }
 
             if (type == ENTRY_TYPE_RAMDISK) {
+                LOGD("%s: Writing patched ramdisk", output_file.c_str());
+
                 std::string ramdisk_in(tmpdir);
                 ramdisk_in += "/ramdisk.in";
                 std::string ramdisk_out(tmpdir);
@@ -446,6 +454,8 @@ bool InstallerUtil::patch_boot_image(const std::string &input_file,
                     return false;
                 }
             } else if (type == ENTRY_TYPE_KERNEL) {
+                LOGD("%s: Writing patched kernel", output_file.c_str());
+
                 std::string kernel_in(tmpdir);
                 kernel_in += "/kernel.in";
                 std::string kernel_out(tmpdir);
@@ -468,6 +478,8 @@ bool InstallerUtil::patch_boot_image(const std::string &input_file,
                     return false;
                 }
             } else {
+                LOGD("%s: Copying entry directly", output_file.c_str());
+
                 // Copy entry directly
                 if (!bi_copy_data_to_data(reader, writer)) {
                     return false;

--- a/mbtool/installer_util.cpp
+++ b/mbtool/installer_util.cpp
@@ -312,7 +312,7 @@ bool InstallerUtil::pack_ramdisk(const std::string &input_dir,
 
 bool InstallerUtil::patch_boot_image(const std::string &input_file,
                                      const std::string &output_file,
-                                     std::vector<std::function<RamdiskPatcherFn>> &rps)
+                                     const std::vector<std::function<RamdiskPatcherFn>> &rps)
 {
     std::string tmpdir = format("%s.XXXXXX", output_file.c_str());
 
@@ -489,7 +489,7 @@ bool InstallerUtil::patch_boot_image(const std::string &input_file,
 bool InstallerUtil::patch_ramdisk(const std::string &input_file,
                                   const std::string &output_file,
                                   unsigned int depth,
-                                  std::vector<std::function<RamdiskPatcherFn>> &rps)
+                                  const std::vector<std::function<RamdiskPatcherFn>> &rps)
 {
     if (depth > 1) {
         LOGV("Ignoring doubly-nested ramdisk");
@@ -536,7 +536,7 @@ bool InstallerUtil::patch_ramdisk(const std::string &input_file,
 }
 
 bool InstallerUtil::patch_ramdisk_dir(const std::string &ramdisk_dir,
-                                      std::vector<std::function<RamdiskPatcherFn>> &rps)
+                                      const std::vector<std::function<RamdiskPatcherFn>> &rps)
 {
     for (auto const &rp : rps) {
         if (!rp(ramdisk_dir)) {

--- a/mbtool/installer_util.h
+++ b/mbtool/installer_util.h
@@ -42,13 +42,13 @@ public:
 
     static bool patch_boot_image(const std::string &input_file,
                                  const std::string &output_file,
-                                 std::vector<std::function<RamdiskPatcherFn>> &rps);
+                                 const std::vector<std::function<RamdiskPatcherFn>> &rps);
     static bool patch_ramdisk(const std::string &input_file,
                               const std::string &output_file,
                               unsigned int depth,
-                              std::vector<std::function<RamdiskPatcherFn>> &rps);
+                              const std::vector<std::function<RamdiskPatcherFn>> &rps);
     static bool patch_ramdisk_dir(const std::string &ramdisk_dir,
-                                  std::vector<std::function<RamdiskPatcherFn>> &rps);
+                                  const std::vector<std::function<RamdiskPatcherFn>> &rps);
     static bool patch_kernel_rkp(const std::string &input_file,
                                  const std::string &output_file);
 


### PR DESCRIPTION
Prior to flashing the zip, mbtool will flash the kernel for the target ROM and undo some ramdisk patches (specifically the `/init` symlink patch). However, `InstallerUtil::patch_boot_image()` was being invoked with the same path for the input and output files, leading to corruption of boot image entries that were directly copied. This included any entry that was not the kernel or ramdisk.

The device tree entry was most commonly corrupted and would manifest via boot loops or other hardware initialization failures, such as a modem boot failure on the Galaxy S8+.

This issue only affected zips that modify the existing boot image, like Magisk or Anykernel-based zips. ROMs that overwrote the boot partition were not affected.

A warning message will be posted at https://dbp.noobdev.io/downloads/ advising users to use the new version and reflash all of their ROMs.