### PR TITLE
Update and Fixed Some Lava  Devices (Face Unfortunately app has stopped)

### DIFF
--- a/data/devices/lava.yml
+++ b/data/devices/lava.yml
@@ -1,11 +1,12 @@
 ---
-- name: Lava Iris 820
+- name: Lava iris 820
   id: lava_iris820
   codenames:
-    - Lava_Iris820
     - lava_iris820
-    - Iris820
-    - lava6580_sp502
+    - lava_iris820
+    - iris820
+    - iris820
+    - iris820
   architecture: armeabi-v7a
 
   block_devs:
@@ -13,17 +14,19 @@
       - /dev/block/platform/mtk-msdc.0/by-name
     system:
       - /dev/block/platform/mtk-msdc.0/by-name/system
-      - /dev/block/mmcblk0p18
+      - /dev/block/mmcblk0p17
     cache:
       - /dev/block/platform/mtk-msdc.0/by-name/cache
-      - /dev/block/mmcblk0p19
+      - /dev/block/mmcblk0p18
     data:
       - /dev/block/platform/mtk-msdc.0/by-name/userdata
-      - /dev/block/mmcblk0p20
+      - /dev/block/mmcblk0p19
     boot:
       - /dev/block/platform/mtk-msdc.0/by-name/boot
+      - /dev/block/mmcblk0p7
     recovery:
       - /dev/block/platform/mtk-msdc.0/by-name/recovery
+      - /dev/block/mmcblk0p8
 
   boot_ui:
     supported: yes
@@ -34,12 +37,12 @@
     cpu_temp_path:  /sys/devices/virtual/thermal/thermal_zone1/temp
     theme: portrait_hdpi
 
-- name: Lava Iris821
+- name: Lava iris 821
   id: lava_iris821
   codenames:
-    - Lava_Iris821
     - lava_iris821
-    - Iris821
+    - lava_iris821
+    - iris821
     - iris821
   architecture: armeabi-v7a
 
@@ -71,31 +74,39 @@
     cpu_temp_path:  /sys/devices/virtual/thermal/thermal_zone1/temp
     theme: portrait_hdpi
     
-- name: Lava Iris 860
+- name: Lava iris 860
   id: lava_iris860
   codenames:
-    - Lava_Iris860
     - lava_iris860
-    - Iris860
-    - lava35p_b501
+    - lava_iris860
+    - iris860
+    - iris860
   architecture: arm64-v8a
 
   block_devs:
     base_dirs:
       - /dev/block/platform/mtk-msdc.0/by-name
+      - /dev/block/platform/mtk-msdc.0/11230000.msdc0/by-name
     system:
       - /dev/block/platform/mtk-msdc.0/by-name/system
-      - /dev/block/mmcblk0p19
+      - /dev/block/platform/mtk-msdc.0/11230000.msdc0/by-name/system
+      - /dev/block/mmcblk0p20
     cache:
       - /dev/block/platform/mtk-msdc.0/by-name/cache
-      - /dev/block/mmcblk0p20
+      - /dev/block/platform/mtk-msdc.0/11230000.msdc0/by-name/cache
+      - /dev/block/mmcblk0p21
     data:
       - /dev/block/platform/mtk-msdc.0/by-name/userdata
-      - /dev/block/mmcblk0p21
+      - /dev/block/platform/mtk-msdc.0/11230000.msdc0/by-name/userdata
+      - /dev/block/mmcblk0p22
     boot:
       - /dev/block/platform/mtk-msdc.0/by-name/boot
+      - /dev/block/platform/mtk-msdc.0/11230000.msdc0/by-name/boot
+      - /dev/block/mmcblk0p7
     recovery:
       - /dev/block/platform/mtk-msdc.0/by-name/recovery
+      - /dev/block/platform/mtk-msdc.0/11230000.msdc0/by-name/recovery
+      - /dev/block/mmcblk0p8
 
   boot_ui:
     supported: yes
@@ -103,35 +114,45 @@
       - fbdev
     brightness_path: /sys/class/leds/lcd-backlight/brightness
     max_brightness: 255
+    default_brightness: 162
+    pixel_format: RGBA_8888
     cpu_temp_path:  /sys/devices/virtual/thermal/thermal_zone1/temp
     theme: portrait_hdpi
 
-- name: Lava Iris 870
+- name: Lava iris 870
   id: lava_iris870
   codenames:
-    - Lava_Iris870
+    - lava_iris870
     - lava_iris8670
     - iris870
