### PR TITLE
Add P20 Lite Support Please

### DIFF
--- a/data/devices/huawei.yml
+++ b/data/devices/huawei.yml
@@ -1009,3 +1009,101 @@
     default_brightness: 162
     battery_path: /sys/devices/platform/battery/power_supply/Battery
     theme: portrait_hdpi
+
+- name:  Huawei P20 Lite
+  id: anne
+  codenames:
+      - ANE-LX1
+      - ANE-LX2
+      - ANE-LX3
+      - ANE-L21
+      - ANE-L22
+      - ANE-L23
+      - ANE-AL00
+      - ANE-TL00
+      - ANE-LX2J
+  architecture: arm64-v8a
+    base_dirs:
+      - /dev/block/platform/hi_mci.0/by-name
+    system:
+      - /dev/block/mmcblk0p51
+      - /dev/block/bootdevice/by-name/system
+    cache:
+      - /dev/block/mmcblk0p42
+      - /dev/block/bootdevice/by-name/cache
+    data:
+      - /dev/block/mmcblk0p56
+      - /dev/block/bootdevice/by-name/userdata
+    boot:
+      - /dev/block/bootdevice/by-name/kernel
+      - /dev/block/mmcblk0p30
+    recovery:
+      -  /dev/block/bootdevice/by-name/recovery-ramdisk
+      - /dev/block/mmcblk0p32
+    extra:
+      - /dev/block/platform/hi_mci.0/by-num/p1
+      - /dev/block/platform/hi_mci.0/by-num/p10
+      - /dev/block/platform/hi_mci.0/by-num/p11
+      - /dev/block/platform/hi_mci.0/by-num/p12
+      - /dev/block/platform/hi_mci.0/by-num/p13
+      - /dev/block/platform/hi_mci.0/by-num/p14
+      - /dev/block/platform/hi_mci.0/by-num/p15
+      - /dev/block/platform/hi_mci.0/by-num/p16
+      - /dev/block/platform/hi_mci.0/by-num/p17
+      - /dev/block/platform/hi_mci.0/by-num/p18
+      - /dev/block/platform/hi_mci.0/by-num/p19
+      - /dev/block/platform/hi_mci.0/by-num/p2
+      - /dev/block/platform/hi_mci.0/by-num/p20
+      - /dev/block/platform/hi_mci.0/by-num/p21
+      - /dev/block/platform/hi_mci.0/by-num/p22
+      - /dev/block/platform/hi_mci.0/by-num/p23
+      - /dev/block/platform/hi_mci.0/by-num/p24
+      - /dev/block/platform/hi_mci.0/by-num/p25
+      - /dev/block/platform/hi_mci.0/by-num/p26
+      - /dev/block/platform/hi_mci.0/by-num/p27
+      - /dev/block/platform/hi_mci.0/by-num/p28
+      - /dev/block/platform/hi_mci.0/by-num/p29
+      - /dev/block/platform/hi_mci.0/by-num/p3
+      - /dev/block/platform/hi_mci.0/by-num/p31
+      - /dev/block/platform/hi_mci.0/by-num/p33
+      - /dev/block/platform/hi_mci.0/by-num/p34
+      - /dev/block/platform/hi_mci.0/by-num/p35
+      - /dev/block/platform/hi_mci.0/by-num/p36
+      - /dev/block/platform/hi_mci.0/by-num/p37
+      - /dev/block/platform/hi_mci.0/by-num/p38
+      - /dev/block/platform/hi_mci.0/by-num/p39
+      - /dev/block/platform/hi_mci.0/by-num/p4
+      - /dev/block/platform/hi_mci.0/by-num/p40
+      - /dev/block/platform/hi_mci.0/by-num/p41
+      - /dev/block/platform/hi_mci.0/by-num/p43
+      - /dev/block/platform/hi_mci.0/by-num/p44
+      - /dev/block/platform/hi_mci.0/by-num/p45
+      - /dev/block/platform/hi_mci.0/by-num/p46
+      - /dev/block/platform/hi_mci.0/by-num/p47
+      - /dev/block/platform/hi_mci.0/by-num/p48
+      - /dev/block/platform/hi_mci.0/by-num/p49
+      - /dev/block/platform/hi_mci.0/by-num/p5
+      - /dev/block/platform/hi_mci.0/by-num/p50
+      - /dev/block/platform/hi_mci.0/by-num/p52
+      - /dev/block/platform/hi_mci.0/by-num/p53
+      - /dev/block/platform/hi_mci.0/by-num/p54
+      - /dev/block/platform/hi_mci.0/by-num/p55
+      - /dev/block/platform/hi_mci.0/by-num/p6
+      - /dev/block/platform/hi_mci.0/by-num/p7
+      - /dev/block/platform/hi_mci.0/by-num/p8
+      - /dev/block/platform/hi_mci.0/by-num/p9
+      - /dev/block/mmcblk1
+      - /dev/block/mmcblk1p1
+ 
+  boot_ui:
+    supported: true
+    flags:
+      - TW_GRAPHICS_FORCE_USE_LINELENGTH
+    brightness_path: /sys/devices/hisi_fb.524289/leds/lcd_backlight0/brightness
+    max_brightness: 255
+    default_brightness: 168
+    cpu_temp_path: /sys/devices/virtual/thermal/thermal_zone0/temp
+    battery_path: /sys/devices/platform/battery/power_supply/Battery
+    graphics_backends:
+      - fbdev
+    theme: portrait_hdpi

