### PR TITLE
 libmbutil: Fix incorrect return value checking of __system_property_foreach

### DIFF
--- a/libmbutil/src/properties.cpp
+++ b/libmbutil/src/properties.cpp
@@ -194,23 +194,17 @@ bool property_iter(const std::function<PropertyIterCb> &fn)
                 == PropertyIterAction::Stop) {
             ctx_->done = true;
         }
-    }, &ctx);
+    }, &ctx) == 0;
 }
 
 std::optional<PropertiesMap> property_get_all()
 {
     PropertiesMap result;
 
-    initialize_properties();
-
-    if (__system_property_foreach([](const prop_info *pi, void *cookie) {
-        auto *map = static_cast<PropertiesMap *>(cookie);
-
-        read_property_cb(pi, [&](std::string_view key, std::string_view value) {
-            map->insert_or_assign(std::string{key}, std::string{value});
-            return PropertyIterAction::Stop;
-        });
-    }, &result)) {
+    if (property_iter([&](std::string_view key, std::string_view value) {
+        result.insert_or_assign(std::string{key}, std::string{value});
+        return PropertyIterAction::Continue;
+    })) {
         return std::move(result);
     } else {
         return std::nullopt;

--- a/mbtool/src/recovery/installer.cpp
+++ b/mbtool/src/recovery/installer.cpp
@@ -855,7 +855,12 @@ bool Installer::set_up_legacy_properties()
     }
 
     for (auto const &pair : _chroot_prop) {
-        _legacy_prop_svc.set(pair.first, pair.second);
+        LOGD("Setting legacy property '%s'='%s'",
+             pair.first.c_str(), pair.second.c_str());
+        if (!_legacy_prop_svc.set(pair.first, pair.second)) {
+            LOGW("Failed to set legacy property '%s'='%s'",
+                 pair.first.c_str(), pair.second.c_str());
+        }
     }
 
     auto [fd, size] = _legacy_prop_svc.workspace();


### PR DESCRIPTION
This caused property_iter() to return the opposite status and property_get_all() to return std::nullopt when successful. This broke the setting of legacy properties when flashing from recovery.