-    - lava6737m_sp504_int
+    - iris870
     
   architecture: arm64-v8a
 
   block_devs:
     base_dirs:
       - /dev/block/platform/mtk-msdc.0/by-name
+      - /dev/block/platform/mtk-msdc.0/11230000.msdc0/by-name
     system:
       - /dev/block/platform/mtk-msdc.0/by-name/system
-      - /dev/block/mmcblk0p19
+      - /dev/block/platform/mtk-msdc.0/11230000.msdc0/by-name/system
+      - /dev/block/mmcblk0p20
     cache:
       - /dev/block/platform/mtk-msdc.0/by-name/cache
-      - /dev/block/mmcblk0p20
+      - /dev/block/platform/mtk-msdc.0/11230000.msdc0/by-name/cache
+      - /dev/block/mmcblk0p21
     data:
       - /dev/block/platform/mtk-msdc.0/by-name/userdata
-      - /dev/block/mmcblk0p21
+      - /dev/block/platform/mtk-msdc.0/11230000.msdc0/by-name/userdata
+      - /dev/block/mmcblk0p22
     boot:
       - /dev/block/platform/mtk-msdc.0/by-name/boot
+      - /dev/block/platform/mtk-msdc.0/11230000.msdc0/by-name/boot
+      - /dev/block/mmcblk0p7
     recovery:
       - /dev/block/platform/mtk-msdc.0/by-name/recovery
+      - /dev/block/platform/mtk-msdc.0/11230000.msdc0/by-name/recovery
+      - /dev/block/mmcblk0p8
 
   boot_ui:
     supported: yes
@@ -139,34 +160,45 @@
       - fbdev
     brightness_path: /sys/class/leds/lcd-backlight/brightness
     max_brightness: 255
+    default_brightness: 162
+    pixel_format: RGBA_8888
     cpu_temp_path:  /sys/devices/virtual/thermal/thermal_zone1/temp
     theme: portrait_hdpi
 
-- name: Lava Pixel V2
+- name: Lava pixel v2
   id: lava_pixelv2
   codenames:
     - lava_pixelv2
+    - lava_pixelv2
     - pixelv2
-    - lava6735p_sp31_lte
+    - pixelv2
 
   architecture: arm64-v8a
 
   block_devs:
     base_dirs:
       - /dev/block/platform/mtk-msdc.0/by-name
+      - /dev/block/platform/mtk-msdc.0/11230000.msdc0/by-name
     system:
       - /dev/block/platform/mtk-msdc.0/by-name/system
-      - /dev/block/mmcblk0p19
+      - /dev/block/platform/mtk-msdc.0/11230000.msdc0/by-name/system
+      - /dev/block/mmcblk0p20
     cache:
       - /dev/block/platform/mtk-msdc.0/by-name/cache
-      - /dev/block/mmcblk0p20
+      - /dev/block/platform/mtk-msdc.0/11230000.msdc0/by-name/cache
+      - /dev/block/mmcblk0p21
     data:
       - /dev/block/platform/mtk-msdc.0/by-name/userdata
-      - /dev/block/mmcblk0p21
+      - /dev/block/platform/mtk-msdc.0/11230000.msdc0/by-name/userdata
+      - /dev/block/mmcblk0p22
     boot:
       - /dev/block/platform/mtk-msdc.0/by-name/boot
+      - /dev/block/platform/mtk-msdc.0/11230000.msdc0/by-name/boot
+      - /dev/block/mmcblk0p7
     recovery:
       - /dev/block/platform/mtk-msdc.0/by-name/recovery
+      - /dev/block/platform/mtk-msdc.0/11230000.msdc0/by-name/recovery
+      - /dev/block/mmcblk0p8
 
   boot_ui:
     supported: yes
@@ -174,11 +206,13 @@
       - fbdev
     brightness_path: /sys/class/leds/lcd-backlight/brightness
     max_brightness: 255
+    default_brightness: 162
+    pixel_format: RGBA_8888
     cpu_temp_path:  /sys/devices/virtual/thermal/thermal_zone1/temp
     theme: portrait_hdpi
 
 
-- name: LAVA iris X1Beats
+- name: LAVA iris X1 Beats
   id: X1Beats
   codenames:
       - LAVA iris X1Beats