--- a/data/devices/huawei.yml
+++ b/data/devices/huawei.yml
@@ -1020,8 +1020,9 @@
       - ANE-L22
       - ANE-L23
       - ANE-AL00
-      - ANE-TL00
       - ANE-LX2J
+      - ANE-TL00
+      - hi6250
   architecture: arm64-v8a
     base_dirs:
       - /dev/block/platform/hi_mci.0/by-name


### PR DESCRIPTION
So i have made a YML for my Huawei P20 Lite so here it is, and i also have the partition list here. Please Add

/dev/block/mmcblk0p48 -> bootfail_info
/dev/block/mmcblk0p42 -> cache
/dev/block/mmcblk0p52 -> cust
/dev/block/mmcblk0p40 -> dfx
/dev/block/mmcblk0p35 -> dto
/dev/block/mmcblk0p34 -> dts
/dev/block/mmcblk0p27 -> erecovery_kernel
/dev/block/mmcblk0p28 -> erecovery_ramdisk
/dev/block/mmcblk0p38 -> erecovery_vbmeta
/dev/block/mmcblk0p29 -> erecovery_vendor
/dev/block/mmcblk0p5  -> fastboot
/dev/block/mmcblk0p4  -> frp
/dev/block/mmcblk0p26 -> fw_hifi
/dev/block/mmcblk0p3  -> fw_lpm3
/dev/block/mmcblk0p44 -> hisitest0
/dev/block/mmcblk0p45 -> hisitest1
/dev/block/mmcblk0p46 -> hisitest2
/dev/block/mmcblk0p30 -> kernel
/dev/block/mmcblk0p20 -> misc
/dev/block/mmcblk0p36 -> modem_fw
/dev/block/mmcblk0p18 -> modem_om
/dev/block/mmcblk0p17 -> modem_secure
/dev/block/mmcblk0p10 -> modemnvm_backup
/dev/block/mmcblk0p6  -> modemnvm_factory
/dev/block/mmcblk0p11 -> modemnvm_img
/dev/block/mmcblk0p12 -> modemnvm_system
/dev/block/mmcblk0p21 -> modemnvm_update
/dev/block/mmcblk0p7  -> nvme
/dev/block/mmcblk0p43 -> odm
/dev/block/mmcblk0p8  -> oeminfo
/dev/block/mmcblk0p47 -> patch
/dev/block/mmcblk0p16 -> persist
/dev/block/mmcblk0p55 -> product
/dev/block/mmcblk0p31 -> ramdisk
/dev/block/mmcblk0p32 -> recovery_ramdisk
/dev/block/mmcblk0p37 -> recovery_vbmeta
/dev/block/mmcblk0p33 -> recovery_vendor
/dev/block/mmcblk0p22 -> reserved2
/dev/block/mmcblk0p9  -> reserved3
/dev/block/mmcblk0p14 -> reserved4 
/dev/block/mmcblk0p15 -> reserved5
/dev/block/mmcblk0p39 -> reserved8
/dev/block/mmcblk0p50 -> reserved9
/dev/block/mmcblk0p49 -> rrecord
/dev/block/mmcblk0p13 -> secure_storage
/dev/block/mmcblk0p25 -> sensorhub
/dev/block/mmcblk0p19 -> splash2
/dev/block/mmcblk0p51 -> system
/dev/block/mmcblk0p23 -> teeos
/dev/block/mmcblk0p24 -> trustfirmware
/dev/block/mmcblk0p56 -> userdata
/dev/block/mmcblk0p41 -> vbmeta
/dev/block/mmcblk0p54 -> vendor
/dev/block/mmcblk0p53 -> version
/dev/block/mmcblk0p1  -> vrl
/dev/block/mmcblk0p2  -> vrl_backup


