### PR TITLE
kingdom: Add support for /vendor

### DIFF
--- a/data/devices/lenovo.yml
+++ b/data/devices/lenovo.yml
@@ -215,10 +215,14 @@
       - /dev/block/platform/msm_sdcc.1/by-name/system
       - /dev/block/bootdevice/by-name/system
       - /dev/block/mmcblk0p21
-    cache:
+    vendor:
       - /dev/block/platform/msm_sdcc.1/by-name/cache
       - /dev/block/bootdevice/by-name/cache
       - /dev/block/mmcblk0p20
+    cache:
+      - /dev/block/platform/msm_sdcc.1/by-name/preload
+      - /dev/block/bootdevice/by-name/preload
+      - /dev/block/mmcblk0p22
     data:
       - /dev/block/platform/msm_sdcc.1/by-name/userdata
       - /dev/block/bootdevice/by-name/userdata


### PR DESCRIPTION
We are using cache partition for /vendor now and unused preload partition as cache.