### PR TITLE
libmbcommon: Remove unneeded includes from file.h

### DIFF
--- a/libmbbootimg/src/format/loki.cpp
+++ b/libmbbootimg/src/format/loki.cpp
@@ -35,6 +35,7 @@
 
 #include "mbcommon/endian.h"
 #include "mbcommon/file.h"
+#include "mbcommon/file_error.h"
 #include "mbcommon/file_util.h"
 #include "mbcommon/finally.h"
 

--- a/libmbbootimg/src/format/loki_reader.cpp
+++ b/libmbbootimg/src/format/loki_reader.cpp
@@ -29,6 +29,7 @@
 
 #include "mbcommon/endian.h"
 #include "mbcommon/file.h"
+#include "mbcommon/file_error.h"
 #include "mbcommon/file_util.h"
 #include "mbcommon/string.h"
 

--- a/libmbbootimg/src/format/mtk_reader.cpp
+++ b/libmbbootimg/src/format/mtk_reader.cpp
@@ -29,6 +29,7 @@
 
 #include "mbcommon/endian.h"
 #include "mbcommon/file.h"
+#include "mbcommon/file_error.h"
 #include "mbcommon/file_util.h"
 #include "mbcommon/string.h"
 

--- a/libmbbootimg/src/format/segment_reader.cpp
+++ b/libmbbootimg/src/format/segment_reader.cpp
@@ -26,6 +26,7 @@
 #include <cstring>
 
 #include "mbcommon/file.h"
+#include "mbcommon/file_error.h"
 #include "mbcommon/file_util.h"
 #include "mbcommon/string.h"
 

--- a/libmbbootimg/src/format/sony_elf_reader.cpp
+++ b/libmbbootimg/src/format/sony_elf_reader.cpp
@@ -29,6 +29,7 @@
 
 #include "mbcommon/endian.h"
 #include "mbcommon/file.h"
+#include "mbcommon/file_error.h"
 #include "mbcommon/file_util.h"
 #include "mbcommon/string.h"
 

--- a/libmbbootimg/tests/format/test_loki_reader.cpp
+++ b/libmbbootimg/tests/format/test_loki_reader.cpp
@@ -23,6 +23,7 @@
 
 #include "mbcommon/file.h"
 #include "mbcommon/file/memory.h"
+#include "mbcommon/file_error.h"
 
 #include "mbbootimg/format/loki_error.h"
 #include "mbbootimg/format/loki_reader_p.h"

--- a/libmbcommon/include/mbcommon/file.h
+++ b/libmbcommon/include/mbcommon/file.h
@@ -21,13 +21,9 @@
 
 #include "mbcommon/common.h"
 
-#include <memory>
-#include <string>
-
 #include <cstddef>
 #include <cstdint>
 
-#include "mbcommon/file_error.h"
 #include "mbcommon/outcome.h"
 
 namespace mb

--- a/libmbcommon/src/file/fd.cpp
+++ b/libmbcommon/src/file/fd.cpp
@@ -29,6 +29,7 @@
 #include <unistd.h>
 
 #include "mbcommon/error_code.h"
+#include "mbcommon/file_error.h"
 #include "mbcommon/finally.h"
 #include "mbcommon/locale.h"
 

--- a/libmbcommon/src/file/memory.cpp
+++ b/libmbcommon/src/file/memory.cpp
@@ -28,6 +28,7 @@
 #include <cstring>
 
 #include "mbcommon/error_code.h"
+#include "mbcommon/file_error.h"
 #include "mbcommon/string.h"
 
 /*!

--- a/libmbcommon/src/file/posix.cpp
+++ b/libmbcommon/src/file/posix.cpp
@@ -28,6 +28,7 @@
 #include <unistd.h>
 
 #include "mbcommon/error_code.h"
+#include "mbcommon/file_error.h"
 #include "mbcommon/finally.h"
 #include "mbcommon/locale.h"
 

--- a/libmbcommon/src/file/win32.cpp
+++ b/libmbcommon/src/file/win32.cpp
@@ -25,6 +25,7 @@
 #include <cstring>
 
 #include "mbcommon/error_code.h"
+#include "mbcommon/file_error.h"
 #include "mbcommon/finally.h"
 #include "mbcommon/locale.h"
 

--- a/libmbcommon/src/file_util.cpp
+++ b/libmbcommon/src/file_util.cpp
@@ -32,6 +32,7 @@
 #include <cstring>
 
 #include "mbcommon/error_code.h"
+#include "mbcommon/file_error.h"
 
 #define DEFAULT_BUFFER_SIZE             (8 * 1024 * 1024)
 

--- a/libmbcommon/tests/file/test_fd.cpp
+++ b/libmbcommon/tests/file/test_fd.cpp
@@ -25,6 +25,7 @@
 
 #include "mbcommon/file.h"
 #include "mbcommon/file/fd.h"
+#include "mbcommon/file_error.h"
 
 using namespace mb;
 using namespace mb::detail;

--- a/libmbcommon/tests/file/test_memory.cpp
+++ b/libmbcommon/tests/file/test_memory.cpp
@@ -23,6 +23,7 @@
 
 #include "mbcommon/file.h"
 #include "mbcommon/file/memory.h"
+#include "mbcommon/file_error.h"
 
 using namespace mb;
 

--- a/libmbcommon/tests/file/test_posix.cpp
+++ b/libmbcommon/tests/file/test_posix.cpp
@@ -21,6 +21,7 @@
 
 #include "mbcommon/file.h"
 #include "mbcommon/file/posix.h"
+#include "mbcommon/file_error.h"
 
 using namespace mb;
 using namespace mb::detail;

--- a/libmbcommon/tests/file/test_win32.cpp
+++ b/libmbcommon/tests/file/test_win32.cpp
@@ -24,6 +24,7 @@
 #include "mbcommon/error_code.h"
 #include "mbcommon/file.h"
 #include "mbcommon/file/win32.h"
+#include "mbcommon/file_error.h"
 
 using namespace mb;
 using namespace mb::detail;

--- a/libmbcommon/tests/test_file_util.cpp
+++ b/libmbcommon/tests/test_file_util.cpp
@@ -26,6 +26,7 @@
 #include <cinttypes>
 
 #include "mbcommon/file/memory.h"
+#include "mbcommon/file_error.h"
 #include "mbcommon/file_util.h"
 #include "mbcommon/string.h"
 

--- a/libmbsparse/src/sparse.cpp
+++ b/libmbsparse/src/sparse.cpp
@@ -32,6 +32,7 @@
 
 #include "mbcommon/algorithm.h"
 #include "mbcommon/endian.h"
+#include "mbcommon/file_error.h"
 #include "mbcommon/file_util.h"
 #include "mbcommon/finally.h"
 #include "mbcommon/string.h"

--- a/libmbsparse/tests/test_sparse.cpp
+++ b/libmbsparse/tests/test_sparse.cpp
@@ -23,6 +23,7 @@
 
 #include "mbcommon/endian.h"
 #include "mbcommon/file/memory.h"
+#include "mbcommon/file_error.h"
 
 #include "mbsparse/sparse_error.h"
 

--- a/odinupdater/odinupdater.cpp
+++ b/odinupdater/odinupdater.cpp
@@ -37,6 +37,7 @@
 // libmbcommon
 #include "mbcommon/error_code.h"
 #include "mbcommon/file/standard.h"
+#include "mbcommon/file_error.h"
 #include "mbcommon/finally.h"
 #include "mbcommon/integer.h"
 #include "mbcommon/string.h"


### PR DESCRIPTION
Signed-off-by: Andrew Gunnerson <andrewgunnerson@gmail.com>