- name:  Huawei P20 Lite
  id: anne
  codenames:
      - ANE-LX1
      - ANE-LX2
      - ANE-LX3
      - ANE-L21
      - ANE-L22
      - ANE-L23
      - ANE-AL00
      - ANE-TL00
      - ANE-LX2J
      - anne
  architecture: arm64-v8a
    base_dirs:
      - /dev/block/platform/hi_mci.0/by-name
    system:
      - /dev/block/mmcblk0p51
      - /dev/block/bootdevice/by-name/system
    cache:
      - /dev/block/mmcblk0p42
      - /dev/block/bootdevice/by-name/cache
    data:
      - /dev/block/mmcblk0p56
      - /dev/block/bootdevice/by-name/userdata
    boot:
      - /dev/block/bootdevice/by-name/kernel
      - /dev/block/mmcblk0p30
    recovery:
      -  /dev/block/bootdevice/by-name/recovery-ramdisk
      - /dev/block/mmcblk0p32
    extra:
      - /dev/block/platform/hi_mci.0/by-num/p1
      - /dev/block/platform/hi_mci.0/by-num/p10
      - /dev/block/platform/hi_mci.0/by-num/p11
      - /dev/block/platform/hi_mci.0/by-num/p12
      - /dev/block/platform/hi_mci.0/by-num/p13
      - /dev/block/platform/hi_mci.0/by-num/p14
      - /dev/block/platform/hi_mci.0/by-num/p15
      - /dev/block/platform/hi_mci.0/by-num/p16
      - /dev/block/platform/hi_mci.0/by-num/p17
      - /dev/block/platform/hi_mci.0/by-num/p18
      - /dev/block/platform/hi_mci.0/by-num/p19
      - /dev/block/platform/hi_mci.0/by-num/p2
      - /dev/block/platform/hi_mci.0/by-num/p20
      - /dev/block/platform/hi_mci.0/by-num/p21
      - /dev/block/platform/hi_mci.0/by-num/p22
      - /dev/block/platform/hi_mci.0/by-num/p23
      - /dev/block/platform/hi_mci.0/by-num/p24
      - /dev/block/platform/hi_mci.0/by-num/p25
      - /dev/block/platform/hi_mci.0/by-num/p26
      - /dev/block/platform/hi_mci.0/by-num/p27
      - /dev/block/platform/hi_mci.0/by-num/p28
      - /dev/block/platform/hi_mci.0/by-num/p29
      - /dev/block/platform/hi_mci.0/by-num/p3
      - /dev/block/platform/hi_mci.0/by-num/p31
      - /dev/block/platform/hi_mci.0/by-num/p33
      - /dev/block/platform/hi_mci.0/by-num/p34
      - /dev/block/platform/hi_mci.0/by-num/p35
      - /dev/block/platform/hi_mci.0/by-num/p36
      - /dev/block/platform/hi_mci.0/by-num/p37
      - /dev/block/platform/hi_mci.0/by-num/p38
      - /dev/block/platform/hi_mci.0/by-num/p39
      - /dev/block/platform/hi_mci.0/by-num/p4
      - /dev/block/platform/hi_mci.0/by-num/p40
      - /dev/block/platform/hi_mci.0/by-num/p41
      - /dev/block/platform/hi_mci.0/by-num/p43
      - /dev/block/platform/hi_mci.0/by-num/p44
      - /dev/block/platform/hi_mci.0/by-num/p45
      - /dev/block/platform/hi_mci.0/by-num/p46
      - /dev/block/platform/hi_mci.0/by-num/p47
      - /dev/block/platform/hi_mci.0/by-num/p48
      - /dev/block/platform/hi_mci.0/by-num/p49
      - /dev/block/platform/hi_mci.0/by-num/p5
      - /dev/block/platform/hi_mci.0/by-num/p50
      - /dev/block/platform/hi_mci.0/by-num/p52
      - /dev/block/platform/hi_mci.0/by-num/p53
      - /dev/block/platform/hi_mci.0/by-num/p54
      - /dev/block/platform/hi_mci.0/by-num/p55
      - /dev/block/platform/hi_mci.0/by-num/p6
      - /dev/block/platform/hi_mci.0/by-num/p7
      - /dev/block/platform/hi_mci.0/by-num/p8
      - /dev/block/platform/hi_mci.0/by-num/p9
      - /dev/block/mmcblk1
      - /dev/block/mmcblk1p1
 
  boot_ui:
    supported: true
    flags:
      - TW_GRAPHICS_FORCE_USE_LINELENGTH
    brightness_path: /sys/devices/hisi_fb.524289/leds/lcd_backlight0/brightness
    max_brightness: 255
    default_brightness: 168
    cpu_temp_path: /sys/devices/virtual/thermal/thermal_zone0/temp
    battery_path: /sys/devices/platform/battery/power_supply/Battery
    graphics_backends:
      - fbdev
    theme: portrait_hdpi