### PR TITLE
Android GUI: Use java.lang.Class.getName() instead of getCanonicalName()

### DIFF
--- a/Android_GUI/src/main/java/com/github/chenxiaolong/dualbootpatcher/AboutFragment.kt
+++ b/Android_GUI/src/main/java/com/github/chenxiaolong/dualbootpatcher/AboutFragment.kt
@@ -73,7 +73,7 @@ class AboutFragment : Fragment() {
         }
 
     companion object {
-        val FRAGMENT_TAG: String = AboutFragment::class.java.canonicalName!!
+        val FRAGMENT_TAG: String = AboutFragment::class.java.name
 
         fun newInstance(): AboutFragment {
             return AboutFragment()

--- a/Android_GUI/src/main/java/com/github/chenxiaolong/dualbootpatcher/MainActivity.kt
+++ b/Android_GUI/src/main/java/com/github/chenxiaolong/dualbootpatcher/MainActivity.kt
@@ -454,7 +454,7 @@ class MainActivity : AppCompatActivity(), OnNavigationItemSelectedListener {
         private const val PREF_SHOW_EXIT = "show_exit"
 
         private val PROGRESS_DIALOG_REBOOT =
-                "${MainActivity::class.java.canonicalName}.progress.reboot"
+                "${MainActivity::class.java.name}.progress.reboot"
 
         private const val REQUEST_SETTINGS_ACTIVITY = 1000
 

--- a/Android_GUI/src/main/java/com/github/chenxiaolong/dualbootpatcher/appsharing/AppListFragment.kt
+++ b/Android_GUI/src/main/java/com/github/chenxiaolong/dualbootpatcher/appsharing/AppListFragment.kt
@@ -417,8 +417,8 @@ class AppListFragment : Fragment(), FirstUseDialogListener, AppCardActionListene
         private const val PREF_SHOW_FIRST_USE_DIALOG = "indiv_app_sync_first_use_show_dialog"
 
         private val CONFIRM_DIALOG_FIRST_USE =
-                "${AppListFragment::class.java.canonicalName}.confirm.first_use"
+                "${AppListFragment::class.java.name}.confirm.first_use"
         private val CONFIRM_DIALOG_A_S_SETTINGS =
-                "${AppListFragment::class.java.canonicalName}.confirm.a_s_settings"
+                "${AppListFragment::class.java.name}.confirm.a_s_settings"
     }
 }

--- a/Android_GUI/src/main/java/com/github/chenxiaolong/dualbootpatcher/appsharing/AppSharingSettingsFragment.kt
+++ b/Android_GUI/src/main/java/com/github/chenxiaolong/dualbootpatcher/appsharing/AppSharingSettingsFragment.kt
@@ -293,9 +293,9 @@ class AppSharingSettingsFragment : PreferenceFragmentCompat(), OnPreferenceChang
         private const val KEY_MANAGE_INDIV_APPS = "manage_indiv_apps"
 
         private val YES_NO_DIALOG_PERMISSIONS =
-                "${AppSharingSettingsFragment::class.java.canonicalName}.yes_no.permissions"
+                "${AppSharingSettingsFragment::class.java.name}.yes_no.permissions"
         private val CONFIRM_DIALOG_PERMISSIONS =
-                "${AppSharingSettingsFragment::class.java.canonicalName}.confirm.permissions"
+                "${AppSharingSettingsFragment::class.java.name}.confirm.permissions"
 
         /**
          * Request code for storage permissions request

--- a/Android_GUI/src/main/java/com/github/chenxiaolong/dualbootpatcher/patcher/InstallLocation.kt
+++ b/Android_GUI/src/main/java/com/github/chenxiaolong/dualbootpatcher/patcher/InstallLocation.kt
@@ -74,8 +74,8 @@ class TemplateLocation(
         private val descriptionArgs: Array<Any>
 ) {
     companion object {
-        val PLACEHOLDER_ID = "${InstallLocation::class.java.canonicalName}.placeholder_id"
-        val PLACEHOLDER_SUFFIX = "${InstallLocation::class.java.canonicalName}.placeholder_suffix"
+        val PLACEHOLDER_ID = "${InstallLocation::class.java.name}.placeholder_id"
+        val PLACEHOLDER_SUFFIX = "${InstallLocation::class.java.name}.placeholder_suffix"
     }
 
     constructor(

--- a/Android_GUI/src/main/java/com/github/chenxiaolong/dualbootpatcher/patcher/PatchFileFragment.kt
+++ b/Android_GUI/src/main/java/com/github/chenxiaolong/dualbootpatcher/patcher/PatchFileFragment.kt
@@ -945,17 +945,17 @@ class PatchFileFragment : Fragment(), ServiceConnection, PatcherOptionsDialogLis
     }
 
     companion object {
-        val FRAGMENT_TAG: String = PatchFileFragment::class.java.canonicalName!!
+        val FRAGMENT_TAG: String = PatchFileFragment::class.java.name
         private val TAG = PatchFileFragment::class.java.simpleName
 
         private val DIALOG_PATCHER_OPTIONS =
-                "${PatchFileFragment::class.java.canonicalName}.patcher_options"
+                "${PatchFileFragment::class.java.name}.patcher_options"
         private val YES_NO_DIALOG_PERMISSIONS =
-                "${PatchFileFragment::class.java.canonicalName}.yes_no.permissions"
+                "${PatchFileFragment::class.java.name}.yes_no.permissions"
         private val CONFIRM_DIALOG_PERMISSIONS =
-                "${PatchFileFragment::class.java.canonicalName}.confirm.permissions"
+                "${PatchFileFragment::class.java.name}.confirm.permissions"
         private val PROGRESS_DIALOG_QUERYING_METADATA =
-                "${PatchFileFragment::class.java.canonicalName}.progress.querying_metadata"
+                "${PatchFileFragment::class.java.name}.progress.querying_metadata"
 
         private const val EXTRA_SELECTED_PATCHER_ID = "selected_patcher_id"
         private const val EXTRA_SELECTED_INPUT_URI = "selected_input_file"

--- a/Android_GUI/src/main/java/com/github/chenxiaolong/dualbootpatcher/patcher/PatcherOptionsDialog.kt
+++ b/Android_GUI/src/main/java/com/github/chenxiaolong/dualbootpatcher/patcher/PatcherOptionsDialog.kt
@@ -282,9 +282,9 @@ class PatcherOptionsDialog : DialogFragment() {
         private const val ARG_PRESELECTED_ROM_ID = "rom_id"
 
         private val STATE_DEVICE_POSITION =
-                "${PatcherOptionsDialog::class.java.canonicalName}.state.device_position"
+                "${PatcherOptionsDialog::class.java.name}.state.device_position"
         private val STATE_LOCATION_POSITION =
-                "${PatcherOptionsDialog::class.java.canonicalName}.state.location_position"
+                "${PatcherOptionsDialog::class.java.name}.state.location_position"
 
         fun newInstanceFromFragment(parent: Fragment?, id: Int,
                                     preselectedDeviceId: String?,

--- a/Android_GUI/src/main/java/com/github/chenxiaolong/dualbootpatcher/pathchooser/PathChooserActivity.kt
+++ b/Android_GUI/src/main/java/com/github/chenxiaolong/dualbootpatcher/pathchooser/PathChooserActivity.kt
@@ -94,13 +94,13 @@ class PathChooserActivity : AppCompatActivity(), FileChooserDialogListener {
 
     companion object {
         val ACTION_OPEN_FILE =
-                "${PathChooserActivity::class.java.canonicalName}.open_file"
+                "${PathChooserActivity::class.java.name}.open_file"
         val ACTION_OPEN_DIRECTORY =
-                "${PathChooserActivity::class.java.canonicalName}.open_directory"
+                "${PathChooserActivity::class.java.name}.open_directory"
         val ACTION_SAVE_FILE =
-                "${PathChooserActivity::class.java.canonicalName}.save_file"
+                "${PathChooserActivity::class.java.name}.save_file"
 
         private val DIALOG_PATH_CHOOSER =
-                "${PathChooserActivity::class.java.canonicalName}.path_chooser"
+                "${PathChooserActivity::class.java.name}.path_chooser"
     }
 }

--- a/Android_GUI/src/main/java/com/github/chenxiaolong/dualbootpatcher/pathchooser/PathChooserDialog.kt
+++ b/Android_GUI/src/main/java/com/github/chenxiaolong/dualbootpatcher/pathchooser/PathChooserDialog.kt
@@ -321,7 +321,7 @@ class PathChooserDialog : DialogFragment(), PathChooserItemClickListener,
 
     companion object {
         private val DIALOG_NEW_FOLDER =
-                "${PathChooserDialog::class.java.canonicalName}.dialog.new_folder"
+                "${PathChooserDialog::class.java.name}.dialog.new_folder"
 
         private const val EMULATED_STORAGE_DIR = "/storage/emulated"
 

--- a/Android_GUI/src/main/java/com/github/chenxiaolong/dualbootpatcher/picasso/PaletteGeneratorTransformation.kt
+++ b/Android_GUI/src/main/java/com/github/chenxiaolong/dualbootpatcher/picasso/PaletteGeneratorTransformation.kt
@@ -30,7 +30,7 @@ class PaletteGeneratorTransformation private constructor() : Transformation {
     }
 
     override fun key(): String {
-        return javaClass.canonicalName!!
+        return javaClass.name
     }
 
     fun getPalette(bitmap: Bitmap): Palette? {

--- a/Android_GUI/src/main/java/com/github/chenxiaolong/dualbootpatcher/socket/MbtoolErrorActivity.kt
+++ b/Android_GUI/src/main/java/com/github/chenxiaolong/dualbootpatcher/socket/MbtoolErrorActivity.kt
@@ -252,7 +252,7 @@ class MbtoolErrorActivity : AppCompatActivity(), ServiceConnection, GenericYesNo
     }
 
     companion object {
-        private val DIALOG_TAG = "${MbtoolErrorActivity::class.java.canonicalName}.dialog"
+        private val DIALOG_TAG = "${MbtoolErrorActivity::class.java.name}.dialog"
 
         // Argument extras
         const val EXTRA_REASON = "reason"

--- a/Android_GUI/src/main/java/com/github/chenxiaolong/dualbootpatcher/switcher/AutomatedSwitcherActivity.kt
+++ b/Android_GUI/src/main/java/com/github/chenxiaolong/dualbootpatcher/switcher/AutomatedSwitcherActivity.kt
@@ -264,7 +264,7 @@ class AutomatedSwitcherActivity : AppCompatActivity(), ConfirmAutomatedSwitchRom
         private const val EXTRA_TASK_ID_SWITCH_ROM = "task_id_switch_rom"
 
         private val CONFIRM_DIALOG_AUTOMATED =
-                "${AutomatedSwitcherActivity::class.java.canonicalName}.confirm.automated"
+                "${AutomatedSwitcherActivity::class.java.name}.confirm.automated"
 
         const val EXTRA_ROM_ID = "rom_id"
         const val EXTRA_REBOOT = "reboot"

--- a/Android_GUI/src/main/java/com/github/chenxiaolong/dualbootpatcher/switcher/InAppFlashingFragment.kt
+++ b/Android_GUI/src/main/java/com/github/chenxiaolong/dualbootpatcher/switcher/InAppFlashingFragment.kt
@@ -702,23 +702,23 @@ class InAppFlashingFragment : Fragment(), FirstUseDialogListener, RomIdSelection
         private const val ACTIVITY_REQUEST_FILE = 1000
 
         private val PROGRESS_DIALOG_VERIFY_ZIP =
-                "${InAppFlashingFragment::class.java.canonicalName}.progress.verify_zip"
+                "${InAppFlashingFragment::class.java.name}.progress.verify_zip"
         private val PROGRESS_DIALOG_QUERYING_METADATA =
-                "${InAppFlashingFragment::class.java.canonicalName}.progress.querying_metadata"
+                "${InAppFlashingFragment::class.java.name}.progress.querying_metadata"
         private val CONFIRM_DIALOG_FIRST_USE =
-                "${InAppFlashingFragment::class.java.canonicalName}.confirm.first_use"
+                "${InAppFlashingFragment::class.java.name}.confirm.first_use"
         private val CONFIRM_DIALOG_INSTALL_LOCATION =
-                "${InAppFlashingFragment::class.java.canonicalName}.confirm.install_location"
+                "${InAppFlashingFragment::class.java.name}.confirm.install_location"
         private val CONFIRM_DIALOG_NAMED_SLOT_ID =
-                "${InAppFlashingFragment::class.java.canonicalName}.confirm.named_slot_id"
+                "${InAppFlashingFragment::class.java.name}.confirm.named_slot_id"
         private val CONFIRM_DIALOG_ROM_ID =
-                "${InAppFlashingFragment::class.java.canonicalName}.confirm.rom_id"
+                "${InAppFlashingFragment::class.java.name}.confirm.rom_id"
         private val CONFIRM_DIALOG_ERROR =
-                "${InAppFlashingFragment::class.java.canonicalName}.confirm.error"
+                "${InAppFlashingFragment::class.java.name}.confirm.error"
         private val CONFIRM_DIALOG_SELECT_BACKUP =
-                "${InAppFlashingFragment::class.java.canonicalName}.confirm.select_backup"
+                "${InAppFlashingFragment::class.java.name}.confirm.select_backup"
         private val CONFIRM_DIALOG_SELECT_TARGETS =
-                "${InAppFlashingFragment::class.java.canonicalName}.confirm.select_targets"
+                "${InAppFlashingFragment::class.java.name}.confirm.select_targets"
 
         private fun getDirectories(context: Context?, uri: Uri?): Array<String>? {
             val directory = FileUtils.getDocumentFile(context!!, uri!!)

--- a/Android_GUI/src/main/java/com/github/chenxiaolong/dualbootpatcher/switcher/MbtoolTaskOutputFragment.kt
+++ b/Android_GUI/src/main/java/com/github/chenxiaolong/dualbootpatcher/switcher/MbtoolTaskOutputFragment.kt
@@ -265,7 +265,7 @@ class MbtoolTaskOutputFragment : Fragment(), ServiceConnection {
     }
 
     companion object {
-        val FRAGMENT_TAG: String = MbtoolTaskOutputFragment::class.java.canonicalName!!
+        val FRAGMENT_TAG: String = MbtoolTaskOutputFragment::class.java.name
 
         private val EXTRA_IS_RUNNING = "$FRAGMENT_TAG.is_running"
         private val EXTRA_TASK_ID = "$FRAGMENT_TAG.task_id"

--- a/Android_GUI/src/main/java/com/github/chenxiaolong/dualbootpatcher/switcher/RomDetailActivity.kt
+++ b/Android_GUI/src/main/java/com/github/chenxiaolong/dualbootpatcher/switcher/RomDetailActivity.kt
@@ -1101,35 +1101,35 @@ class RomDetailActivity : AppCompatActivity(), RomNameInputDialogListener,
         private const val ACTION_WIPE_ROM = 5
 
         private val PROGRESS_DIALOG_SWITCH_ROM =
-                "${RomDetailActivity::class.java.canonicalName}.progress.switch_rom"
+                "${RomDetailActivity::class.java.name}.progress.switch_rom"
         private val PROGRESS_DIALOG_SET_KERNEL =
-                "${RomDetailActivity::class.java.canonicalName}.progress.set_kernel"
+                "${RomDetailActivity::class.java.name}.progress.set_kernel"
         private val PROGRESS_DIALOG_UPDATE_RAMDISK =
-                "${RomDetailActivity::class.java.canonicalName}.progress.update_ramdisk"
+                "${RomDetailActivity::class.java.name}.progress.update_ramdisk"
         private val PROGRESS_DIALOG_WIPE_ROM =
-                "${RomDetailActivity::class.java.canonicalName}.progress.wipe_rom"
+                "${RomDetailActivity::class.java.name}.progress.wipe_rom"
         private val PROGRESS_DIALOG_REBOOT =
-                "${RomDetailActivity::class.java.canonicalName}.progress.reboot"
+                "${RomDetailActivity::class.java.name}.progress.reboot"
         private val CONFIRM_DIALOG_UPDATED_RAMDISK =
-                "${RomDetailActivity::class.java.canonicalName}.confirm.updated_ramdisk"
+                "${RomDetailActivity::class.java.name}.confirm.updated_ramdisk"
         private val CONFIRM_DIALOG_ADD_TO_HOME_SCREEN =
-                "${RomDetailActivity::class.java.canonicalName}.confirm.add_to_home_screen"
+                "${RomDetailActivity::class.java.name}.confirm.add_to_home_screen"
         private val CONFIRM_DIALOG_ROM_NAME =
-                "${RomDetailActivity::class.java.canonicalName}.confirm.rom_name"
+                "${RomDetailActivity::class.java.name}.confirm.rom_name"
         private val CONFIRM_DIALOG_SET_KERNEL =
-                "${RomDetailActivity::class.java.canonicalName}.confirm.set_kernel"
+                "${RomDetailActivity::class.java.name}.confirm.set_kernel"
         private val CONFIRM_DIALOG_MISMATCHED_KERNEL =
-                "${RomDetailActivity::class.java.canonicalName}.confirm.mismatched_kernel"
+                "${RomDetailActivity::class.java.name}.confirm.mismatched_kernel"
         private val CONFIRM_DIALOG_BACKUP_RESTORE_TARGETS =
-                "${RomDetailActivity::class.java.canonicalName}.confirm.backup_restore_targets"
+                "${RomDetailActivity::class.java.name}.confirm.backup_restore_targets"
         private val CONFIRM_DIALOG_WIPE_TARGETS =
-                "${RomDetailActivity::class.java.canonicalName}.confirm.wipe_targets"
+                "${RomDetailActivity::class.java.name}.confirm.wipe_targets"
         private val CONFIRM_DIALOG_CHECKSUM_ISSUE =
-                "${RomDetailActivity::class.java.canonicalName}.confirm.checksum_issue"
+                "${RomDetailActivity::class.java.name}.confirm.checksum_issue"
         private val CONFIRM_DIALOG_UNKNOWN_BOOT_PARTITION =
-                "${RomDetailActivity::class.java.canonicalName}.confirm.unknown_boot_partition"
+                "${RomDetailActivity::class.java.name}.confirm.unknown_boot_partition"
         private val INPUT_DIALOG_BACKUP_NAME =
-                "${RomDetailActivity::class.java.canonicalName}.input.backup_name"
+                "${RomDetailActivity::class.java.name}.input.backup_name"
 
         private const val REQUEST_IMAGE = 1234
         private const val REQUEST_MBTOOL_ERROR = 2345

--- a/Android_GUI/src/main/java/com/github/chenxiaolong/dualbootpatcher/switcher/SwitcherListFragment.kt
+++ b/Android_GUI/src/main/java/com/github/chenxiaolong/dualbootpatcher/switcher/SwitcherListFragment.kt
@@ -743,7 +743,7 @@ class SwitcherListFragment : Fragment(), RomCardActionListener, SetKernelNeededD
     }
 
     companion object {
-        val FRAGMENT_TAG: String = SwitcherListFragment::class.java.canonicalName!!
+        val FRAGMENT_TAG: String = SwitcherListFragment::class.java.name
         private val TAG = SwitcherListFragment::class.java.simpleName
 
         private const val EXTRA_TASK_ID_GET_ROMS_STATE = "task_id_get_roms_state"
@@ -760,21 +760,21 @@ class SwitcherListFragment : Fragment(), RomCardActionListener, SetKernelNeededD
 
         /** Fragment tag for progress dialog for switching ROMS  */
         private val PROGRESS_DIALOG_SWITCH_ROM =
-                "${SwitcherListFragment::class.java.canonicalName}.progress.switch_rom"
+                "${SwitcherListFragment::class.java.name}.progress.switch_rom"
         /** Fragment tag for progress dialog for setting the kernel  */
         private val PROGRESS_DIALOG_SET_KERNEL =
-                "${SwitcherListFragment::class.java.canonicalName}.progress.set_kernel"
+                "${SwitcherListFragment::class.java.name}.progress.set_kernel"
         /** Fragment tag for confirmation dialog saying that setting the kernel is needed  */
         private val CONFIRM_DIALOG_SET_KERNEL_NEEDED =
-                "${SwitcherListFragment::class.java.canonicalName}.confirm.set_kernel_needed"
+                "${SwitcherListFragment::class.java.name}.confirm.set_kernel_needed"
         private val CONFIRM_DIALOG_CHECKSUM_ISSUE =
-                "${SwitcherListFragment::class.java.canonicalName}.confirm.checksum_issue"
+                "${SwitcherListFragment::class.java.name}.confirm.checksum_issue"
         private val CONFIRM_DIALOG_UNKNOWN_BOOT_PARTITION =
-                "${SwitcherListFragment::class.java.canonicalName}.confirm.unknown_boot_partition"
+                "${SwitcherListFragment::class.java.name}.confirm.unknown_boot_partition"
         private val CONFIRM_DIALOG_PERMISSIONS =
-                "${SwitcherListFragment::class.java.canonicalName}.confirm.permissions"
+                "${SwitcherListFragment::class.java.name}.confirm.permissions"
         private val YES_NO_DIALOG_PERMISSIONS =
-                "${SwitcherListFragment::class.java.canonicalName}.yes_no.permissions"
+                "${SwitcherListFragment::class.java.name}.yes_no.permissions"
 
         /**
          * Request code for storage permissions request


### PR DESCRIPTION
Signed-off-by: Andrew Gunnerson <andrewgunnerson@gmail.com>