### PR TITLE
mbtool: sepolpatch.cpp: Fix MLS constraint handling for /data/media type

### DIFF
--- a/mbtool/include/util/sepolpatch.h
+++ b/mbtool/include/util/sepolpatch.h
@@ -57,6 +57,9 @@ SELinuxResult selinux_raw_set_permissive(policydb_t *pdb,
 SELinuxResult selinux_raw_set_attribute(policydb_t *pdb,
                                         uint16_t type_val,
                                         uint16_t attr_val);
+SELinuxResult selinux_raw_copy_constraints(policydb_t *pdb,
+                                           uint16_t source_type_val,
+                                           uint16_t target_type_val);
 SELinuxResult selinux_raw_add_to_role(policydb_t *pdb,
                                       uint16_t role_val,
                                       uint16_t type_val);


### PR DESCRIPTION
On policy versions < 29, the type_names field of the constraint
expression is empty, so adding the /data/media type to the
mlstrustedobject attribute would have no effect. There's no way to tell
that a constraint applies to a particular attribute. This would prevent
apps from writing to /data/media on devices where it is labeled with a
type that doesn't exist in the policy (and thus, mbtool has to create
it).

This commit adds the ability to add the dynamically created type to
every constraint that applies to the expected /data/media type.

Fixes: #1396

Signed-off-by: Andrew Gunnerson <andrewgunnerson@gmail.com>