### PR TITLE
Revert "docker: Install transifex-client in a virtualenv"

### DIFF
--- a/docker/common.sh
+++ b/docker/common.sh
@@ -1,3 +1,3 @@
 repo=chenxiaolong/dualbootpatcher
 version=9.3.0
-release=9
+release=10

--- a/docker/template/Dockerfile.base.in
+++ b/docker/template/Dockerfile.base.in
@@ -66,23 +66,12 @@ RUN parent=$(dirname ${ANDROID_NDK_HOME}) \
 ENV PATH ${PATH}:${ANDROID_NDK_HOME}
 
 # Install dependencies
-# * procps-ng is needed due to:
-#   https://issues.jenkins-ci.org/browse/JENKINS-40101
-# * A virtualenv is used for transifex instead of the transifex-client package
-#   because of: https://bugzilla.redhat.com/show_bug.cgi?id=1653103
+# procps-ng is needed due to https://issues.jenkins-ci.org/browse/JENKINS-40101
 RUN dnf -y install \
         ccache cmake findutils gcc-c++ git make procps-ng unzip zip \
         ncurses-compat-libs \
-        java-1.8.0-openjdk-headless \
+        java-1.8.0-openjdk-headless transifex-client \
         openssl-devel yaml-cpp-devel \
-    && dnf clean all
-
-# Transifex virtualenv
-RUN dnf -y install python3-virtualenv \
-    && virtualenv /usr/local/venv-transifex \
-    && /usr/local/venv-transifex/bin/pip install transifex-client \
-    && ln -s /usr/local/venv-transifex/bin/tx /usr/local/bin/ \
-    && dnf remove -y python3-virtualenv \
     && dnf clean all
 
 # Volumes

--- a/docs/build/Docker.md
+++ b/docs/build/Docker.md
@@ -26,10 +26,10 @@ Note that building the docker images will take a long time and consume a lot of 
 Once the images have been built, the resulting image tags are written to `docker/generated/images.properties`. It will look something like the following:
 
 ```dosini
-android=chenxiaolong/dualbootpatcher:9.3.0-9-android
-base=chenxiaolong/dualbootpatcher:9.3.0-9-base
-linux=chenxiaolong/dualbootpatcher:9.3.0-9-linux
-mingw=chenxiaolong/dualbootpatcher:9.3.0-9-mingw
+android=chenxiaolong/dualbootpatcher:9.3.0-10-android
+base=chenxiaolong/dualbootpatcher:9.3.0-10-base
+linux=chenxiaolong/dualbootpatcher:9.3.0-10-linux
+mingw=chenxiaolong/dualbootpatcher:9.3.0-10-mingw
 ```
 
 The following table describes the images that are built:
@@ -54,7 +54,7 @@ docker run --rm -it \
     -v "${HOME}/.android:/builder/.android:rw,z" \
     -v "${HOME}/.ccache:/builder/.ccache:rw,z" \
     -v "${HOME}/.gradle:/builder/.gradle:rw,z" \
-    chenxiaolong/dualbootpatcher:9.3.0-9-android \
+    chenxiaolong/dualbootpatcher:9.3.0-10-android \
     bash
 ```
 


### PR DESCRIPTION
The upstream bug with the RPM packaging has been fixed.

https://bugzilla.redhat.com/show_bug.cgi?id=1653103

This reverts commit 8dea723f1e028833587f23d20750b30b0573fa83.

Signed-off-by: Andrew Gunnerson <andrewgunnerson@gmail.com>