### PR TITLE
Update Samsung Galaxy S4 mini variants

### DIFF
--- a/data/devices/samsung/00_galaxy_s.yml
+++ b/data/devices/samsung/00_galaxy_s.yml
@@ -400,6 +400,8 @@
     # Duos variant
     - serranods
     - serranodsxx
+    - serranodsdd
+    - serranodsub
     # LTE variant
     - serranolte
     - serranoltexx


### PR DESCRIPTION
This will fix recovery flashing error 1..