### PR TITLE
Fix gradle to build apk

### DIFF
--- a/Android_GUI/build.gradle.in
+++ b/Android_GUI/build.gradle.in
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.2'
+        classpath 'com.android.tools.build:gradle:3.1.3'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }


### PR DESCRIPTION
Gradle 3.1.2 falling , because can t download libs, upstream gradle version to 3.1.3