### PR TITLE
Include alternative codename of Axon 7

### DIFF
--- a/data/devices/zte.yml
+++ b/data/devices/zte.yml
@@ -3,6 +3,7 @@
   id: ailsa_ii
   codenames:
     - ailsa_ii
+    - axon7
   architecture: arm64-v8a
 
   block_devs:


### PR DESCRIPTION
Add alternative codename 'axon7' to support more recoveries, especially newer ones that report the Axon 7 as 'axon7' rather than the old 'ailsa_ii'. Reason is that at the moment dualboot patcher patched zips for the Axon 7 refuse to be flashed on newer (Oreo) recoveries because the device is called 'axon7' now.