### PR DESCRIPTION
---
- name: Lava iris 820
  id: lava_iris820
  codenames:
    - lava_iris820
    - lava_iris820
    - iris820
    - iris820
    - iris820
  architecture: armeabi-v7a

  block_devs:
    base_dirs:
      - /dev/block/platform/mtk-msdc.0/by-name
    system:
      - /dev/block/platform/mtk-msdc.0/by-name/system
      - /dev/block/mmcblk0p17
    cache:
      - /dev/block/platform/mtk-msdc.0/by-name/cache
      - /dev/block/mmcblk0p18
    data:
      - /dev/block/platform/mtk-msdc.0/by-name/userdata
      - /dev/block/mmcblk0p19
    boot:
      - /dev/block/platform/mtk-msdc.0/by-name/boot
      - /dev/block/mmcblk0p7
    recovery:
      - /dev/block/platform/mtk-msdc.0/by-name/recovery
      - /dev/block/mmcblk0p8

  boot_ui:
    supported: yes
    graphics_backends:
      - fbdev
    brightness_path: /sys/class/leds/lcd-backlight/brightness
    max_brightness: 255
    cpu_temp_path:  /sys/devices/virtual/thermal/thermal_zone1/temp
    theme: portrait_hdpi

- name: Lava iris 821
  id: lava_iris821
  codenames:
    - lava_iris821
    - lava_iris821
    - iris821
    - iris821
  architecture: armeabi-v7a

  block_devs:
    base_dirs:
      - /dev/block/platform/mtk-msdc.0/by-name
    system:
      - /dev/block/platform/mtk-msdc.0/by-name/system
      - /dev/block/mmcblk0p17
    cache:
      - /dev/block/platform/mtk-msdc.0/by-name/cache
      - /dev/block/mmcblk0p18
    data:
      - /dev/block/platform/mtk-msdc.0/by-name/userdata
      - /dev/block/mmcblk0p19
    boot:
      - /dev/block/platform/mtk-msdc.0/by-name/boot
      - /dev/block/mmcblk0p7
    recovery:
      - /dev/block/platform/mtk-msdc.0/by-name/recovery
      - /dev/block/mmcblk0p8

  boot_ui:
    supported: yes
    graphics_backends:
      - fbdev
    brightness_path: /sys/class/leds/lcd-backlight/brightness
    max_brightness: 255
    cpu_temp_path:  /sys/devices/virtual/thermal/thermal_zone1/temp
    theme: portrait_hdpi
    
- name: Lava iris 860
  id: lava_iris860
  codenames:
    - lava_iris860
    - lava_iris860
    - iris860
    - iris860
  architecture: arm64-v8a

  block_devs:
    base_dirs:
      - /dev/block/platform/mtk-msdc.0/by-name
      - /dev/block/platform/mtk-msdc.0/11230000.msdc0/by-name
    system:
      - /dev/block/platform/mtk-msdc.0/by-name/system
      - /dev/block/platform/mtk-msdc.0/11230000.msdc0/by-name/system
      - /dev/block/mmcblk0p20
    cache:
      - /dev/block/platform/mtk-msdc.0/by-name/cache
      - /dev/block/platform/mtk-msdc.0/11230000.msdc0/by-name/cache
      - /dev/block/mmcblk0p21
    data:
      - /dev/block/platform/mtk-msdc.0/by-name/userdata
      - /dev/block/platform/mtk-msdc.0/11230000.msdc0/by-name/userdata
      - /dev/block/mmcblk0p22
    boot:
      - /dev/block/platform/mtk-msdc.0/by-name/boot
      - /dev/block/platform/mtk-msdc.0/11230000.msdc0/by-name/boot
      - /dev/block/mmcblk0p7
    recovery:
      - /dev/block/platform/mtk-msdc.0/by-name/recovery
      - /dev/block/platform/mtk-msdc.0/11230000.msdc0/by-name/recovery
      - /dev/block/mmcblk0p8

  boot_ui:
    supported: yes
    graphics_backends:
      - fbdev
    brightness_path: /sys/class/leds/lcd-backlight/brightness
    max_brightness: 255
    default_brightness: 162
    pixel_format: RGBA_8888
    cpu_temp_path:  /sys/devices/virtual/thermal/thermal_zone1/temp
    theme: portrait_hdpi

