### PR TITLE
Enchilada: I'm OnePlus 6.

### DIFF
--- a/data/devices/oneplus.yml
+++ b/data/devices/oneplus.yml
@@ -312,3 +312,46 @@
     theme: portrait_hdpi
     brightness_path: /sys/class/leds/lcd-backlight/brightness
     default_brightness: 255
+    
+    
+- name: OnePlus 6
+  id: enchilada
+  codenames:
+    - OnePlus6
+    - enchilada
+    - A6000
+    - op6
+  architecture: arm64-v8a
+
+  block_devs:
+    base_dirs:
+      - /dev/block/bootdevice/by-name
+      - /dev/block/platform/soc/1d84000.ufshc/by-name
+    system:
+      - /dev/block/bootdevice/by-name/system_a
+      - /dev/block/platform/soc/1d84000.ufshc/by-name/system_a
+      - /dev/block/sda13
+      - /dev/block/bootdevice/by-name/system_b
+      - /dev/block/platform/soc/1d84000.ufshc/by-name/system_b
+      - /dev/block/sda14
+    data:
+      - /dev/block/bootdevice/by-name/userdata
+      - /dev/block/platform/soc/1d84000.ufshc/by-name/userdata
+      - /dev/block/sda17
+    boot:
+      - /dev/block/bootdevice/by-name/boot_a
+      - /dev/block/platform/soc/1d84000.ufshc/by-name/boot_a
+      - /dev/block/sde11
+      - /dev/block/bootdevice/by-name/boot_b
+      - /dev/block/platform/soc/1d84000.ufshc/by-name/boot_b
+      - /dev/block/sde39
+
+  boot_ui:
+    supported: true
+    flags:
+      - TW_QCOM_RTC_FIX
+    graphics_backends:
+      - fbdev
+    theme: portrait_hdpi
+    brightness_path: /sys/class/leds/lcd-backlight/brightness
+    default_brightness: 255


### PR DESCRIPTION
This device's recovery is in boot partitions.
All block except userdata have _a or _b suffix.
This devece's cache is in /data/cache. So it's havn't cache partitions.
(pls. forget my English grammar)