- name: Lava iris 870
  id: lava_iris870
  codenames:
    - lava_iris870
    - lava_iris8670
    - iris870
    - iris870
    
  architecture: arm64-v8a

  block_devs:
    base_dirs:
      - /dev/block/platform/mtk-msdc.0/by-name
      - /dev/block/platform/mtk-msdc.0/11230000.msdc0/by-name
    system:
      - /dev/block/platform/mtk-msdc.0/by-name/system
      - /dev/block/platform/mtk-msdc.0/11230000.msdc0/by-name/system
      - /dev/block/mmcblk0p20
    cache:
      - /dev/block/platform/mtk-msdc.0/by-name/cache
      - /dev/block/platform/mtk-msdc.0/11230000.msdc0/by-name/cache
      - /dev/block/mmcblk0p21
    data:
      - /dev/block/platform/mtk-msdc.0/by-name/userdata
      - /dev/block/platform/mtk-msdc.0/11230000.msdc0/by-name/userdata
      - /dev/block/mmcblk0p22
    boot:
      - /dev/block/platform/mtk-msdc.0/by-name/boot
      - /dev/block/platform/mtk-msdc.0/11230000.msdc0/by-name/boot
      - /dev/block/mmcblk0p7
    recovery:
      - /dev/block/platform/mtk-msdc.0/by-name/recovery
      - /dev/block/platform/mtk-msdc.0/11230000.msdc0/by-name/recovery
      - /dev/block/mmcblk0p8

  boot_ui:
    supported: yes
    graphics_backends:
      - fbdev
    brightness_path: /sys/class/leds/lcd-backlight/brightness
    max_brightness: 255
    default_brightness: 162
    pixel_format: RGBA_8888
    cpu_temp_path:  /sys/devices/virtual/thermal/thermal_zone1/temp
    theme: portrait_hdpi

- name: Lava pixel v2
  id: lava_pixelv2
  codenames:
    - lava_pixelv2
    - lava_pixelv2
    - pixelv2
    - pixelv2

  architecture: arm64-v8a

  block_devs:
    base_dirs:
      - /dev/block/platform/mtk-msdc.0/by-name
      - /dev/block/platform/mtk-msdc.0/11230000.msdc0/by-name
    system:
      - /dev/block/platform/mtk-msdc.0/by-name/system
      - /dev/block/platform/mtk-msdc.0/11230000.msdc0/by-name/system
      - /dev/block/mmcblk0p20
    cache:
      - /dev/block/platform/mtk-msdc.0/by-name/cache
      - /dev/block/platform/mtk-msdc.0/11230000.msdc0/by-name/cache
      - /dev/block/mmcblk0p21
    data:
      - /dev/block/platform/mtk-msdc.0/by-name/userdata
      - /dev/block/platform/mtk-msdc.0/11230000.msdc0/by-name/userdata
      - /dev/block/mmcblk0p22
    boot:
      - /dev/block/platform/mtk-msdc.0/by-name/boot
      - /dev/block/platform/mtk-msdc.0/11230000.msdc0/by-name/boot
      - /dev/block/mmcblk0p7
    recovery:
      - /dev/block/platform/mtk-msdc.0/by-name/recovery
      - /dev/block/platform/mtk-msdc.0/11230000.msdc0/by-name/recovery
      - /dev/block/mmcblk0p8

  boot_ui:
    supported: yes
    graphics_backends:
      - fbdev
    brightness_path: /sys/class/leds/lcd-backlight/brightness
    max_brightness: 255
    default_brightness: 162
    pixel_format: RGBA_8888
    cpu_temp_path:  /sys/devices/virtual/thermal/thermal_zone1/temp
    theme: portrait_hdpi


- name: LAVA iris X1 Beats
  id: X1Beats
  codenames:
      - LAVA iris X1Beats
      - LAVA iris X1 Beats
      - LAVA iris X1_Beats
      - X1Beats
      - X1 Beats
      - X1_Beats
  architecture: armeabi-v7a
  
  block_devs:
    base_dirs:
      - /dev/block/platform/sprd-sdhci.3/by-name
      - /dev/block/bootdevice/by-name
    system:
      - /dev/block/mmcblk0p17
      - /dev/block/platform/sprd-sdhci.3/by-name/system
    cache:
      - /dev/block/mmcblk0p18
      - /dev/block/platform/sprd-sdhci.3/by-name/cache
    data:
      - /dev/block/mmcblk0p21
      - /dev/block/platform/sprd-sdhci.3/by-name/userdata
    boot:
      - /dev/block/mmcblk0p16
      - /dev/block/platform/sprd-sdhci.3/by-name/boot
    recovery:
      - /dev/block/mmcblk0p19
      - /dev/block/platform/sprd-sdhci.3/by-name/recovery
    
